### PR TITLE
Repository adapter registration

### DIFF
--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -26,9 +26,39 @@ module ROM
     # @api public
     attr_reader :options
 
+    # Register a repository adapter
+    #
+    # @example
+    #
+    #   Repository.register(MyRepositoryAdapter)
+    #
+    # @param [Repository] klass
+    #
+    # @return [Array] registered adapters
+    #
+    # @api public
+    def self.register(klass)
+      Repository.registered.unshift(klass)
+    end
+
+    # Unregister a repository adapter
+    #
+    # @example
+    #
+    #   Repository.unregister(MyRepositoryAdapter)
+    #
+    # @param [Repository] klass
+    #
+    # @return [Repository]
+    #
+    # @api public
+    def self.unregister(klass)
+      Repository.registered.delete(klass)
+    end
+
     # @api private
     def self.inherited(klass)
-      Repository.registered.unshift(klass)
+      register(klass) if @@auto_register_adapters
     end
 
     # @api private

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -5,6 +5,7 @@ module ROM
   #
   # @api public
   class Repository
+
     # Return connection URI associated with the repository
     #
     # @return [String]
@@ -54,6 +55,30 @@ module ROM
     # @api public
     def self.unregister(klass)
       Repository.registered.delete(klass)
+    end
+
+    # Repository auto-registration is on by default
+    @@auto_register_adapters = true
+
+    # Turn on adapter auto-registration when inheriting from Repository
+    #
+    # @example
+    #   Repsitory.enable_auto_registration!
+    #
+    # @api public
+    def self.enable_auto_registration!
+      @@auto_register_adapters = true
+    end
+
+    # Turn off adapter auto-registration when inheriting from Repository
+    #
+    # @example
+    #
+    #   Repository.disable_auto_registration!
+    #
+    # @api public
+    def self.disable_auto_registration!
+      @@auto_register_adapters = false
     end
 
     # @api private

--- a/spec/integration/mappers/deep_embedded_spec.rb
+++ b/spec/integration/mappers/deep_embedded_spec.rb
@@ -5,6 +5,10 @@ describe 'Mappers / deeply embedded tuples' do
   let(:setup) { ROM.setup('memory://test') }
   let(:rom) { setup.finalize }
 
+  before do
+    register_repo ROM::Memory::Repository
+  end
+
   it 'allows mapping embedded tuples' do
     setup.relation(:users)
 

--- a/spec/integration/mappers/embedded_spec.rb
+++ b/spec/integration/mappers/embedded_spec.rb
@@ -5,6 +5,10 @@ describe 'Mappers / embedded' do
   let(:setup) { ROM.setup('memory://test') }
   let(:rom) { setup.finalize }
 
+  before do
+    register_repo ROM::Memory::Repository
+  end
+
   it 'allows mapping embedded tuples' do
     setup.relation(:users)
 

--- a/spec/integration/mappers/prefixing_attributes_spec.rb
+++ b/spec/integration/mappers/prefixing_attributes_spec.rb
@@ -5,6 +5,7 @@ describe 'Mappers / Prefixing attributes' do
   let(:setup) { ROM.setup('memory://test') }
 
   before do
+    register_repo ROM::Memory::Repository
     setup.relation(:users)
   end
 

--- a/spec/integration/mappers/renaming_attributes_spec.rb
+++ b/spec/integration/mappers/renaming_attributes_spec.rb
@@ -5,6 +5,8 @@ describe 'Mappers / Renaming attributes' do
   let(:setup) { ROM.setup('memory://test') }
 
   before do
+    register_repo ROM::Memory::Repository
+
     setup.relation(:addresses)
 
     setup.relation(:users) do

--- a/spec/integration/mappers/symbolizing_attributes_spec.rb
+++ b/spec/integration/mappers/symbolizing_attributes_spec.rb
@@ -6,6 +6,7 @@ describe 'Mappers / Symbolizing atributes' do
   let(:rom) { setup.finalize }
 
   before do
+    register_repo ROM::Memory::Repository
     setup.relation(:users)
     setup.relation(:tasks)
   end

--- a/spec/integration/multi_repo_spec.rb
+++ b/spec/integration/multi_repo_spec.rb
@@ -13,6 +13,10 @@ describe 'Using in-memory repositories for cross-repo access' do
   let(:repositories) { rom.repositories }
   let(:rom) { setup.finalize }
 
+  before do
+    register_repo ROM::Memory::Repository
+  end
+
   it 'works' do
     setup.relation(:users, repository: :left) do
       def by_name(name)

--- a/spec/integration/repositories/extending_relations_spec.rb
+++ b/spec/integration/repositories/extending_relations_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 describe "Repository" do
   include_context "users and tasks" do
-    before(:all) do
-      Class.new(ROM::Memory::Repository) do
+    before(:context) do
+      extending_repo = Class.new(ROM::Memory::Repository) do
         def self.schemes
           [:memory]
         end
@@ -24,6 +24,8 @@ describe "Repository" do
           end
         end
       end
+
+      register_repo extending_repo
     end
   end
 

--- a/spec/integration/repositories/setting_logger_spec.rb
+++ b/spec/integration/repositories/setting_logger_spec.rb
@@ -22,6 +22,10 @@ describe 'Repositories / Setting logger' do
     logger_class.new
   end
 
+  before do
+    register_repo ROM::Memory::Repository
+  end
+
   it 'sets up a logger for a given repository' do
     setup = ROM.setup('memory://localhost')
 

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 require 'virtus'
+require 'rom/memory'
 
 describe 'Setting up ROM' do
+  before do
+    register_repo ROM::Memory::Repository
+  end
+
   context 'with existing schema' do
     include_context 'users and tasks'
 

--- a/spec/shared/users_and_tasks.rb
+++ b/spec/shared/users_and_tasks.rb
@@ -1,6 +1,10 @@
 RSpec.shared_context 'users and tasks' do
   require 'rom/memory'
 
+  before(:context) do
+    register_repo ROM::Memory::Repository
+  end
+
   subject(:rom) { setup.finalize }
 
   let(:setup) { ROM.setup("memory://localhost") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,15 @@ root = Pathname(__FILE__).dirname
 Dir[root.join('support/*.rb').to_s].each { |f| require f }
 Dir[root.join('shared/*.rb').to_s].each { |f| require f }
 
+ROM::Repository.disable_auto_registration!
+
+# Helper to register a repository unless it is already registered
+def register_repo(klass)
+  return if ROM::Repository.registered.include?(klass)
+
+  ROM::Repository.register(klass)
+end
+
 RSpec.configure do |config|
   config.before do
     @constants = Object.constants
@@ -27,6 +36,6 @@ RSpec.configure do |config|
     added_constants.each { |name| Object.send(:remove_const, name) }
 
     added_repos = ROM::Repository.registered - @repos
-    added_repos.each { |repo| ROM::Repository.registered.delete(repo) }
+    added_repos.each { |repo| ROM::Repository.unregister(repo) }
   end
 end

--- a/spec/unit/rom/repository_spec.rb
+++ b/spec/unit/rom/repository_spec.rb
@@ -10,7 +10,9 @@ describe ROM::Repository do
   end
 
   describe '.setup' do
-    before { test_repository }
+    before do
+      register_repo test_repository
+    end
 
     it 'sets up connection based on a uri' do
       repository = ROM::Repository.setup("test_scheme::memory")
@@ -27,7 +29,7 @@ describe ROM::Repository do
 
   describe '.[]' do
     it "looks up and return the repository class for the given schema" do
-      test_repository
+      register_repo test_repository
 
       expect(ROM::Repository[:test_scheme]).to eq test_repository
     end
@@ -45,10 +47,14 @@ describe ROM::Repository do
         end
       end
 
+      register_repo order_test_first
+
       repository = ROM::Repository.setup("order_test::memory")
       expect(repository).to be_instance_of(order_test_first)
 
       order_test_second = Class.new(order_test_first)
+
+      register_repo order_test_second
 
       repository = ROM::Repository.setup("order_test::memory")
 
@@ -72,7 +78,7 @@ describe ROM::Repository do
 
   describe '.setup' do
     it 'supports connection uri and additional options' do
-      Class.new(ROM::Repository) {
+      register_repo Class.new(ROM::Repository) {
         def self.schemes
           [:bazinga]
         end


### PR DESCRIPTION
## Problem
In my work with the lint tests I've struggled with the global state created by the adapter auto-registration with the `inherited` hook. It can cause unexpected behavior like adapters registered from a shared context and the need to control the requiring of `rom/memory` to prevent or control the order of registration.

## Proposal
I have brought back (I think there was a way to register adapters before...) an explicit `register` / `unregister` as well as a class level flag to enable or disable the auto-registration. Provides a way to turn off the auto-registration of repository adapters when they inherit from ROM::Repository.

Using this will mean our specs may be more explicit but it also means we can control the environment and test different behavior in isolation without workarounds and complications.

## Impact
* Four methods on `Repository`
* An additional class variable 
* More explicit registration in our specs
