### PR TITLE
Add Result#and_then and Result#or_else as per #104

### DIFF
--- a/lib/rom/commands/result.rb
+++ b/lib/rom/commands/result.rb
@@ -4,14 +4,12 @@ module ROM
     #
     # @public
     class Result
-      # Wrap a value in a Result type if it's not already wrapped
-      #
-      # @return [Success, Failure]
-      #
-      # @api public
-      def self.wrap(value)
-        return value if value.kind_of?(Result)
-        new(value)
+      def self.success(value)
+        Success.new(value)
+      end
+
+      def self.failure(error)
+        Failure.new(error)
       end
 
       # Return command execution result
@@ -34,11 +32,6 @@ module ROM
       end
       alias_method :to_a, :to_ary
 
-      def wrap(*args)
-        self.class.wrap(*args)
-      end
-      private :wrap
-
       # Success result has a value and no error
       #
       # @public
@@ -52,14 +45,14 @@ module ROM
         #
         # @api public
         def >(other)
-          other.call(value)
+          other.call(value, Result)
         end
 
         # Yield to block with value of result
         #
         # @api public
         def and_then(&blk)
-          wrap(self > blk)
+          self > blk
         end
 
         # Ignore block and return self
@@ -112,7 +105,7 @@ module ROM
         #
         # @api public
         def or_else(&blk)
-          wrap(blk.call(error))
+          blk.call(error, Result)
         end
 
         # Return the error

--- a/lib/rom/commands/result.rb
+++ b/lib/rom/commands/result.rb
@@ -40,6 +40,22 @@ module ROM
           other.call(value)
         end
 
+        # Yield to block with value of result
+        #
+        # @api public
+        def and_then(&blk)
+          self > blk
+        end
+
+        # Ignore block and return self
+        #
+        # @return [self]
+        #
+        # @api public
+        def or_else(&_)
+          self
+        end
+
         # Return the value
         #
         # @return [Array]
@@ -66,6 +82,22 @@ module ROM
         # @api public
         def >(_other)
           self
+        end
+
+        # Do not yield to block, return self
+        #
+        # @return [self]
+        #
+        # @api public
+        def and_then(&blk)
+          self > blk
+        end
+
+        # Yield to block with error of result
+        #
+        # @api public
+        def or_else(&blk)
+          blk.call(error)
         end
 
         # Return the error

--- a/lib/rom/commands/result.rb
+++ b/lib/rom/commands/result.rb
@@ -4,10 +4,16 @@ module ROM
     #
     # @public
     class Result
+      # Wrap the value in a ROM::Commands::Success
+      #
+      # @api public
       def self.success(value)
         Success.new(value)
       end
 
+      # Wrap the error in a ROM::Commands::Failure
+      #
+      # @api public
       def self.failure(error)
         Failure.new(error)
       end
@@ -36,6 +42,8 @@ module ROM
       #
       # @public
       class Success < Result
+        include Equalizer.new(:class, :value)
+
         # @api private
         def initialize(value)
           @value = value.is_a?(self.class) ? value.value : value
@@ -78,6 +86,8 @@ module ROM
       #
       # @public
       class Failure < Result
+        include Equalizer.new(:class, :error)
+
         # @api private
         def initialize(error)
           @error = error

--- a/lib/rom/commands/result.rb
+++ b/lib/rom/commands/result.rb
@@ -4,6 +4,16 @@ module ROM
     #
     # @public
     class Result
+      # Wrap a value in a Result type if it's not already wrapped
+      #
+      # @return [Success, Failure]
+      #
+      # @api public
+      def self.wrap(value)
+        return value if value.kind_of?(Result)
+        new(value)
+      end
+
       # Return command execution result
       #
       # @api public
@@ -23,6 +33,11 @@ module ROM
         raise NotImplementedError
       end
       alias_method :to_a, :to_ary
+
+      def wrap(*args)
+        self.class.wrap(*args)
+      end
+      private :wrap
 
       # Success result has a value and no error
       #
@@ -44,7 +59,7 @@ module ROM
         #
         # @api public
         def and_then(&blk)
-          self > blk
+          wrap(self > blk)
         end
 
         # Ignore block and return self
@@ -97,7 +112,7 @@ module ROM
         #
         # @api public
         def or_else(&blk)
-          blk.call(error)
+          wrap(blk.call(error))
         end
 
         # Return the error

--- a/spec/integration/commands/result_monad_spec.rb
+++ b/spec/integration/commands/result_monad_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+# http://en.wikipedia.org/wiki/Monad_%28functional_programming%29#Monad_laws
+describe 'Commands / Result Monad' do
+  include_context 'users and tasks'
+
+  before do
+    setup.relation(:users)
+    setup.commands(:users) { define(:create) }
+  end
+
+  subject(:users) { rom.commands.users }
+
+  let(:on_success) { RecordCalls.new { |value, result| result.success(value) } }
+  let(:on_failure) { RecordCalls.new { |error, result| result.failure(error) } }
+
+  describe "Laws" do
+    let(:success_fn) { ->(value, results) { results.success([value, value]) } }
+    let(:failure_fn) { ->(value, results) { results.failure([value, value]) } }
+
+    describe "associativity" do
+      let(:run_chained) do
+        users.
+          try { users.create.call(name: "Bob") }.
+          and_then(&success_fn).
+          and_then(&on_success)
+      end
+
+      let(:run_nested) do
+        users.
+          try { users.create.call(name: "Bob") }.
+          and_then { |value, results|
+            success_fn.call(value, results).and_then(&on_success)
+          }
+      end
+
+      before do
+        run_chained
+        run_nested
+      end
+
+      specify { expect(run_chained).to eq run_nested }
+      specify { expect(on_success.call_count).to eq 2 }
+      specify { expect(on_success.calls[0]).to eq on_success.calls[1] }
+    end
+
+    describe "identity" do
+      let(:result) { ROM::Commands::Result }
+
+      let(:value) { double(:value) }
+      let(:error) { double(:error) }
+
+      describe "left identity" do
+        specify do
+          a = result.success(value).and_then(&success_fn)
+          b = success_fn.call(value, result)
+          expect(a).to eq(b)
+        end
+
+        specify do
+          a = result.failure(error).or_else(&failure_fn)
+          b = failure_fn.call(error, result)
+          expect(a).to eq(b)
+        end
+      end
+
+      describe "right identity" do
+        specify do
+          b = result.success(value)
+          # can't because of extra argument
+          # a = b.and_then &result.public_method(:success)
+          a = b.and_then { |value, r| r.success(value) }
+          c = b.and_then { |value, _| result.success(value) }
+          expect(a).to eq(b)
+          expect(b).to eq(c)
+        end
+
+        specify do
+          b = result.failure(error)
+          # can't because of extra argument
+          # a = b.or_else &result.public_method(:failure)
+          a = b.or_else { |error, r| r.failure(error) }
+          c = b.or_else { |error, _| result.failure(error) }
+          expect(a).to eq(b)
+          expect(b).to eq(c)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/commands/try_spec.rb
+++ b/spec/integration/commands/try_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe 'Commands / Control Flow' do
+  include_context 'users and tasks'
+
+  before do
+    setup.relation(:users)
+    setup.commands(:users) { define(:create) }
+  end
+
+  subject(:users) { rom.commands.users }
+
+  let(:on_success) { RecordCalls.new }
+  let(:on_failure) { RecordCalls.new }
+
+  describe "a successful command" do
+    let(:run_command) do
+      users.try {
+        users.create.call(name: "Bob")
+      }.and_then(&on_success).or_else(&on_failure)
+    end
+
+    before do
+      run_command
+    end
+
+    it "calls the block registered via #and_then" do
+      expect(on_success.call_count).to eq(1)
+      expect(on_success.calls.first).to eq [[{ name: "Bob" }]]
+    end
+
+    it "ignores the block registered via #or_else" do
+      expect(on_failure.call_count).to eq(0)
+    end
+  end
+
+  describe "an unsuccessful command" do
+    let(:run_command) do
+      users.try {
+        raise error
+      }.and_then(&on_success).or_else(&on_failure)
+    end
+
+    let(:error) { ROM::CommandError.new }
+
+    before do
+      run_command
+    end
+
+    it "ignores the block registered via #and_then" do
+      expect(on_success.call_count).to eq(0)
+    end
+
+    it "calls the block registered via #or_else" do
+      expect(on_failure.call_count).to eq(1)
+      expect(on_failure.calls.first).to eq [error]
+    end
+  end
+
+  describe "chaining" do
+    let(:run_command) do
+      users.try {
+        users.create.call(name: "Bob")
+      }.and_then(&upcase_names).and_then(&on_success)
+    end
+
+    let(:upcase_names) do
+      proc { |users|
+        users.map { |user|
+          user.tap do |user|
+            user[:name] = user[:name].upcase
+          end
+        }
+      }
+    end
+
+    before do
+      run_command
+    end
+
+    it "calls each block with the result of the previous" do
+      expect(on_success.call_count).to eq(1)
+      expect(on_success.calls.first).to eq [[{ name: "BOB" }]]
+    end
+  end
+end

--- a/spec/support/record_calls.rb
+++ b/spec/support/record_calls.rb
@@ -1,20 +1,30 @@
 class RecordCalls
-  def initialize
+  def initialize(&blk)
+    @blk = blk
     @calls = []
-  end
-
-  def record_call(*args)
-    calls << args
   end
 
   def call_count
     calls.length
   end
 
+  def call(*args)
+    record_call(*args)
+    blk.call(*args)
+  end
+
   def to_proc
-    public_method(:record_call).to_proc
+    public_method(:call).to_proc
   end
 
   attr_reader :calls
+
+  private
+
+  attr_reader :blk
+
+  def record_call(*args)
+    calls << args
+  end
 end
 

--- a/spec/support/record_calls.rb
+++ b/spec/support/record_calls.rb
@@ -1,0 +1,20 @@
+class RecordCalls
+  def initialize
+    @calls = []
+  end
+
+  def record_call(*args)
+    calls << args
+  end
+
+  def call_count
+    calls.length
+  end
+
+  def to_proc
+    public_method(:record_call).to_proc
+  end
+
+  attr_reader :calls
+end
+

--- a/spec/unit/rom/commands/result/control_flow_spec.rb
+++ b/spec/unit/rom/commands/result/control_flow_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe ROM::Commands::Result do
+  describe "control flow" do
+    let(:blk_result) { double(:blk_result) }
+    let(:blk) { ->(_) { blk_result } }
+    let(:wrapped_blk_result) { double(:wrapped_blk_result) }
+
+    before do
+      allow(ROM::Commands::Result).to receive(:wrap)
+      allow(ROM::Commands::Result).to receive(:wrap).
+        with(blk_result).and_return(wrapped_blk_result)
+    end
+
+    context ROM::Commands::Result::Success do
+      subject(:result) { described_class.new(value) }
+
+      let(:value) { double(:value) }
+
+      describe '#and_then' do
+        it 'calls the block with the value of the result' do
+          expect { |blk|
+            result.and_then(&blk)
+          }.to yield_with_args(value)
+        end
+
+        it 'wraps the return value of the block in a result' do
+          expect(result.and_then(&blk)).to eq(wrapped_blk_result)
+        end
+      end
+
+      describe '#or_else' do
+        it 'does not call the block' do
+          expect { |blk|
+            result.or_else(&blk)
+          }.not_to yield_control
+        end
+
+        it 'returns the result' do
+          expect(result.or_else(&blk)).to eq(result)
+        end
+      end
+    end
+
+    context ROM::Commands::Result::Failure do
+      subject(:result) { described_class.new(error) }
+
+      let(:error) { double(:error) }
+
+      describe '#and_then' do
+        it 'does not call the block' do
+          expect { |blk|
+            result.and_then(&blk)
+          }.not_to yield_control
+        end
+
+        it 'returns the result' do
+          expect(result.and_then(&blk)).to eq(result)
+        end
+      end
+
+      describe '#or_else' do
+        it 'calls the block with the error of the result' do
+          expect { |blk|
+            result.or_else(&blk)
+          }.to yield_with_args(error)
+        end
+
+        it 'wraps the return value of the block in a result' do
+          expect(result.or_else(&blk)).to eq(wrapped_blk_result)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/rom/commands/result_spec.rb
+++ b/spec/unit/rom/commands/result_spec.rb
@@ -11,4 +11,69 @@ describe ROM::Commands::Result do
       expect(r.value).to eq(data)
     end
   end
+
+  describe "control flow" do
+    let(:blk_result) { double(:blk_result) }
+    let(:blk) { ->(_) { blk_result } }
+
+    context ROM::Commands::Result::Success do
+      subject(:result) { described_class.new(value) }
+
+      let(:value) { double(:value) }
+
+      describe '#and_then' do
+        it 'calls the block with the value of the result' do
+          expect { |blk|
+            result.and_then(&blk)
+          }.to yield_with_args(value)
+        end
+
+        it 'returns the result of calling the block' do
+          expect(result.and_then(&blk)).to eq(blk_result)
+        end
+      end
+
+      describe '#or_else' do
+        it 'does not call the block' do
+          expect { |blk|
+            result.or_else(&blk)
+          }.not_to yield_control
+        end
+
+        it 'returns the result' do
+          expect(result.or_else(&blk)).to eq(result)
+        end
+      end
+    end
+
+    context ROM::Commands::Result::Failure do
+      subject(:result) { described_class.new(error) }
+
+      let(:error) { double(:error) }
+
+      describe '#and_then' do
+        it 'does not call the block' do
+          expect { |blk|
+            result.and_then(&blk)
+          }.not_to yield_control
+        end
+
+        it 'returns the result' do
+          expect(result.and_then(&blk)).to eq(result)
+        end
+      end
+
+      describe '#or_else' do
+        it 'calls the block with the error of the result' do
+          expect { |blk|
+            result.or_else(&blk)
+          }.to yield_with_args(error)
+        end
+
+        it 'returns the result of calling the block' do
+          expect(result.or_else(&blk)).to eq(blk_result)
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/rom/commands/result_spec.rb
+++ b/spec/unit/rom/commands/result_spec.rb
@@ -1,33 +1,25 @@
 require 'spec_helper'
 
 describe ROM::Commands::Result do
-  describe ".wrap" do
-    context ROM::Commands::Result::Success do
-      it "wraps unwrapped values in success" do
-        value = double(:value)
-        wrapped = described_class.wrap(value)
-        expect(wrapped).to be_a described_class
-        expect(wrapped.value).to eq(value)
-      end
+  describe ".success" do
+    subject(:result) { ROM::Commands::Result.success(value) }
 
-      it "leaves wrapped values alone" do
-        value = ROM::Commands::Result::Failure.new("Failure to launch")
-        expect(described_class.wrap(value)).to eq(value)
-      end
+    let(:value) { double(:value) }
+
+    it "wraps the value in a success" do
+      expect(result).to be_a(ROM::Commands::Result::Success)
+      expect(result.value).to eq(value)
     end
+  end
 
-    context ROM::Commands::Result::Failure do
-      it "wraps unwrapped values in failure" do
-        value = double(:value)
-        wrapped = described_class.wrap(value)
-        expect(wrapped).to be_a described_class
-        expect(wrapped.error).to eq(value)
-      end
+  describe ".failure" do
+    subject(:result) { ROM::Commands::Result.failure(error) }
 
-      it "leaves wrapped values alone" do
-        value = ROM::Commands::Result::Success.new("We did it!")
-        expect(described_class.wrap(value)).to eq(value)
-      end
+    let(:error) { double(:error) }
+
+    it "wraps the value in a failure" do
+      expect(result).to be_a(ROM::Commands::Result::Failure)
+      expect(result.error).to eq(error)
     end
   end
 


### PR DESCRIPTION
Considered adding runtime checks to make sure the value returned from the block is a `Result` as per the type signatures in the [Rust docs](http://doc.rust-lang.org/0.11.0/std/result/index.html), but decided to poll opinions first.