### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency Status](https://gemnasium.com/rom-rb/rom.png)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/rom-rb/rom.png)][codeclimate]
 [![Coverage Status](https://coveralls.io/repos/rom-rb/rom/badge.png?branch=master)][coveralls]
-[![Inline docs](http://inch-pages.github.io/github/rom-rb/rom.png)][coveralls]
+[![Inline docs](http://inch-pages.github.io/github/rom-rb/rom.png)][inchpages]
 
 [gem]: https://rubygems.org/gems/rom
 [travis]: https://travis-ci.org/rom-rb/rom


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/rom-rb/rom.png)](http://inch-pages.github.io/github/rom-rb/rom) (regarding your integration of yardstick into the workflow, the completeness comes as no suprise :wink: )

Although I already spoke to some of you, let me leave my usual note about this badge:

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for ROM is http://inch-pages.github.io/github/rom-rb/rom/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard) and [Pry](https://github.com/pry/pry).

Hope you like it!
