### PR TITLE
Run rspec with bundle exec inside guard

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard :rspec do
+guard :rspec, cmd: 'bundle exec rspec' do
   #run all specs if configuration is modified
   watch('Guardfile')           { 'spec' }
   watch('Gemfile.lock')        { 'spec' }


### PR DESCRIPTION
If multiple versions of rspec is installed, guard might fail with the message:

```
WARN: Unresolved specs during Gem::Specification.reset:
      rspec (< 4.0, >= 2.14)
      listen (~> 2.7)
      formatador (>= 0.2.4)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
```

This fixes that. This is also the default in guard-rspec now: https://github.com/guard/guard-rspec/blob/master/lib/guard/rspec/templates/Guardfile#L9
