### PR TITLE
Make storage in memory adapter thread safe

### DIFF
--- a/lib/rom/adapter/memory/storage.rb
+++ b/lib/rom/adapter/memory/storage.rb
@@ -1,3 +1,5 @@
+require 'thread_safe'
+
 module ROM
   class Adapter
     class Memory < Adapter
@@ -5,7 +7,7 @@ module ROM
         attr_reader :data
 
         def initialize
-          @data = {}
+          @data = ThreadSafe::Hash.new
         end
 
         def [](name)
@@ -13,11 +15,15 @@ module ROM
         end
 
         def create_dataset(name)
-          data[name] = Dataset.new([])
+          data[name] = Dataset.new(ThreadSafe::Array.new)
         end
 
         def key?(name)
           data.key?(name)
+        end
+
+        def size
+          data.size
         end
       end
     end

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'concord',     '~> 0.1', '>= 0.1.4'
   gem.add_runtime_dependency 'charlatan',   '~> 0.1', '>= 0.1'
   gem.add_runtime_dependency 'inflecto',    '~> 0.0', '>= 0.0.2'
+  gem.add_runtime_dependency 'thread_safe', '~> 0.3'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rspec-core', '~> 3.1'

--- a/spec/unit/rom/adapter/memory/storage_spec.rb
+++ b/spec/unit/rom/adapter/memory/storage_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe ROM::Adapter::Memory::Storage do
+  subject(:storage) do
+    ROM::Adapter::Memory::Storage.new
+  end
+
+  describe 'thread safe' do
+    let(:threads) { 4 }
+    let(:operations) { 5000 }
+
+    describe 'data' do
+      it 'create datasets properly' do
+        threaded_operations do |thread, operation|
+          key = "#{thread}:#{operation}"
+          storage.create_dataset(key)
+        end
+
+        expect(storage.size).to eql(threads * operations)
+      end
+    end
+
+    describe 'dataset' do
+      before { storage.create_dataset(:ary) }
+      let(:dataset) { storage[:ary] }
+
+      it 'inserts data in proper order' do
+        threaded_operations do
+          dataset << :data
+        end
+
+        expect(dataset.size).to eql(threads * operations)
+      end
+    end
+
+    def threaded_operations
+      threads.times.map do |thread|
+        Thread.new do
+          operations.times do |operation|
+            yield thread, operation
+          end
+        end
+      end.each(&:join)
+    end
+  end
+end


### PR DESCRIPTION
`ROM::Adapter::Memory::Storage` is currently not thread-safe which becomes an issue on JRuby and Rubinius.