### PR TITLE
Remove `inflecto` from gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem 'minitest'
   gem 'thread_safe'
   gem 'activesupport'
+  gem 'inflecto', '~> 0.0', '>= 0.0.2'
 
   platforms :rbx do
     gem 'rubysl-bigdecimal', platforms: :rbx

--- a/lib/rom/support/inflector.rb
+++ b/lib/rom/support/inflector.rb
@@ -4,13 +4,19 @@ module ROM
   # @private
   module Inflector
     BACKENDS = {
-      activesupport: ['active_support/inflector', 'ActiveSupport::Inflector'],
-      inflecto: ['inflecto', 'Inflecto']
+      activesupport: [
+        'active_support/inflector',
+        proc { ::ActiveSupport::Inflector }
+      ],
+      inflecto: [
+        'inflecto',
+        proc { ::Inflecto }
+      ]
     }.freeze
 
-    def self.realize_backend(path, inflector_class)
+    def self.realize_backend(path, inflector_backend_factory)
       require path
-      Object.const_get(inflector_class)
+      inflector_backend_factory.call
     rescue LoadError
       nil
     end

--- a/lib/rom/support/inflector.rb
+++ b/lib/rom/support/inflector.rb
@@ -3,7 +3,7 @@ module ROM
   #
   # @private
   module Inflector
-    begin
+    def self.setup
       @inflector =
         begin
           require 'active_support/inflector'
@@ -13,8 +13,11 @@ module ROM
           ::Inflecto
         end
     rescue LoadError
-      raise 'Unable to find an inflector library'
+      raise LoadError,
+            "No inflector library could be found: "\
+            "please install either the `activesupport` or `inflecto` gem."
     end
+    setup
 
     def self.camelize(input)
       @inflector.camelize(input)

--- a/lib/rom/support/inflector.rb
+++ b/lib/rom/support/inflector.rb
@@ -4,8 +4,8 @@ module ROM
   # @private
   module Inflector
     BACKENDS = {
-      activesupport: ['active_support/inflector', '::ActiveSupport::Inflector'],
-      inflecto: ['inflecto', '::Inflecto']
+      activesupport: ['active_support/inflector', 'ActiveSupport::Inflector'],
+      inflecto: ['inflecto', 'Inflecto']
     }.freeze
 
     def self.realize_backend(path, inflector_class)

--- a/lib/rom/support/inflector.rb
+++ b/lib/rom/support/inflector.rb
@@ -3,48 +3,65 @@ module ROM
   #
   # @private
   module Inflector
-    def self.setup
-      @inflector =
-        begin
-          require 'active_support/inflector'
-          ::ActiveSupport::Inflector
-        rescue LoadError
-          require 'inflecto'
-          ::Inflecto
-        end
+    BACKENDS = {
+      activesupport: ['active_support/inflector', '::ActiveSupport::Inflector'],
+      inflecto: ['inflecto', '::Inflecto']
+    }.freeze
+
+    def self.realize_backend(path, inflector_class)
+      require path
+      Object.const_get(inflector_class)
     rescue LoadError
-      raise LoadError,
-            "No inflector library could be found: "\
-            "please install either the `activesupport` or `inflecto` gem."
+      nil
     end
-    setup
+
+    def self.detect_backend
+      BACKENDS.find do |_, (path, inflector_class)|
+        backend = realize_backend(path, inflector_class)
+        break backend if backend
+      end ||
+        raise(LoadError,
+              "No inflector library could be found: "\
+              "please install either the `inflecto` or `activesupport` gem.")
+    end
+
+    def self.select_backend(name = nil)
+      if name && !BACKENDS.key?(name)
+        raise NameError, "Invalid inflector library selection: '#{name}'"
+      end
+      @inflector = name ? realize_backend(*BACKENDS[name]) : detect_backend
+    end
+
+    def self.inflector
+      @inflector || select_backend
+    end
 
     def self.camelize(input)
-      @inflector.camelize(input)
+      inflector.camelize(input)
     end
 
     def self.underscore(input)
-      @inflector.underscore(input)
+      inflector.underscore(input)
     end
 
     def self.singularize(input)
-      @inflector.singularize(input)
+      inflector.singularize(input)
     end
 
     def self.pluralize(input)
-      @inflector.pluralize(input)
+      inflector.pluralize(input)
     end
 
     def self.demodulize(input)
-      @inflector.demodulize(input)
+      inflector.demodulize(input)
     end
 
     def self.constantize(input)
-      @inflector.constantize(input)
+      inflector.constantize(input)
     end
 
     def self.classify(input)
-      @inflector.classify(input)
+      inflector.classify(input)
     end
   end
 end

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'transproc',   '~> 0.1'
   gem.add_runtime_dependency 'equalizer',   '~> 0.0', '>= 0.0.9'
-  gem.add_runtime_dependency 'inflecto',    '~> 0.0', '>= 0.0.2'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rspec-core', '~> 3.2'

--- a/spec/unit/rom/support/inflector_spec.rb
+++ b/spec/unit/rom/support/inflector_spec.rb
@@ -34,6 +34,10 @@ describe ROM::Inflector do
   subject(:api) { ROM::Inflector }
 
   context 'with detected inflector' do
+    before do
+      api.remove_instance_variable(:@inflector)
+      api.setup
+    end
     it_behaves_like 'an inflector'
   end
 
@@ -51,5 +55,28 @@ describe ROM::Inflector do
       api.instance_variable_set(:@inflector, ::Inflecto)
     end
     it_behaves_like 'an inflector'
+  end
+
+  context 'without an inflector library' do
+    around do |example|
+      begin
+        api.remove_instance_variable(:@inflector)
+        original_load_path = $LOAD_PATH.dup
+        # Remove inflectors from the load path
+        Gem::Specification.each do |g|
+          if g.name == 'activesupport' || g.name == 'inflecto'
+            $LOAD_PATH.delete(g.lib_dirs_glob)
+          end
+        end
+        example.run
+      ensure
+        # restore the load path
+        $LOAD_PATH.clear.concat(original_load_path)
+        api.setup
+      end
+    end
+    it 'raises a LoadError' do
+      expect { api.setup }.to raise_error(LoadError)
+    end
   end
 end

--- a/spec/unit/rom/support/inflector_spec.rb
+++ b/spec/unit/rom/support/inflector_spec.rb
@@ -36,7 +36,7 @@ describe ROM::Inflector do
   context 'with detected inflector' do
     before do
       if api.instance_variables.include?(:@inflector)
-        api.remove_instance_variable(:@inflector)
+        api.__send__(:remove_instance_variable, :@inflector)
       end
     end
 
@@ -48,7 +48,7 @@ describe ROM::Inflector do
   context 'with automatic detection' do
     before do
       if api.instance_variables.include?(:@inflector)
-        api.remove_instance_variable(:@inflector)
+        api.__send__(:remove_instance_variable, :@inflector)
       end
     end
 

--- a/spec/unit/rom/support/inflector_spec.rb
+++ b/spec/unit/rom/support/inflector_spec.rb
@@ -86,16 +86,4 @@ describe ROM::Inflector do
       expect { api.select_backend(:foo) }.to raise_error(NameError)
     end
   end
-
-  context 'an inflector library cannot be found' do
-    before do
-      if api.instance_variables.include?(:@inflector)
-        api.remove_instance_variable(:@inflector)
-      end
-      stub_const("ROM::Inflector::BACKENDS", {})
-    end
-    it 'raises a LoadError' do
-      expect { api.inflector }.to raise_error(LoadError)
-    end
-  end
 end

--- a/spec/unit/rom/support/inflector_spec.rb
+++ b/spec/unit/rom/support/inflector_spec.rb
@@ -63,7 +63,7 @@ describe ROM::Inflector do
     end
 
     it 'is ActiveSupport::Inflector' do
-      expect(api.inflector == ::ActiveSupport::Inflector).to be true
+      expect(api.inflector).to be(::ActiveSupport::Inflector)
     end
 
     it_behaves_like 'an inflector'
@@ -75,7 +75,7 @@ describe ROM::Inflector do
     end
 
     it 'is Inflecto' do
-      expect(api.inflector == ::Inflecto).to be true
+      expect(api.inflector).to be(::Inflecto)
     end
 
     it_behaves_like 'an inflector'


### PR DESCRIPTION
The `inflecto` gem is no longer a dependency.  If neither `activesupport` nor `inflecto` are available, the inflector API raises a `LoadError` informing the user that they should install an inflector backend.

I'm not entirely happy with having to introduce the `setup` method to `ROM::Inflector` and call it immediately, but it was the only obvious way to make it testable.  Suggestions on patterns for cleaning that up welcomed. :smile:
