### PR TITLE
Simplify #repository in BaseRelationDsl

### DIFF
--- a/lib/rom/setup/base_relation_dsl.rb
+++ b/lib/rom/setup/base_relation_dsl.rb
@@ -12,10 +12,10 @@ module ROM
       end
 
       def repository(name = nil)
-        if @repository
-          @repository
-        else
+        if name
           @repository = env[name]
+        else
+          @repository
         end
       end
 


### PR DESCRIPTION
This method changes its behavior after the first call. It might not hurt
right now as `@repository` is always empty, but let's clean this up
anyways.