### PR TITLE
Hide inflections behind an internal interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'virtus'
   gem 'minitest'
   gem 'thread_safe'
+  gem 'activesupport'
 
   platforms :rbx do
     gem 'rubysl-bigdecimal', platforms: :rbx

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -1,10 +1,10 @@
 require 'equalizer'
-require 'inflecto'
 
 require 'rom/version'
 require 'rom/constants'
 
 # internal ROM support lib
+require 'rom/support/inflector'
 require 'rom/support/registry'
 require 'rom/support/options'
 require 'rom/support/class_macros'

--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -38,7 +38,7 @@ module ROM
     #
     # @api public
     def self.[](adapter)
-      adapter_namespace(adapter).const_get(Inflecto.demodulize(name))
+      adapter_namespace(adapter).const_get(Inflector.demodulize(name))
     end
 
     # Return namespaces that contains command subclasses of a specific adapter
@@ -103,7 +103,7 @@ module ROM
     #
     # @api private
     def self.default_name
-      Inflecto.underscore(Inflecto.demodulize(name)).to_sym
+      Inflector.underscore(Inflector.demodulize(name)).to_sym
     end
 
     # Return default options based on class macros

--- a/lib/rom/model_builder.rb
+++ b/lib/rom/model_builder.rb
@@ -54,7 +54,7 @@ module ROM
 
         @namespace =
           if parts.any?
-            Inflecto.constantize(parts.join('::'))
+            Inflector.constantize(parts.join('::'))
           else
             Object
           end

--- a/lib/rom/reader.rb
+++ b/lib/rom/reader.rb
@@ -57,7 +57,7 @@ module ROM
     #
     # @api private
     def self.build_class(relation, method_names)
-      klass_name = "#{Reader.name}[#{Inflecto.camelize(relation.name)}]"
+      klass_name = "#{Reader.name}[#{Inflector.camelize(relation.name)}]"
 
       ClassBuilder.new(name: klass_name, parent: Reader).call do |klass|
         method_names.each do |method_name|

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -104,7 +104,7 @@ module ROM
     # @api private
     def self.default_name
       return unless name
-      Inflecto.underscore(name).gsub('/', '_').to_sym
+      Inflector.underscore(name).gsub('/', '_').to_sym
     end
 
     # Build relation registry of specified descendant classes

--- a/lib/rom/setup_dsl/command.rb
+++ b/lib/rom/setup_dsl/command.rb
@@ -10,7 +10,7 @@ module ROM
     # @api private
     def self.build_class(name, relation, options = {}, &block)
       type = options.fetch(:type) { name }
-      command_type = Inflecto.classify(type)
+      command_type = Inflector.classify(type)
       adapter = options.fetch(:adapter)
       parent = adapter_namespace(adapter).const_get(command_type)
       class_name = generate_class_name(adapter, command_type, relation)
@@ -27,9 +27,9 @@ module ROM
     # @api private
     def self.generate_class_name(adapter, command_type, relation)
       pieces = ['ROM']
-      pieces << Inflecto.classify(adapter)
+      pieces << Inflector.classify(adapter)
       pieces << 'Commands'
-      pieces << "#{command_type}[#{Inflecto.classify(relation)}s]"
+      pieces << "#{command_type}[#{Inflector.classify(relation)}s]"
       pieces.join('::')
     end
   end

--- a/lib/rom/setup_dsl/relation.rb
+++ b/lib/rom/setup_dsl/relation.rb
@@ -9,7 +9,7 @@ module ROM
     #
     # @api private
     def self.build_class(name, options = {})
-      class_name = "ROM::Relation[#{Inflecto.camelize(name)}]"
+      class_name = "ROM::Relation[#{Inflector.camelize(name)}]"
       adapter = options.fetch(:adapter)
 
       ClassBuilder.new(name: class_name, parent: self[adapter]).call do |klass|

--- a/lib/rom/support/inflector.rb
+++ b/lib/rom/support/inflector.rb
@@ -1,0 +1,47 @@
+module ROM
+  # Helper module providing thin interface around an inflection backend.
+  #
+  # @private
+  module Inflector
+    begin
+      @inflector =
+        begin
+          require 'active_support/inflector'
+          ::ActiveSupport::Inflector
+        rescue LoadError
+          require 'inflecto'
+          ::Inflecto
+        end
+    rescue LoadError
+      raise 'Unable to find an inflector library'
+    end
+
+    def self.camelize(input)
+      @inflector.camelize(input)
+    end
+
+    def self.underscore(input)
+      @inflector.underscore(input)
+    end
+
+    def self.singularize(input)
+      @inflector.singularize(input)
+    end
+
+    def self.pluralize(input)
+      @inflector.pluralize(input)
+    end
+
+    def self.demodulize(input)
+      @inflector.demodulize(input)
+    end
+
+    def self.constantize(input)
+      @inflector.constantize(input)
+    end
+
+    def self.classify(input)
+      @inflector.classify(input)
+    end
+  end
+end

--- a/spec/unit/rom/support/inflector_spec.rb
+++ b/spec/unit/rom/support/inflector_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe ROM::Inflector do
+  shared_examples 'an inflector' do
+    it 'singularises' do
+      expect(api.singularize('tasks')).to eq 'task'
+    end
+
+    it 'pluralizes' do
+      expect(api.pluralize('task')).to eq 'tasks'
+    end
+
+    it 'camelizes' do
+      expect(api.camelize('task_user')).to eq 'TaskUser'
+    end
+
+    it 'underscores' do
+      expect(api.underscore('TaskUser')).to eq 'task_user'
+    end
+
+    it 'demodulizes' do
+      expect(api.demodulize('Task::User')).to eq 'User'
+    end
+
+    it 'constantizes' do
+      expect(api.constantize('String')).to equal String
+    end
+
+    it 'classifies' do
+      expect(api.classify('task_user/name')).to eq 'TaskUser::Name'
+    end
+  end
+
+  subject(:api) { ROM::Inflector }
+
+  context 'with detected inflector' do
+    it_behaves_like 'an inflector'
+  end
+
+  context 'with ActiveSupport::Inflector' do
+    before do
+      require 'active_support/inflector'
+      api.instance_variable_set(:@inflector, ::ActiveSupport::Inflector)
+    end
+    it_behaves_like 'an inflector'
+  end
+
+  context 'with Inflecto' do
+    before do
+      require 'inflecto'
+      api.instance_variable_set(:@inflector, ::Inflecto)
+    end
+    it_behaves_like 'an inflector'
+  end
+end


### PR DESCRIPTION
Drop hard dependency on Inflecto and use a simple detection mechanism to use ActiveSupport::Inflector if it's available. We still fall back to using Inflecto if not.

Fixes #156.