### PR TITLE
Add support for setting decorators for a reader

### DIFF
--- a/lib/rom/setup/finalize.rb
+++ b/lib/rom/setup/finalize.rb
@@ -61,9 +61,16 @@ module ROM
           relation = relations[name]
           methods = relation.exposed_relations
 
-          readers[name] = Reader.build(
-            name, relation, MapperRegistry.new(mappers), methods
-          )
+          reader_class = Reader.descendants.detect { |klass| klass.relation == name }
+
+          klass =
+            if reader_class
+              Reader.define_relation_methods(reader_class, methods)
+            else
+              Reader.build_class(relation, methods)
+            end
+
+          readers[name] = klass.new(name, relation, MapperRegistry.new(mappers))
         end
 
         ReaderRegistry.new(readers)

--- a/spec/integration/reading/decor_spec.rb
+++ b/spec/integration/reading/decor_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'ostruct'
+
+describe 'Reading / Decoration' do
+  include_context 'users and tasks'
+
+  it 'allows setting a decorator' do
+    UserPresenter = Class.new(OpenStruct) {
+      def name
+        super.upcase
+      end
+    }
+
+    UserDecor = proc { |user| UserPresenter.new(user) }
+
+    class Users < ROM::Relation[:memory]
+    end
+
+    class UserMapper < ROM::Mapper
+      relation :users
+      attribute :name
+    end
+
+    class UserReader < ROM::Reader
+      relation :users
+      decors user_decor: UserDecor
+    end
+
+    users = rom.read(:users).decorate(:user_decor).map(&:name)
+
+    expect(users).to match_array(%w(JANE JOE))
+  end
+end


### PR DESCRIPTION
I found that to be super nice so I thought it could be part of ROM. This basically allows you to decorate mapped objects with additional behavior that can be anything, ie:

* UI view presenters (for presenting *values*)
* UI view renderers (for rendering html chunks etc.)
* JSON serializers (for more higher level stuff like hypermedia etc.)
* probably more...

I don't have a strong opinion if it should be part of rom core or an external plugin. My tactic right now is to put stuff into ROM and extract later once we see things clearly.