### PR TITLE
Add Relation::Loaded and use it in rom.relation {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ end
 # could define it explicitly
 class UserMapper < ROM::Mapper
   relation :users
+  register_as :entities
 
   model User
 
@@ -89,7 +90,7 @@ rom.command(:users).create.call(name: "Joe", age: 17)
 rom.command(:users).create.call(name: "Joe", age: 17)
 
 # reading relations using defined mappers
-puts rom.read(:users).by_name("Jane").adults.to_a.inspect
+puts rom.relation(:users) { |r| r.by_name("Jane").adults }.as(:entities)
 # => [#<User:0x007fdba161cc48 @id=2, @name="Jane", @age=18>]
 ```
 

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -1,9 +1,11 @@
+require 'rom/relation/loaded'
+
 module ROM
   # Exposes defined repositories, relations and mappers
   #
   # @api public
   class Env
-    include Equalizer.new(:repositories, :relations, :readers, :commands)
+    include Equalizer.new(:repositories, :relations, :mappers, :commands)
 
     # @return [Hash] configured repositories
     #
@@ -25,13 +27,49 @@ module ROM
     # @api public
     attr_reader :commands
 
+    # @return [Registry] mapper registry
+    #
+    # @api public
+    attr_reader :mappers
+
     # @api private
     def initialize(repositories, relations, readers, commands)
       @repositories = repositories
       @relations = relations
       @readers = readers
       @commands = commands
+      initialize_mappers
       freeze
+    end
+
+    # Load relation by name
+    #
+    # @example
+    #
+    #   rom.relation(:users)
+    #   rom.relation(:users) { |r| r.by_name('Jane') }
+    #
+    #   # with mapping
+    #   rom.relation(:users).map_with(:presenter)
+    #
+    #   rom.relation(:users) { |r| r.page(1) }.map_with(:presenter, :json_serializer)
+    #
+    # @param [Symbol] name of the relation to load
+    #
+    # @yield [Relation]
+    #
+    # @return [Relation::Loaded]
+    #
+    # @api public
+    def relation(name, &block)
+      tuples =
+        if block
+          yield(relations[name])
+        else
+          relations[name]
+        end
+
+      Relation::Loaded.new(tuples.to_a, mappers[name])
     end
 
     # Returns a reader with access to defined mappers
@@ -67,6 +105,16 @@ module ROM
     # @api public
     def command(name)
       commands[name]
+    end
+
+    private
+
+    # @api private
+    def initialize_mappers
+      elements = readers.each_with_object({}) { |(name, reader), h|
+        h[name] = reader.mappers
+      }
+      @mappers = Registry.new(elements)
     end
   end
 end

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -69,7 +69,7 @@ module ROM
           relations[name]
         end
 
-      Relation::Loaded.new(tuples.to_a, mappers[name])
+      Relation::Loaded.new(tuples, mappers[name])
     end
 
     # Returns a reader with access to defined mappers

--- a/lib/rom/relation/loaded.rb
+++ b/lib/rom/relation/loaded.rb
@@ -1,0 +1,46 @@
+require 'rom/support/array_dataset'
+
+module ROM
+  class Relation
+    # Wraps loaded data from a relation and gives access to its mappers
+    #
+    # @public
+    class Loaded
+      include ArrayDataset
+
+      forward :first
+
+      # @return [ROM::MapperRegistry]
+      #
+      # @api private
+      attr_reader :mappers
+
+      # @api private
+      def initialize(data, mappers)
+        super
+        @mappers = mappers
+      end
+
+      # Map loaded relation using a specified mapper
+      #
+      # @example
+      #
+      #   loaded = rom.relation(:users) { |r| r.by_name('Jane') }
+      #
+      #   # mapping with a single mapper
+      #   loaded.map_with(:entity_mapper)
+      #
+      #   # mapping with a multiple mappers
+      #   loaded.map_with(:entity_mapper, :presenter_decorator)
+      #
+      # @return [Array] array of mapped tuples
+      #
+      # @api public
+      def map_with(*names)
+        result = data
+        names.each { |name| result = mappers[name].call(result) }
+        result
+      end
+    end
+  end
+end

--- a/lib/rom/relation/loaded.rb
+++ b/lib/rom/relation/loaded.rb
@@ -6,9 +6,12 @@ module ROM
     #
     # @public
     class Loaded
-      include ArrayDataset
-
-      forward :first
+      # Materialized relation
+      #
+      # @return [Relation]
+      #
+      # @api private
+      attr_reader :relation
 
       # @return [ROM::MapperRegistry]
       #
@@ -16,9 +19,39 @@ module ROM
       attr_reader :mappers
 
       # @api private
-      def initialize(data, mappers)
-        super
+      def initialize(relation, mappers)
+        @relation = relation.to_a
         @mappers = mappers
+      end
+
+      # Returns a single tuple from the relation if there is one.
+      #
+      # @raise [ROM::TupleCountMismatchError] if the relation contains more than
+      #   one tuple
+      #
+      # @api public
+      def one
+        if relation.size > 1
+          raise(
+            TupleCountMismatchError,
+            'The relation consists of more than one tuple'
+          )
+        else
+          relation.first
+        end
+      end
+
+      # Like [one], but additionally raises an error if the relation is empty.
+      #
+      # @raise [ROM::TupleCountMismatchError] if the relation does not contain
+      #   exactly one tuple
+      #
+      # @api public
+      def one!
+        one || raise(
+          TupleCountMismatchError,
+          'The relation does not contain any tuples'
+        )
       end
 
       # Map loaded relation using a specified mapper
@@ -37,7 +70,7 @@ module ROM
       #
       # @api public
       def as(*names)
-        result = data
+        result = relation
         names.each { |name| result = mappers[name].call(result) }
         result
       end

--- a/lib/rom/relation/loaded.rb
+++ b/lib/rom/relation/loaded.rb
@@ -36,11 +36,12 @@ module ROM
       # @return [Array] array of mapped tuples
       #
       # @api public
-      def map_with(*names)
+      def as(*names)
         result = data
         names.each { |name| result = mappers[name].call(result) }
         result
       end
+      alias_method :map_with, :as
     end
   end
 end

--- a/lib/rom/support/enumerable_dataset.rb
+++ b/lib/rom/support/enumerable_dataset.rb
@@ -45,7 +45,7 @@ module ROM
 
     [
       :chunk, :collect, :collect_concat, :drop_while, :find_all, :flat_map,
-      :grep, :map, :reject, :select, :sort, :sort_by, :take_while
+      :grep, :map, :reject, :select, :sort, :sort_by, :take, :take_while
     ].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{method}(*args, &block)

--- a/spec/integration/relations/reading_spec.rb
+++ b/spec/integration/relations/reading_spec.rb
@@ -194,14 +194,16 @@ describe 'Reading relations' do
     rom = setup.finalize
 
     expect {
-      rom.read(:users) { |users| users.not_here }
-    }.to raise_error(ROM::NoRelationError, /not_here/)
+      rom.relation(:users) { |users| users.not_here }
+    }.to raise_error(NoMethodError, /not_here/)
 
     expect {
-      rom.read(:users) { |users| users.by_name('Joe') }.map(:not_here)
+      rom.relation(:users) { |users| users.by_name('Joe') }.map_with(:not_here)
     }.to raise_error(ROM::MapperMissingError, /not_here/)
 
-    user = rom.read(:users) { |users| users.by_name('Joe') }.map(:prefixer).first
+    user = rom.relation(:users) { |users|
+      users.by_name('Joe')
+    }.map_with(:prefixer).first
 
     expect(user).to eql(user_name: 'Joe', user_email: "joe@doe.org")
   end

--- a/spec/integration/relations/reading_spec.rb
+++ b/spec/integration/relations/reading_spec.rb
@@ -198,7 +198,7 @@ describe 'Reading relations' do
     }.to raise_error(NoMethodError, /not_here/)
 
     expect {
-      rom.relation(:users) { |users| users.by_name('Joe') }.map_with(:not_here)
+      rom.relation(:users) { |users| users.by_name('Joe') }.as(:not_here)
     }.to raise_error(ROM::MapperMissingError, /not_here/)
 
     user = rom.relation(:users) { |users|

--- a/spec/unit/rom/env_spec.rb
+++ b/spec/unit/rom/env_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe ROM::Env do
+  include_context 'users and tasks'
+
+  before do
+    setup.relation(:users) do
+      def by_name(name)
+        restrict(name: name).project(:name)
+      end
+    end
+
+    setup.mappers do
+      define(:users) do
+        attribute :name
+        attribute :email
+      end
+
+      define(:name_list, parent: :users) do
+        attribute :name
+        exclude :email
+      end
+    end
+  end
+
+  describe '#relation' do
+    it 'yields selected relation to the block and returns a reader' do
+      result = rom.relation(:users) { |r| r.by_name('Jane') }.map_with(:name_list)
+      expect(result).to match_array([{ name: 'Jane' }])
+    end
+  end
+
+  describe '#mappers' do
+    it 'returns mappers for all relations' do
+      expect(rom.mappers.users).to eql(rom.readers.users.mappers)
+    end
+  end
+end

--- a/spec/unit/rom/env_spec.rb
+++ b/spec/unit/rom/env_spec.rb
@@ -25,7 +25,7 @@ describe ROM::Env do
 
   describe '#relation' do
     it 'yields selected relation to the block and returns a reader' do
-      result = rom.relation(:users) { |r| r.by_name('Jane') }.map_with(:name_list)
+      result = rom.relation(:users) { |r| r.by_name('Jane') }.as(:name_list)
       expect(result).to match_array([{ name: 'Jane' }])
     end
   end

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe ROM::Relation::Loaded do
+  include_context 'users and tasks'
+
+  subject(:users) { ROM::Relation::Loaded.new(rom.relations.users, mappers) }
+
+  let(:mappers) { {} }
+
+  before { setup.relation(:users) }
+
+  describe '#first' do
+    it 'returns first tuple' do
+      expect(users.first).to eql(name: 'Joe', email: 'joe@doe.org')
+    end
+  end
+
+  describe '#map' do
+    let(:mappers) { { email_list: email_mapper, upcase: upcase_mapper } }
+    let(:email_mapper) { proc { |data| data.map { |t| t[:email] } } }
+    let(:upcase_mapper) { proc { |data| data.map(&:upcase) } }
+
+    it 'maps relation using specified mapper' do
+      expect(users.map_with(:email_list)).to match_array(
+        %w(joe@doe.org jane@doe.org)
+      )
+    end
+
+    it 'allows mappping with multiple mappers' do
+      expect(users.map_with(:email_list, :upcase)).to match_array(
+        %w(JOE@DOE.ORG JANE@DOE.ORG)
+      )
+    end
+
+    describe 'enumerable chaining' do
+      it 'allows chain enumerable method calls' do
+        result = users.map_with(:email_list).take(1).map(&:upcase)
+        expect(result).to match_array(%w(JOE@DOE.ORG))
+      end
+    end
+  end
+end

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -15,26 +15,26 @@ describe ROM::Relation::Loaded do
     end
   end
 
-  describe '#map' do
+  describe '#as' do
     let(:mappers) { { email_list: email_mapper, upcase: upcase_mapper } }
     let(:email_mapper) { proc { |data| data.map { |t| t[:email] } } }
     let(:upcase_mapper) { proc { |data| data.map(&:upcase) } }
 
     it 'maps relation using specified mapper' do
-      expect(users.map_with(:email_list)).to match_array(
+      expect(users.as(:email_list)).to match_array(
         %w(joe@doe.org jane@doe.org)
       )
     end
 
     it 'allows mappping with multiple mappers' do
-      expect(users.map_with(:email_list, :upcase)).to match_array(
+      expect(users.as(:email_list, :upcase)).to match_array(
         %w(JOE@DOE.ORG JANE@DOE.ORG)
       )
     end
 
     describe 'enumerable chaining' do
       it 'allows chain enumerable method calls' do
-        result = users.map_with(:email_list).take(1).map(&:upcase)
+        result = users.as(:email_list).take(1).map(&:upcase)
         expect(result).to match_array(%w(JOE@DOE.ORG))
       end
     end

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -9,9 +9,28 @@ describe ROM::Relation::Loaded do
 
   before { setup.relation(:users) }
 
-  describe '#first' do
+  describe '#one' do
     it 'returns first tuple' do
-      expect(users.first).to eql(name: 'Joe', email: 'joe@doe.org')
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+      expect(users.one).to eql(name: 'Jane', email: 'jane@doe.org')
+    end
+
+    it 'raises error when there is more than one tuple' do
+      expect { users.one }.to raise_error(ROM::TupleCountMismatchError)
+    end
+  end
+
+  describe '#one!' do
+    it 'returns first tuple' do
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+      expect(users.one!).to eql(name: 'Jane', email: 'jane@doe.org')
+    end
+
+    it 'raises error when there is no tuples' do
+      rom.relations.users.delete(name: 'Jane', email: 'jane@doe.org')
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+
+      expect { users.one! }.to raise_error(ROM::TupleCountMismatchError)
     end
   end
 


### PR DESCRIPTION
This does a couple of things:

- adds `ROM::Env#relation` that yields *relation object* to the block and returns an instance of `Relation::Loaded` it means that you have access to all methods exposed by a relation there including adapter-specific query DSL
- `Relation::Loaded` exposes `#map_with` interface that accepts name of a mapper that should be used
- `Relation::Loaded#map_with` supports multiple mapper names so we can map and decorate tuples passing them through a "mapping pipe", see my comment with an example in this PR
- the contract is that `map_with` can be called only once, it returns an array
- `ROM::Env#mappers` returns a registry of relation mappers that were defined during setup

Things to consider:

- Deprecate usage of Reader and remove it in 0.7.0 (or 1.0.0!) - I realized this is a very heavy abstraction and even though I still want to maintain the logic of restricting access to relation only to methods defined by me and avoid using query dsls I no longer think rom core is the right place to put it
- Extend Mapper API with composability so that we can "join" mappers as a nice lower-level API and re-use it in `Relation::Loaded`