### PR TITLE
Infer undefined schemas from Sequel adapter

### DIFF
--- a/lib/rom/adapter.rb
+++ b/lib/rom/adapter.rb
@@ -31,6 +31,10 @@ module ROM
       raise NotImplemented, "#{self.class}#connection must be implemented"
     end
 
+    def schema
+      []
+    end
+
   end
 
 end

--- a/lib/rom/adapter/sequel.rb
+++ b/lib/rom/adapter/sequel.rb
@@ -17,6 +17,35 @@ module ROM
         connection[name]
       end
 
+      def schema
+        tables.map do |table|
+          [table, dataset(table), dataset(table).columns]
+        end
+      end
+
+      private
+
+      def tables
+        connection.tables
+      end
+
+      def dataset(table)
+        connection[table]
+      end
+
+      def attributes(table)
+        map_attribute_types connection.schema(table)
+      end
+
+      def map_attribute_types(attrs)
+        attrs.map do |column, opts|
+          [column, { type: map_schema_type(opts[:type]) }]
+        end.to_h
+      end
+
+      def map_schema_type(type)
+        connection.class::SCHEMA_TYPE_CLASSES.fetch(type)
+      end
     end
 
   end

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -19,7 +19,7 @@ module ROM
     end
 
     def schema(&block)
-      @schema = Schema.define(self, &block) if block
+      @schema = Schema.define(self, &block) if block || @schema.nil?
       @schema
     end
 
@@ -34,6 +34,10 @@ module ROM
 
     def respond_to_missing?(name, include_private = false)
       repositories.key?(name)
+    end
+
+    def load_schema
+      repositories.map { |_, repo| repo.schema }.reduce(:+)
     end
 
     private

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -15,6 +15,10 @@ module ROM
       adapter[name]
     end
 
+    def schema
+      adapter.schema
+    end
+
     private
 
     def method_missing(name)

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -62,9 +62,21 @@ module ROM
     include Concord::Public.new(:relations)
 
     def self.define(env, &block)
-      dsl = DSL.new(env)
-      dsl.instance_exec(&block)
-      dsl.call
+      if block
+        dsl = DSL.new(env)
+        dsl.instance_exec(&block)
+        dsl.call
+      else
+        load_schema(env)
+      end
+    end
+
+    def self.load_schema(env)
+      relations = env.load_schema.each_with_object({}) do |(table, dataset, attributes), hash|
+        hash[table] = ROM::Relation.new(dataset, attributes)
+      end
+
+      Schema.new(relations)
     end
 
     def key?(name)

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -27,3 +27,41 @@ describe 'Defining schema' do
     end
   end
 end
+
+describe 'Inferring schema from database' do
+  let(:rom) { ROM.setup(sqlite: SEQUEL_TEST_DB_URI) }
+
+  context "when database schema exists" do
+
+    before do
+      seed(rom.sqlite.connection)
+    end
+
+    after do
+      deseed(rom.sqlite.connection)
+    end
+
+    it "infers the schema from the database relations" do
+      schema = rom.schema
+
+      expect(schema.users.to_a).to eql(rom.sqlite.users.to_a)
+      expect(schema.users.header).to eql([:id, :name])
+    end
+  end
+
+  context "for empty database schemas" do
+    it "returns an empty schema" do
+      schema = rom.schema
+
+      expect(schema.relations).to be_empty
+    end
+  end
+
+  context "for adapters that don't support inferring" do
+    it "returns an empty schema" do
+      schema = ROM.setup(memory: 'memory://test').schema
+
+      expect(schema.relations).to be_empty
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ end
 DB = Sequel.connect(SEQUEL_TEST_DB_URI)
 
 def seed(db = DB)
-  db.run("CREATE TABLE users (id SERIAL, name STRING)")
+  db.run("CREATE TABLE users (id INTEGER PRIMARY KEY, name STRING)")
 
   db[:users].insert(id: 1, name: 'Jane')
   db[:users].insert(id:2, name: 'Joe')

--- a/spec/unit/rom/adapter_spec.rb
+++ b/spec/unit/rom/adapter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Adapter do
   describe '.setup' do
     it 'sets up connection based on a uri' do
-      connection = Adapter.setup(SEQUEL_TEST_DB_URI)
+      connection = Adapter.setup(SEQUEL_TEST_DB_URI).connection
 
       if USING_JRUBY
         expect(connection).to be_instance_of(Sequel::JDBC::Database)


### PR DESCRIPTION
This commit adds automatic inference of the database schema for sequel
adapters. Manually defined schemas still have higher precedence over the
inference.

Other adapters only return an empty schema.

Closes #39
