### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 [![Dependency Status](https://gemnasium.com/rom-rb/rom.png)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/rom-rb/rom.png)][codeclimate]
 [![Coverage Status](https://coveralls.io/repos/rom-rb/rom/badge.png?branch=master)][coveralls]
-[![Inline docs](http://inch-pages.github.io/github/rom-rb/rom.png)][inchpages]
+[![Inline docs](http://inch-ci.org/github/rom-rb/rom.png)][inchpages]
 
 [gem]: https://rubygems.org/gems/rom
 [travis]: https://travis-ci.org/rom-rb/rom
 [gemnasium]: https://gemnasium.com/rom-rb/rom
 [codeclimate]: https://codeclimate.com/github/rom-rb/rom
 [coveralls]: https://coveralls.io/r/rom-rb/rom
-[inchpages]: http://inch-pages.github.io/github/rom-rb/rom/
+[inchpages]: http://inch-ci.org/github/rom-rb/rom/
 
 Ruby Object Mapper is an implementation of [the Data Mapper](http://martinfowler.com/eaaCatalog/dataMapper.html)
 pattern in Ruby language. It consists of multiple loosely coupled pieces and uses


### PR DESCRIPTION
Hi there,

this patch updates the URL of the docs badge in your README. Inch's badges will be served from it's own CI service http://inch-ci.org in the future and I will slowly retire the old [Inch Pages project](http://inch-pages.github.io/). 

With the new service, people can [add projects straight from the homepage](http://inch-ci.org/) and also [configure a webhook to rebuild](http://inch-ci.org/howto/webhook) their badges auto-magically :star2:

I am so happy that Inch and Inch Pages were so well received in the community and that I am now able to keep [my promise](http://trivelop.de/2014/02/24/visibility-of-documentation/) to deliver a real, [open source](https://github.com/inch-ci) web service for the badges.

P.S. I have not written an announcement or anything for this, yet. **But**: Everybody who reads this is invited to add their projects to the site. Please help me find the last bugs, so I can start writing the "Introducing Inch CI" blog post :wink:
