### PR TITLE
Raise an error if repository is blank

### DIFF
--- a/lib/rom/schema/builder.rb
+++ b/lib/rom/schema/builder.rb
@@ -54,6 +54,11 @@ module ROM
       # @api private
       def base_relation(name, options = {}, &block)
         definition = Definition::Relation::Base.new(relations, &block)
+
+        if definition.repository.nil?
+          raise ArgumentError.new("schema repository was not set")
+        end
+
         repository = repositories.fetch(definition.repository)
 
         repository[name] = build_relation(name, definition)

--- a/spec/unit/rom/schema/builder/call_spec.rb
+++ b/spec/unit/rom/schema/builder/call_spec.rb
@@ -25,66 +25,85 @@ describe Schema::Builder, '#call' do
 
   context 'defining base relations' do
 
-    def self.it_registers_relation
-      it 'registers base relation in the repository' do
-        expect(schema[:users]).to be(gateway)
-        expect(repository).to have_received.[]=(:users, relation)
-      end
-    end
+    context 'with repository' do
 
-    before do
-      key_args = keys
-
-      schema.call do
-        base_relation :users do
-          repository :test
-
-          attribute :id,   Integer
-          attribute :name, String
-
-          key(*key_args)
+      def self.it_registers_relation
+        it 'registers base relation in the repository' do
+          expect(schema[:users]).to be(gateway)
+          expect(repository).to have_received.[]=(:users, relation)
         end
       end
-    end
 
-    context 'with a single key' do
-      it_registers_relation
-    end
-
-    context 'with multiple keys' do
-      let(:keys) { [:id, :name] }
-
-      it_registers_relation
-    end
-
-    context 'defining relations' do
       before do
-        stub(gateway).restrict(name: 'Jane') { gateway }
+        key_args = keys
 
         schema.call do
-          relation :restricted_users do
-            users.restrict(name: 'Jane')
+          base_relation :users do
+            repository :test
+
+            attribute :id,   Integer
+            attribute :name, String
+
+            key(*key_args)
           end
         end
       end
 
-      it 'registers restricted relation' do
-        expect(schema[:restricted_users]).to be(gateway)
-        expect(gateway).to have_received.restrict(name: 'Jane')
+      context 'with a single key' do
+        it_registers_relation
       end
 
-      context 'when invalid relation name is used' do
-        it 'raises error' do
-          expect {
-            schema.call do
-              relation :restricted_users do
-                not_here.restrict
-              end
+      context 'with multiple keys' do
+        let(:keys) { [:id, :name] }
+
+        it_registers_relation
+      end
+
+      context 'defining relations' do
+        before do
+          stub(gateway).restrict(name: 'Jane') { gateway }
+
+          schema.call do
+            relation :restricted_users do
+              users.restrict(name: 'Jane')
             end
-          }.to raise_error(NameError, /method `not_here'/)
+          end
+        end
+
+        it 'registers restricted relation' do
+          expect(schema[:restricted_users]).to be(gateway)
+          expect(gateway).to have_received.restrict(name: 'Jane')
+        end
+
+        context 'when invalid relation name is used' do
+          it 'raises error' do
+            expect {
+              schema.call do
+                relation :restricted_users do
+                  not_here.restrict
+                end
+              end
+            }.to raise_error(NameError, /method `not_here'/)
+          end
         end
       end
     end
 
+    context 'without repository' do
+      let(:schema) {
+        described_class.new(test: repository).call do
+          base_relation :users do
+            attribute :id,   Integer
+            attribute :name, String
+
+            key :id
+          end
+        end
+      }
+
+      it 'raises an error' do
+        expect { schema }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Otherwise the error is not friendly: `/Users/kir/Projects/opensource/rom/lib/rom/schema/builder.rb:57:in`fetch': key not found: nil (KeyError)`
