### PR TITLE
bubble up nested values

### DIFF
--- a/lib/rom/commands/result.rb
+++ b/lib/rom/commands/result.rb
@@ -30,7 +30,7 @@ module ROM
       class Success < Result
         # @api private
         def initialize(value)
-          @value = value
+          @value = value.is_a?(self.class) ? value.value : value
         end
 
         # Call next command on continuation

--- a/spec/unit/rom/commands/result_spec.rb
+++ b/spec/unit/rom/commands/result_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe ROM::Commands::Result do
+  describe '#value' do
+    subject(:result) { ROM::Commands::Result::Success }
+
+    it 'bubble up nested values' do
+      data = double(to_ary: ['foo'])
+      r = result.new(result.new(result.new(data)))
+
+      expect(r.value).to eq(data)
+    end
+  end
+end


### PR DESCRIPTION
Do not allow ROM::Commands::Result#value to nest another instance of ROM::Commands::Result. Bubble up value to root. 