### PR TITLE
Remove unused `connection` from Repository

### DIFF
--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -1,6 +1,5 @@
 module ROM
-  # Repository exposes native database connection and schema when it's
-  # supported by the adapter
+  # Repository exposes schema if supported by the adapter
   #
   # @api public
   class Repository
@@ -31,13 +30,6 @@ module ROM
     # @api public
     def logger
       adapter.logger
-    end
-
-    # Return the database connection provided by the adapter
-    #
-    # @api public
-    def connection
-      adapter.connection
     end
 
     # Return the schema provided by the adapter


### PR DESCRIPTION
Let's remove this - it's not used, but marked as public API and we're thinking about removing `Adapter#connection`.