### PR TITLE
Rework specs to function under jruby

### DIFF
--- a/lib/rom/adapter.rb
+++ b/lib/rom/adapter.rb
@@ -13,7 +13,7 @@ module ROM
 
       adapter =
         case uri.scheme
-        when 'sqlite' then Adapter::Sequel
+        when 'sqlite', 'jdbc' then Adapter::Sequel
         when 'memory' then Adapter::Memory
         else
           raise ArgumentError, "#{uri_string.inspect} uri is not supported"

--- a/spec/integration/join_spec.rb
+++ b/spec/integration/join_spec.rb
@@ -7,6 +7,14 @@ describe RA::Operation::Join do
   let(:left) { Relation.new(DB[:users]) }
   let(:right) { [{ name: 'Jane', age: 21 }] }
 
+  before do
+    seed
+  end
+
+  after do
+    deseed
+  end
+
   describe '#each' do
     it 'yields joined relation' do
       result = []

--- a/spec/integration/mapper_spec.rb
+++ b/spec/integration/mapper_spec.rb
@@ -11,6 +11,14 @@ describe Mapper do
   let(:jane) { user_model.new(id: 1, name: 'Jane') }
   let(:joe) { user_model.new(id: 2, name: 'Joe') }
 
+  before do
+    seed
+  end
+
+  after do
+    deseed
+  end
+
   describe "#each" do
     it "yields all mapped objects" do
       result = []

--- a/spec/integration/mappers_spec.rb
+++ b/spec/integration/mappers_spec.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 
 describe 'Defining mappers' do
   let(:rom) do
-    ROM.setup(sqlite: 'sqlite::memory') do
+    ROM.setup(sqlite: SEQUEL_TEST_DB_URI) do
       schema do
         base_relation(:users) do
           repository :sqlite
@@ -20,6 +20,7 @@ describe 'Defining mappers' do
   end
 
   after do
+    rom.sqlite.connection.drop_table? :users
     Object.send(:remove_const, :User)
   end
 

--- a/spec/integration/public_relations_spec.rb
+++ b/spec/integration/public_relations_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Defining public relations' do
-  let(:rom) { ROM.setup(sqlite: "sqlite::memory") }
+  let(:rom) { ROM.setup(sqlite: SEQUEL_TEST_DB_URI) }
 
   before do
     conn = rom.sqlite.connection
@@ -29,6 +29,12 @@ describe 'Defining public relations' do
         attribute :priority, Integer
       end
     end
+  end
+
+  after do
+    conn = rom.sqlite.connection
+    conn.drop_table? :users
+    conn.drop_table? :tasks
   end
 
   it 'allows to expose chainable relations' do

--- a/spec/integration/relation_spec.rb
+++ b/spec/integration/relation_spec.rb
@@ -6,6 +6,14 @@ describe Relation do
   let(:jane) { { id: 1, name: 'Jane' } }
   let(:joe) { { id: 2, name: 'Joe' } }
 
+  before do
+    seed
+  end
+
+  after do
+    deseed
+  end
+
   describe "#each" do
     it "yields all objects" do
       result = []

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -1,10 +1,14 @@
 require 'spec_helper'
 
 describe 'Defining schema' do
-  let(:rom) { ROM.setup(sqlite: 'sqlite::memory', memory: 'memory://test') }
+  let(:rom) { ROM.setup(sqlite: SEQUEL_TEST_DB_URI, memory: 'memory://test') }
 
   before do
     seed(rom.sqlite.connection)
+  end
+
+  after do
+    deseed(rom.sqlite.connection)
   end
 
   describe '.define' do

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -1,14 +1,20 @@
 require 'spec_helper'
 
 describe ROM, '.setup' do
+  let(:rom) { ROM.setup(sqlite: SEQUEL_TEST_DB_URI) }
   let(:jane) { { id: 1, name: 'Jane' } }
   let(:joe) { { id: 2, name: 'Joe' } }
 
-  it 'configures relations' do
-    rom = ROM.setup(sqlite: "sqlite::memory")
 
+  before do
     seed(rom.sqlite.connection)
+  end
 
+  after do
+    deseed(rom.sqlite.connection)
+  end
+
+  it 'configures relations' do
     expect(rom.sqlite.users.to_a).to eql([jane, joe])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,19 @@ require 'rom'
 
 include ROM
 
-DB = Sequel.connect("sqlite::memory")
+if defined? JRUBY_VERSION
+  USING_JRUBY = true
+else
+  USING_JRUBY = false
+end
+
+if USING_JRUBY
+  SEQUEL_TEST_DB_URI = "jdbc:sqlite::memory"
+else
+  SEQUEL_TEST_DB_URI = "sqlite::memory"
+end
+
+DB = Sequel.connect(SEQUEL_TEST_DB_URI)
 
 def seed(db = DB)
   db.run("CREATE TABLE users (id SERIAL, name STRING)")
@@ -13,4 +25,6 @@ def seed(db = DB)
   db[:users].insert(id:2, name: 'Joe')
 end
 
-seed
+def deseed(db = DB)
+  db.drop_table? :users
+end

--- a/spec/unit/rom/adapter_spec.rb
+++ b/spec/unit/rom/adapter_spec.rb
@@ -3,9 +3,14 @@ require 'spec_helper'
 describe Adapter do
   describe '.setup' do
     it 'sets up connection based on a uri' do
-      connection = Adapter.setup('sqlite::memory')
+      connection = Adapter.setup(SEQUEL_TEST_DB_URI)
 
-      expect(connection).to be_instance_of(Sequel::SQLite::Database)
+      if USING_JRUBY
+        expect(connection).to be_instance_of(Sequel::JDBC::Database)
+      else
+        expect(connection).to be_instance_of(Sequel::SQLite::Database)
+      end
+
     end
   end
 end


### PR DESCRIPTION
In response to #30.
- adapter now accepts the 'jdbc' uri scheme and maps it to Sequel
- Test DB URI is pulled out into a constant (SEQUEL_TEST_DB_URI)
- `seed` is no longer run automatically in `spec_helper`; each spec is responsible for setting up and tearing down test tables as necessary.
