### PR TITLE
Add basic docs for linters

### DIFF
--- a/lib/rom/lint/enumerable_dataset.rb
+++ b/lib/rom/lint/enumerable_dataset.rb
@@ -2,6 +2,10 @@ require 'rom/lint/linter'
 
 module ROM
   module Lint
+    # Ensures that a [ROM::EnumerableDataset] extension correctly yields
+    # arrays and tuples
+    #
+    # @public
     class EnumerableDataset < ROM::Lint::Linter
       attr_reader :dataset, :data
 

--- a/lib/rom/lint/linter.rb
+++ b/lib/rom/lint/linter.rb
@@ -1,5 +1,19 @@
 module ROM
   module Lint
+    # Base class for building linters that check source code
+    #
+    # Linters are used by authors of ROM adapters to verify that their
+    # integration comnplies with the ROM api.
+    #
+    # Most of the time, authors won't need to construct linters directly
+    # because the provided test helpers will automatically run when required
+    # in tests and specs.
+    #
+    # @example
+    #   require 'rom/lint/spec'
+    # 
+    #
+    # @public
     class Linter
       Failure = Class.new(StandardError)
 

--- a/lib/rom/lint/repository.rb
+++ b/lib/rom/lint/repository.rb
@@ -2,6 +2,10 @@ require 'rom/lint/linter'
 
 module ROM
   module Lint
+    # Ensures that a [ROM::Repository] extension provides datasets through the
+    # expected methods
+    #
+    # @public
     class Repository < ROM::Lint::Linter
       attr_reader :identifier, :repository, :uri
 


### PR DESCRIPTION
I'm really impressed by some of the ideas in ROM and it has been a lot of fun to play with writing extensions so far. While rapidly growing and stabilising, ROM (in its current state) is still a bit daunting for authors of adapters to get their heads around. I'd like to help improve that.

If these docs are okay, I'll start adding more patches here and there, and make some notes from the perspective of helping library authors get up to speed with what they need to do to plug all kinds of query APIs and dataset enumerators into ROM.

Let me know what you think.