### PR TITLE
Lazy-relation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ rom.command(:users).create.call(name: "Joe", age: 17)
 rom.command(:users).create.call(name: "Jane", age: 18)
 
 # reading relations using defined mappers
-puts rom.relation(:users) { |r| r.by_name("Jane").adults }.as(:entities)
+puts rom.relation(:users) { |r| r.by_name("Jane").adults }.as(:entities).to_a.inspect
 # => [#<User:0x007fdba161cc48 @id=2, @name="Jane", @age=18>]
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class Users < ROM::Relation[:memory]
   end
 
   def adults
-    find_all { |user| user[:age] >= 18 }
+    restrict { |user| user[:age] >= 18 }
   end
 end
 
@@ -87,7 +87,7 @@ rom = ROM.finalize.env
 
 # accessing defined commands
 rom.command(:users).create.call(name: "Joe", age: 17)
-rom.command(:users).create.call(name: "Joe", age: 17)
+rom.command(:users).create.call(name: "Jane", age: 18)
 
 # reading relations using defined mappers
 puts rom.relation(:users) { |r| r.by_name("Jane").adults }.as(:entities)

--- a/benchmarks/basic.rb
+++ b/benchmarks/basic.rb
@@ -5,56 +5,90 @@ require_relative 'setup'
 
 run("Loading ONE user object") do
   Benchmark.ips do |x|
-    x.report("AR") { ARUser.by_name('name 1').first }
-    x.report("ROM") { users.by_name('name 1').first }
+    x.report("AR") do
+      ARUser.by_name('name 1').first
+    end
+    x.report("ROM") do
+      users.by_name('name 1').as(:users).one
+    end
     x.compare!
   end
 end
 
 run("Loading ALL user objects") do
   Benchmark.ips do |x|
-    x.report("AR") { ARUser.all.to_a }
-    x.report("ROM") { users.all.to_a }
+    x.report("AR") do
+      ARUser.all.to_a
+    end
+    x.report("ROM") do
+      users.all.as(:users).to_a
+    end
     x.compare!
   end
 end
 
 run("Loading ALL users with their tasks") do
   Benchmark.ips do |x|
-    x.report("AR") { ARUser.all.includes(:tasks).to_a }
-    x.report("ROM") { users.all.with_tasks.to_a }
+    x.report("AR") do
+      ARUser.all.includes(:tasks).to_a
+    end
+    x.report("ROM") do
+      users.all.with_tasks.as(:user_with_tasks).to_a
+    end
     x.compare!
   end
 end
 
 run("Loading ONE task with its user and tags") do
   Benchmark.ips do |x|
-    x.report("AR") { ARTask.all.includes(:user).includes(:tags).first }
-    x.report("ROM") { tasks.with_user.with_tags.by_title('task 1').first }
+    x.report("AR") do
+      ARTask.all
+        .includes(:user)
+        .includes(:tags)
+        .where(users: { name: 'User 1' }, tasks: { title: 'Task 1' })
+        .to_a
+    end
+    x.report("ROM") do
+      tasks_with_user_and_tags
+        .where(users__name: 'User 1', tasks__title: 'Task 1')
+        .to_a
+    end
     x.compare!
   end
 end
 
 run("Loading ALL tasks with their users") do
   Benchmark.ips do |x|
-    x.report("AR") { ARTask.all.includes(:user).to_a }
-    x.report("ROM") { tasks.with_user.to_a }
+    x.report("AR") do
+      ARTask.all.includes(:user).to_a
+    end
+    x.report("ROM") do
+      tasks.with_user.as(:task_with_user).to_a
+    end
     x.compare!
   end
 end
 
 run("Loading ALL tasks with their users and tags") do
   Benchmark.ips do |x|
-    x.report("AR") { ARTask.all.includes(:user).includes(:tags).to_a }
-    x.report("ROM") { tasks.all.with_user.with_tags.to_a }
+    x.report("AR") do
+      ARTask.all.includes(:user).includes(:tags).to_a
+    end
+    x.report("ROM") do
+      tasks.all.with_user.with_tags.as(:task_with_user_and_tags).to_a
+    end
     x.compare!
   end
 end
 
 run("to_json on ALL user objects") do
   Benchmark.ips do |x|
-    x.report("AR") { ARUser.all.to_a.to_json }
-    x.report("ROM") { users.all.to_a.to_json }
+    x.report("AR") do
+      ARUser.all.to_a.to_json
+    end
+    x.report("ROM") do
+      users.all.to_a.to_json
+    end
     x.compare!
   end
 end

--- a/benchmarks/basic.rb
+++ b/benchmarks/basic.rb
@@ -6,10 +6,10 @@ require_relative 'setup'
 run("Loading ONE user object") do
   Benchmark.ips do |x|
     x.report("AR") do
-      ARUser.by_name('name 1').first
+      ARUser.by_name('User 1').first
     end
     x.report("ROM") do
-      users.by_name('name 1').as(:users).one
+      users.by_name('User 1').as(:users).one
     end
     x.compare!
   end

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -14,15 +14,19 @@ def rom
 end
 
 def users
-  rom.read(:users)
+  rom.relation(:users)
 end
 
 def tasks
-  rom.read(:tasks)
+  rom.relation(:tasks)
+end
+
+def tasks_with_user_and_tags
+  tasks.with_user.with_tags.as(:task_with_user_and_tags)
 end
 
 def tags
-  rom.read(:tags)
+  rom.relation(:tags)
 end
 
 def hr
@@ -142,6 +146,7 @@ module Mappers
 
       model name: 'User'
 
+      attribute :id
       attribute :name
       attribute :email
       attribute :age
@@ -150,7 +155,7 @@ module Mappers
     class WithTasks < Base
       model name: 'UserWithTasks'
 
-      relation :with_tasks
+      register_as :user_with_tasks
 
       group :tasks do
         model name: 'UserTask'
@@ -166,6 +171,15 @@ module Mappers
 
       model name: 'Task'
 
+      attribute :id
+      attribute :title
+    end
+
+    class WithUser < Base
+      register_as :task_with_user
+
+      model name: 'TaskWithUser'
+
       wrap :user do
         model name: 'TaskUser'
 
@@ -174,6 +188,12 @@ module Mappers
         attribute :email
         attribute :age
       end
+    end
+
+    class WithUserAndTags < WithUser
+      register_as :task_with_user_and_tags
+
+      model name: 'TaskWithUserAndTags'
 
       group :tags do
         model name: 'Tag'
@@ -192,7 +212,7 @@ COUNT = ENV.fetch('COUNT', 1000).to_i
 
 USER_SEED = COUNT.times.map do |i|
   { id:    i + 1,
-    name:  "name #{i}",
+    name:  "User #{i}",
     email: "email_#{i}@domain.com",
     age:   i*10 }
 end

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -94,7 +94,7 @@ end
 
 module Relations
   class Users < ROM::Relation[:sql]
-    base_name :users
+    dataset :users
 
     one_to_many :tasks, key: :user_id
 
@@ -112,7 +112,7 @@ module Relations
   end
 
   class Tasks < ROM::Relation[:sql]
-    base_name :tasks
+    dataset :tasks
 
     many_to_one :users, key: :user_id
     one_to_many :tags, key: :task_id

--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -14,5 +14,6 @@ module ROM
   InvalidOptionValueError = Class.new(StandardError)
   InvalidOptionKeyError = Class.new(StandardError)
 
+  EMPTY_ARRAY = [].freeze
   EMPTY_HASH = {}.freeze
 end

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -69,7 +69,11 @@ module ROM
           relations[name]
         end
 
-      relation.to_lazy(mappers: mappers[name])
+      if mappers.elements.key?(name)
+        relation.to_lazy(mappers: mappers[name])
+      else
+        relation.to_lazy
+      end
     end
 
     # Returns a reader with access to defined mappers

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -62,14 +62,14 @@ module ROM
     #
     # @api public
     def relation(name, &block)
-      tuples =
+      relation =
         if block
           yield(relations[name])
         else
           relations[name]
         end
 
-      Relation::Loaded.new(tuples, mappers[name])
+      relation.to_lazy(mappers: mappers[name])
     end
 
     # Returns a reader with access to defined mappers

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -1,3 +1,5 @@
+require 'rom/relation/lazy'
+
 module ROM
   # Base relation class
   #
@@ -187,6 +189,11 @@ module ROM
     # @api private
     def repository
       self.class.repository
+    end
+
+    # @api public
+    def to_lazy
+      Lazy.new(self)
     end
 
     private

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -1,4 +1,5 @@
 require 'rom/relation/lazy'
+require 'rom/relation/curried'
 
 module ROM
   # Base relation class

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -192,8 +192,8 @@ module ROM
     end
 
     # @api public
-    def to_lazy
-      Lazy.new(self)
+    def to_lazy(*args)
+      Lazy.new(self, *args)
     end
 
     private

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -47,14 +47,15 @@ module ROM
       end
       alias_method :[], :call
 
-      # Return results from the left and the composite result
+      # Coerce composite relation to an array
       #
-      # @return [Array<Array>]
+      # @return [Array]
       #
-      # @api private
+      # @api public
       def to_a
-        [left.to_a, call.to_a]
+        call.to_a
       end
+      alias_method :to_ary, :to_a
 
       # @api private
       def respond_to_missing?(name, include_private = false)

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -69,7 +69,12 @@ module ROM
       # @api private
       def method_missing(name, *args, &block)
         if left.respond_to?(name)
-          self.class.new(left.__send__(name, *args, &block), right)
+          response = left.__send__(name, *args, &block)
+          if response.is_a?(left.class)
+            self.class.new(response, right)
+          else
+            response
+          end
         else
           super
         end

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -37,13 +37,13 @@ module ROM
       #
       # Optional args are passed to the left object
       #
-      # @return [Array]
+      # @return [Loaded]
       #
       # @alias []
       #
       # @api public
       def call(*args)
-        right.call(left.call(*args))
+        Loaded.new(right.call(left.call(*args)))
       end
       alias_method :[], :call
 
@@ -56,6 +56,28 @@ module ROM
         call.to_a
       end
       alias_method :to_ary, :to_a
+
+      # Delegate to loaded relation and return one object
+      #
+      # @return [Object]
+      #
+      # @see Loaded#one
+      #
+      # @api public
+      def one
+        call.one
+      end
+
+      # Delegate to loaded relation and return one object
+      #
+      # @return [Object]
+      #
+      # @see Loaded#one
+      #
+      # @api public
+      def one!
+        call.one!
+      end
 
       # @api private
       def respond_to_missing?(name, include_private = false)

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -1,3 +1,5 @@
+require 'rom/relation/loaded'
+
 module ROM
   class Relation
     # Left-to-right relation composition used for data-pipelining
@@ -43,7 +45,14 @@ module ROM
       #
       # @api public
       def call(*args)
-        Loaded.new(right.call(left.call(*args)))
+        relation = left.call(*args)
+        response = right.call(relation)
+
+        if relation.is_a?(Loaded)
+          relation.new(response)
+        else
+          Loaded.new(relation, response)
+        end
       end
       alias_method :[], :call
 

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -1,34 +1,71 @@
 module ROM
   class Relation
+    # Left-to-right relation composition used for data-pipelining
+    #
+    # @api public
     class Composite
       include Equalizer.new(:left, :right)
 
-      attr_reader :left, :right
+      # @return [Lazy,Curried,Composite,#call]
+      #
+      # @api private
+      attr_reader :left
 
+      # @return [Lazy,Curried,Composite,#call]
+      #
+      # @api private
+      attr_reader :right
+
+      # @api private
       def initialize(left, right)
         @left = left
         @right = right
       end
 
+      # Compose with another callable object
+      #
+      # @param [#call]
+      #
+      # @return [Composite]
+      #
+      # @api public
       def >>(other)
         self.class.new(self, other)
       end
 
+      # Call the pipeline by passing results from left to right
+      #
+      # Optional args are passed to the left object
+      #
+      # @return [Array]
+      #
+      # @alias []
+      #
+      # @api public
       def call(*args)
         right.call(left.call(*args))
       end
       alias_method :[], :call
 
+      # Return results from the left and the composite result
+      #
+      # @return [Array<Array>]
+      #
+      # @api private
       def to_a
         [left.to_a, call.to_a]
       end
 
+      # @api private
       def respond_to_missing?(name, include_private = false)
         left.respond_to?(name) || super
       end
 
       private
 
+      # Allow calling methods on the left side object
+      #
+      # @api private
       def method_missing(name, *args, &block)
         if left.respond_to?(name)
           self.class.new(left.__send__(name, *args, &block), right)

--- a/lib/rom/relation/composite.rb
+++ b/lib/rom/relation/composite.rb
@@ -1,0 +1,41 @@
+module ROM
+  class Relation
+    class Composite
+      include Equalizer.new(:left, :right)
+
+      attr_reader :left, :right
+
+      def initialize(left, right)
+        @left = left
+        @right = right
+      end
+
+      def >>(other)
+        self.class.new(self, other)
+      end
+
+      def call(*args)
+        right.call(left.call(*args))
+      end
+      alias_method :[], :call
+
+      def to_a
+        [left.to_a, call.to_a]
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        left.respond_to?(name) || super
+      end
+
+      private
+
+      def method_missing(name, *args, &block)
+        if left.respond_to?(name)
+          self.class.new(left.__send__(name, *args, &block), right)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/relation/curried.rb
+++ b/lib/rom/relation/curried.rb
@@ -1,0 +1,30 @@
+require 'rom/relation/lazy'
+
+module ROM
+  class Relation
+    class Curried < Lazy
+      option :name, type: Symbol, reader: true
+      option :arity, type: Integer, reader: true, default: -1
+      option :curry_args, type: Array, reader: true, default: EMPTY_ARRAY
+
+      def call(*args)
+        if arity != -1
+          all_args = curry_args + args
+
+          if arity == all_args.size
+            Loaded.new(relation.__send__(name, *all_args), mappers)
+          else
+            __new__(relation, curry_args: all_args)
+          end
+        else
+          super
+        end
+      end
+      alias_method :[], :call
+
+      def curried?
+        true
+      end
+    end
+  end
+end

--- a/lib/rom/relation/curried.rb
+++ b/lib/rom/relation/curried.rb
@@ -36,6 +36,13 @@ module ROM
       def curried?
         true
       end
+
+      private
+
+      # @api private
+      def __new__(relation, new_opts = {})
+        Curried.new(relation, options.update(new_opts))
+      end
     end
   end
 end

--- a/lib/rom/relation/curried.rb
+++ b/lib/rom/relation/curried.rb
@@ -18,7 +18,7 @@ module ROM
           all_args = curry_args + args
 
           if arity == all_args.size
-            Loaded.new(relation.__send__(name, *all_args), mappers)
+            Loaded.new(relation.__send__(name, *all_args))
           else
             __new__(relation, curry_args: all_args)
           end

--- a/lib/rom/relation/curried.rb
+++ b/lib/rom/relation/curried.rb
@@ -7,6 +7,12 @@ module ROM
       option :arity, type: Integer, reader: true, default: -1
       option :curry_args, type: Array, reader: true, default: EMPTY_ARRAY
 
+      # Load relation if args match the arity
+      #
+      # @return [Loaded,Lazy,Curried]
+      # @see Lazy#call
+      #
+      # @api public
       def call(*args)
         if arity != -1
           all_args = curry_args + args
@@ -22,6 +28,11 @@ module ROM
       end
       alias_method :[], :call
 
+      # Return if this lazy relation is curried
+      #
+      # @return [true]
+      #
+      # @api private
       def curried?
         true
       end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -75,7 +75,7 @@ module ROM
           if method.arity == all_args.size
             Loaded.new(relation.__send__(name, *all_args), mappers)
           else
-            self.class.new(relation, name: name, curry_args: all_args)
+            self.class.new(relation, options.merge(name: name, curry_args: all_args))
           end
         else
           Loaded.new(relation, mappers)
@@ -90,7 +90,7 @@ module ROM
       private
 
       def method_missing(name, *args)
-        self.class.new(relation, name: name, curry_args: args)
+        self.class.new(relation, options.merge(name: name, curry_args: args))
       end
     end
   end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -87,8 +87,8 @@ module ROM
       # @alias []
       #
       # @api public
-      def call(*args)
-        Loaded.new(relation, mappers)
+      def call
+        Loaded.new(relation)
       end
       alias_method :[], :call
 

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -1,0 +1,64 @@
+module ROM
+  class Relation
+    class Composite
+      attr_reader :left, :right
+
+      def initialize(left, right)
+        @left = left
+        @right = right
+      end
+
+      def call
+        right.call(left.call)
+      end
+
+      def to_a
+        [left.to_a, call.to_a]
+      end
+    end
+
+    class Lazy
+      include Options
+
+      option :name, type: Symbol, reader: true
+      option :curry_args, type: Array, reader: true
+
+      attr_reader :relation, :method
+
+      def initialize(relation, options = {})
+        super
+        @relation = relation
+        @method = relation.method(name) if name
+      end
+
+      def >>(other)
+        Composite.new(self, other)
+      end
+
+      def to_a
+        call.to_a
+      end
+
+      def call(*args)
+        if name
+          all_args = curry_args + args
+
+          if method.arity == curry_args.size
+            relation.__send__(name, *all_args)
+          else
+            self.class.new(relation, name: name, curry_args: all_args)
+          end
+        else
+          relation
+        end
+      end
+      alias_method :[], :call
+
+      private
+
+      def method_missing(name, *args)
+        self.class.new(relation, name: name, curry_args: args)
+      end
+    end
+  end
+end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -3,49 +3,118 @@ require 'rom/relation/composite'
 
 module ROM
   class Relation
+    # Lazy relation wraps canonical relation for data-pipelining
+    #
+    # @example
+    #   ROM.setup(:memory)
+    #
+    #   class Users < ROM::Relation[:memory]
+    #     def by_name(name)
+    #       restrict(name: name)
+    #     end
+    #   end
+    #
+    #   rom = ROM.finalize.env
+    #
+    #   rom.relations.users << { name: 'Jane' }
+    #   rom.relations.users << { name: 'Joe' }
+    #
+    #   mapper = proc { |users| users.map { |user| user[:name] } }
+    #   users = rom.relation(:users)
+    #
+    #   (users.by_name >> mapper)['Jane'].inspect # => ["Jane"]
+    #
+    # @api public
     class Lazy
       include Equalizer.new(:relation, :options)
       include Options
 
       option :mappers, reader: true, default: EMPTY_HASH
 
+      # @return [Relation]
+      #
+      # @api private
       attr_reader :relation
 
+      # @api private
       def initialize(relation, options = {})
         super
         @relation = relation
       end
 
+      # Compose two relation with a left-to-right composition
+      #
+      # @example
+      #   users.by_name('Jane') >> tasks.for_users
+      #
+      # @param [Relation] other The right relation
+      #
+      # @return [Relation::Composite]
+      #
+      # @api public
       def >>(other)
         Composite.new(self, other)
       end
 
+      # Build a relation pipeline using registered mappers
+      #
+      # @example
+      #   rom.relation(:users).map_with(:json_serializer)
+      #
+      # @return [Relation::Composite]
+      #
+      # @api public
       def map_with(*names)
         [self, *names.map { |name| mappers[name] }]
           .reduce { |a, e| Composite.new(a, e) }
       end
       alias_method :as, :map_with
 
+      # Coerce lazy relation to an array
+      #
+      # @return [Array]
+      #
+      # @api public
       def to_a
         call.to_a
       end
       alias_method :to_ary, :to_a
 
+      # Load relation
+      #
+      # @return [Relation::Loaded]
+      #
+      # @alias []
+      #
+      # @api public
       def call(*args)
         Loaded.new(relation, mappers)
       end
       alias_method :[], :call
 
+      # @api private
       def respond_to_missing?(name, include_private = false)
         relation.respond_to?(name) || super
       end
 
+      # Return if this lazy relation is curried
+      #
+      # @return [false]
+      #
+      # @api private
       def curried?
         false
       end
 
       private
 
+      # Forward methods to the underlaying relation
+      #
+      # Auto-curry relations when args size doesn't match arity
+      #
+      # @return [Lazy,Curried]
+      #
+      # @api private
       def method_missing(meth, *args, &block)
         if !relation.respond_to?(meth) || (curried? && name != meth)
           super
@@ -60,6 +129,9 @@ module ROM
         end
       end
 
+      # Return new lazy relation with updated options
+      #
+      # @api private
       def __new__(relation, new_opts = {})
         Lazy.new(relation, options.merge(new_opts))
       end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -3,6 +3,8 @@ require 'rom/relation/loaded'
 module ROM
   class Relation
     class Composite
+      include Equalizer.new(:left, :right)
+
       attr_reader :left, :right
 
       def initialize(left, right)
@@ -39,6 +41,8 @@ module ROM
     end
 
     class Lazy
+      include Equalizer.new(:relation, :options)
+
       include Options
 
       option :name, type: Symbol, reader: true

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -47,7 +47,7 @@ module ROM
 
       option :name, type: Symbol, reader: true
       option :arity, type: Integer, reader: true, default: -1
-      option :curry_args, type: Array, reader: true
+      option :curry_args, type: Array, reader: true, default: EMPTY_ARRAY
       option :mappers, reader: true, default: EMPTY_HASH
 
       attr_reader :relation, :arity
@@ -95,16 +95,22 @@ module ROM
 
       def method_missing(name, *args, &block)
         if relation.respond_to?(name)
-          __new__(
-            relation,
-            name: name, curry_args: args, arity: relation.method(name).arity
-          )
+          arity = relation.method(name).arity
+
+          if arity == -1 || arity == args.size
+            __new__(relation.__send__(name, *args, *block))
+          else
+            __new__(
+              relation,
+              name: name, curry_args: args, arity: arity
+            )
+          end
         else
           super
         end
       end
 
-      def __new__(relation, new_opts)
+      def __new__(relation, new_opts = {})
         self.class.new(relation, options.merge(new_opts))
       end
     end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -144,7 +144,12 @@ module ROM
           arity = relation.method(meth).arity
 
           if arity == -1 || arity == args.size
-            __new__(relation.__send__(meth, *args, &block))
+            response = relation.__send__(meth, *args, &block)
+            if response.is_a?(Relation)
+              __new__(response)
+            else
+              response
+            end
           else
             Curried.new(relation, name: meth, curry_args: args, arity: arity)
           end

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -93,20 +93,20 @@ module ROM
 
       private
 
-      def method_missing(name, *args, &block)
-        if relation.respond_to?(name)
-          arity = relation.method(name).arity
+      def method_missing(meth, *args, &block)
+        if !relation.respond_to?(meth) || (name && meth != name)
+          super
+        else
+          arity = relation.method(meth).arity
 
           if arity == -1 || arity == args.size
-            __new__(relation.__send__(name, *args, *block))
+            __new__(relation.__send__(meth, *args, &block))
           else
             __new__(
               relation,
-              name: name, curry_args: args, arity: arity
+              name: meth, curry_args: args, arity: arity
             )
           end
-        else
-          super
         end
       end
 

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -5,7 +5,6 @@ module ROM
   class Relation
     class Lazy
       include Equalizer.new(:relation, :options)
-
       include Options
 
       option :name, type: Symbol, reader: true
@@ -13,7 +12,7 @@ module ROM
       option :curry_args, type: Array, reader: true, default: EMPTY_ARRAY
       option :mappers, reader: true, default: EMPTY_HASH
 
-      attr_reader :relation, :arity
+      attr_reader :relation
 
       def initialize(relation, options = {})
         super

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -92,6 +92,28 @@ module ROM
       end
       alias_method :[], :call
 
+      # Delegate to loaded relation and return one object
+      #
+      # @return [Object]
+      #
+      # @see Loaded#one
+      #
+      # @api public
+      def one
+        call.one
+      end
+
+      # Delegate to loaded relation and return one object
+      #
+      # @return [Object]
+      #
+      # @see Loaded#one
+      #
+      # @api public
+      def one!
+        call.one!
+      end
+
       # @api private
       def respond_to_missing?(name, include_private = false)
         relation.respond_to?(name) || super

--- a/lib/rom/relation/lazy.rb
+++ b/lib/rom/relation/lazy.rb
@@ -1,45 +1,8 @@
 require 'rom/relation/loaded'
+require 'rom/relation/composite'
 
 module ROM
   class Relation
-    class Composite
-      include Equalizer.new(:left, :right)
-
-      attr_reader :left, :right
-
-      def initialize(left, right)
-        @left = left
-        @right = right
-      end
-
-      def >>(other)
-        self.class.new(self, other)
-      end
-
-      def call(*args)
-        right.call(left.call(*args))
-      end
-      alias_method :[], :call
-
-      def to_a
-        [left.to_a, call.to_a]
-      end
-
-      def respond_to_missing?(name, include_private = false)
-        left.respond_to?(name) || super
-      end
-
-      private
-
-      def method_missing(name, *args, &block)
-        if left.respond_to?(name)
-          self.class.new(left.__send__(name, *args, &block), right)
-        else
-          super
-        end
-      end
-    end
-
     class Lazy
       include Equalizer.new(:relation, :options)
 

--- a/lib/rom/relation/loaded.rb
+++ b/lib/rom/relation/loaded.rb
@@ -6,16 +6,24 @@ module ROM
     class Loaded
       include Enumerable
 
-      # Materialized relation
+      # Source relation
       #
       # @return [Relation]
       #
       # @api private
-      attr_reader :relation
+      attr_reader :source
+
+      # Materialized relation
+      #
+      # @return [Object]
+      #
+      # @api private
+      attr_reader :collection
 
       # @api private
-      def initialize(relation)
-        @relation = relation.to_a
+      def initialize(source, collection = source.to_a)
+        @source = source
+        @collection = collection
       end
 
       # Yield relation tuples
@@ -25,7 +33,12 @@ module ROM
       # @api public
       def each(&block)
         return to_enum unless block
-        relation.each(&block)
+        collection.each(&block)
+      end
+
+      # @api public
+      def new(collection)
+        self.class.new(source, collection)
       end
 
       # Returns a single tuple from the relation if there is one.
@@ -35,13 +48,13 @@ module ROM
       #
       # @api public
       def one
-        if relation.size > 1
+        if collection.count > 1
           raise(
             TupleCountMismatchError,
             'The relation consists of more than one tuple'
           )
         else
-          relation.first
+          collection.first
         end
       end
 

--- a/lib/rom/relation/loaded.rb
+++ b/lib/rom/relation/loaded.rb
@@ -1,6 +1,6 @@
 module ROM
   class Relation
-    # Wraps loaded data from a relation and gives access to its mappers
+    # Materializes a relation and exposes interface to access the data
     #
     # @public
     class Loaded
@@ -13,15 +13,9 @@ module ROM
       # @api private
       attr_reader :relation
 
-      # @return [ROM::MapperRegistry]
-      #
       # @api private
-      attr_reader :mappers
-
-      # @api private
-      def initialize(relation, mappers)
+      def initialize(relation)
         @relation = relation.to_a
-        @mappers = mappers
       end
 
       # Yield relation tuples
@@ -63,28 +57,6 @@ module ROM
           'The relation does not contain any tuples'
         )
       end
-
-      # Map loaded relation using a specified mapper
-      #
-      # @example
-      #
-      #   loaded = rom.relation(:users) { |r| r.by_name('Jane') }
-      #
-      #   # mapping with a single mapper
-      #   loaded.map_with(:entity_mapper)
-      #
-      #   # mapping with a multiple mappers
-      #   loaded.map_with(:entity_mapper, :presenter_decorator)
-      #
-      # @return [Array] array of mapped tuples
-      #
-      # @api public
-      def as(*names)
-        result = relation
-        names.each { |name| result = mappers[name].call(result) }
-        result
-      end
-      alias_method :map_with, :as
     end
   end
 end

--- a/spec/integration/relations/reading_spec.rb
+++ b/spec/integration/relations/reading_spec.rb
@@ -203,7 +203,7 @@ describe 'Reading relations' do
 
     user = rom.relation(:users) { |users|
       users.by_name('Joe')
-    }.map_with(:prefixer).first
+    }.map_with(:prefixer).call.first
 
     expect(user).to eql(user_name: 'Joe', user_email: "joe@doe.org")
   end

--- a/spec/shared/one_behavior.rb
+++ b/spec/shared/one_behavior.rb
@@ -1,0 +1,26 @@
+shared_examples_for 'a relation that returns one tuple' do
+  describe '#one' do
+    it 'returns first tuple' do
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+      expect(users.one).to eql(name: 'Jane', email: 'jane@doe.org')
+    end
+
+    it 'raises error when there is more than one tuple' do
+      expect { users.one }.to raise_error(ROM::TupleCountMismatchError)
+    end
+  end
+
+  describe '#one!' do
+    it 'returns first tuple' do
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+      expect(users.one!).to eql(name: 'Jane', email: 'jane@doe.org')
+    end
+
+    it 'raises error when there is no tuples' do
+      rom.relations.users.delete(name: 'Jane', email: 'jane@doe.org')
+      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
+
+      expect { users.one! }.to raise_error(ROM::TupleCountMismatchError)
+    end
+  end
+end

--- a/spec/shared/one_behavior.rb
+++ b/spec/shared/one_behavior.rb
@@ -2,25 +2,25 @@ shared_examples_for 'a relation that returns one tuple' do
   describe '#one' do
     it 'returns first tuple' do
       rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
-      expect(users.one).to eql(name: 'Jane', email: 'jane@doe.org')
+      expect(relation.one).to eql(name: 'Jane', email: 'jane@doe.org')
     end
 
     it 'raises error when there is more than one tuple' do
-      expect { users.one }.to raise_error(ROM::TupleCountMismatchError)
+      expect { relation.one }.to raise_error(ROM::TupleCountMismatchError)
     end
   end
 
   describe '#one!' do
     it 'returns first tuple' do
       rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
-      expect(users.one!).to eql(name: 'Jane', email: 'jane@doe.org')
+      expect(relation.one!).to eql(name: 'Jane', email: 'jane@doe.org')
     end
 
     it 'raises error when there is no tuples' do
       rom.relations.users.delete(name: 'Jane', email: 'jane@doe.org')
       rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
 
-      expect { users.one! }.to raise_error(ROM::TupleCountMismatchError)
+      expect { relation.one! }.to raise_error(ROM::TupleCountMismatchError)
     end
   end
 end

--- a/spec/unit/rom/env_spec.rb
+++ b/spec/unit/rom/env_spec.rb
@@ -24,7 +24,7 @@ describe ROM::Env do
   end
 
   describe '#relation' do
-    it 'yields selected relation to the block and returns a reader' do
+    it 'yields selected relation to the block and returns a loaded relation' do
       result = rom.relation(:users) { |r| r.by_name('Jane') }.as(:name_list)
       expect(result).to match_array([{ name: 'Jane' }])
     end

--- a/spec/unit/rom/env_spec.rb
+++ b/spec/unit/rom/env_spec.rb
@@ -10,6 +10,8 @@ describe ROM::Env do
       end
     end
 
+    setup.relation(:tasks)
+
     setup.mappers do
       define(:users) do
         attribute :name
@@ -34,6 +36,11 @@ describe ROM::Env do
       by_name = rom.relation(:users).as(:name_list).by_name
 
       expect(by_name['Jane']).to match_array([{ name: 'Jane' }])
+    end
+
+    it 'returns lazy relation without mappers when mappers are not defined' do
+      expect(rom.relation(:tasks)).to be_instance_of(ROM::Relation::Lazy)
+      expect(rom.relation(:tasks).relation).to be(rom.relations.tasks)
     end
   end
 

--- a/spec/unit/rom/env_spec.rb
+++ b/spec/unit/rom/env_spec.rb
@@ -26,7 +26,14 @@ describe ROM::Env do
   describe '#relation' do
     it 'yields selected relation to the block and returns a loaded relation' do
       result = rom.relation(:users) { |r| r.by_name('Jane') }.as(:name_list)
-      expect(result).to match_array([{ name: 'Jane' }])
+
+      expect(result.call).to match_array([{ name: 'Jane' }])
+    end
+
+    it 'returns lazy-mapped relation' do
+      by_name = rom.relation(:users).as(:name_list).by_name
+
+      expect(by_name['Jane']).to match_array([{ name: 'Jane' }])
     end
   end
 

--- a/spec/unit/rom/relation/composite_spec.rb
+++ b/spec/unit/rom/relation/composite_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe ROM::Relation::Composite do
+  include_context 'users and tasks'
+
+  let(:users) { rom.relation(:users) }
+
+  let(:name_list) { proc { |r| r.map { |t| t[:name] } } }
+  let(:upcaser) { proc { |r| r.map(&:upcase) } }
+
+  before do
+    setup.relation(:users) do
+      def by_name(name)
+        restrict(name: name)
+      end
+
+      def sorted(other)
+        other.sort_by { |t| t[:name] }
+      end
+    end
+  end
+
+  describe '#call' do
+    it 'sends a relation through mappers' do
+      relation = users >> name_list >> upcaser
+      loaded = relation.call
+
+      expect(loaded.source).to eql(users.relation)
+      expect(loaded).to match_array(%w(JANE JOE))
+    end
+
+    it 'sends a relation through another relation' do
+      relation = users >> users.sorted
+      loaded = relation.call
+
+      expect(loaded.source).to eql(users.relation)
+      expect(loaded).to match_array([
+        { name: 'Jane', email: 'jane@doe.org' },
+        { name: 'Joe', email: 'joe@doe.org' }
+      ])
+    end
+  end
+end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -122,6 +122,16 @@ describe ROM::Relation::Lazy do
 
     it_behaves_like 'a relation that returns one tuple' do
       let(:relation) { rom.relation(:users) >> proc { |r| r } }
+
+      describe 'using a mapper' do
+        it 'returns one mapped tuple' do
+          mapper = proc { |r| r.map { |t| t[:name].upcase } }
+          relation = users.by_name('Jane') >> mapper
+
+          expect(relation.one).to eql('JANE')
+          expect(relation.one!).to eql('JANE')
+        end
+      end
     end
   end
 end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -116,4 +116,6 @@ describe ROM::Relation::Lazy do
       ])
     end
   end
+
+  it_behaves_like 'a relation that returns one tuple'
 end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -52,15 +52,13 @@ describe ROM::Relation::Lazy do
     it 'forwards to relation and does not auto-curry when it is not needed' do
       relation = users.by_name('Jane')
 
-      expect(relation.name).to be(nil)
-      expect(relation.curry_args).to be_empty
-
+      expect(relation).to_not be_curried
       expect(relation).to match_array(rom.relations.users.by_name('Jane'))
     end
 
     it 'forwards to relation and return lazy when arity is unknown' do
       relation = users.all(name: 'Jane')
-      expect(relation.name).to be(nil)
+      expect(relation).to_not be_curried
       expect(relation).to match_array(rom.relations.users.by_name('Jane').to_a)
     end
 

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -111,9 +111,8 @@ describe ROM::Relation::Lazy do
     it 'composes two relations' do
       other = users.by_name('Jane') >> tasks.for_users
 
-      expect(other.to_a).to eql([
-        [{ name: 'Jane', email: 'jane@doe.org' }],
-        [{ name: 'Jane', title: 'be cool', priority: 2 }]
+      expect(other).to match_array([
+        { name: 'Jane', title: 'be cool', priority: 2 }
       ])
     end
   end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe ROM::Relation::Lazy do
+  include_context 'users and tasks'
+
+  let(:users) { rom.relations.users.to_lazy }
+  let(:tasks) { rom.relations.tasks.to_lazy }
+
+  before do
+    setup.relation(:users) do
+      def by_name(name)
+        restrict(name: name)
+      end
+    end
+
+    setup.relation(:tasks) do
+      def for_users(users)
+        names = users.map { |u| u[:name] }
+        restrict { |t| names.include?(t[:name]) }
+      end
+    end
+  end
+
+  describe '#call' do
+    it 'auto-curries' do
+      relation = users.by_name
+
+      expect(relation.name).to eql(:by_name)
+      expect(relation['Jane'].call).to eql(rom.relations.users.by_name('Jane'))
+    end
+
+    it 'returns relation' do
+      expect(users.call).to eql(rom.relations.users)
+    end
+  end
+
+  describe '#>>' do
+    it 'composes two relations' do
+      other = users.by_name('Jane') >> tasks.for_users
+
+      expect(other.to_a).to eql([
+        [{ name: 'Jane', email: 'jane@doe.org' }],
+        [{ name: 'Jane', title: 'be cool', priority: 2 }]
+      ])
+    end
+  end
+end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -8,6 +8,10 @@ describe ROM::Relation::Lazy do
 
   before do
     setup.relation(:users) do
+      def first
+        to_a.first
+      end
+
       def by_name(name)
         restrict(name: name)
       end
@@ -73,6 +77,10 @@ describe ROM::Relation::Lazy do
       relation = users.all(name: 'Jane')
       expect(relation).to_not be_curried
       expect(relation).to match_array(rom.relations.users.by_name('Jane').to_a)
+    end
+
+    it 'returns original response if it is not a relation' do
+      expect(users.first).to eql(name: 'Joe', email: 'joe@doe.org')
     end
 
     it 'raises NoMethodError when relation does not respond to a method' do

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -49,10 +49,19 @@ describe ROM::Relation::Lazy do
       )
     end
 
+    it 'forwards to relation and does not auto-curry when it is not needed' do
+      relation = users.by_name('Jane')
+
+      expect(relation.name).to be(nil)
+      expect(relation.curry_args).to be_empty
+
+      expect(relation).to match_array(rom.relations.users.by_name('Jane'))
+    end
+
     it 'forwards to relation and return lazy when arity is unknown' do
-      relation = users.all
-      expect(relation.name).to eql(:all)
-      expect(relation).to match_array(rom.relations.users.all)
+      relation = users.all(name: 'Jane')
+      expect(relation.name).to be(nil)
+      expect(relation).to match_array(rom.relations.users.by_name('Jane').to_a)
     end
 
     it 'raises NoMethodError when relation does not respond to a method' do

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -41,6 +41,10 @@ describe ROM::Relation::Lazy do
     end
   end
 
+  it_behaves_like 'a relation that returns one tuple' do
+    let(:relation) { users }
+  end
+
   describe '#method_missing' do
     it 'forwards to relation and auto-curries' do
       relation = users.by_name_and_email_sorted('Jane')
@@ -115,7 +119,9 @@ describe ROM::Relation::Lazy do
         { name: 'Jane', title: 'be cool', priority: 2 }
       ])
     end
-  end
 
-  it_behaves_like 'a relation that returns one tuple'
+    it_behaves_like 'a relation that returns one tuple' do
+      let(:relation) { rom.relation(:users) >> proc { |r| r } }
+    end
+  end
 end

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -20,6 +20,10 @@ describe ROM::Relation::Lazy do
         by_name(name).by_email(email)
       end
 
+      def by_name_and_email_sorted(name, email, order_by)
+        by_name_and_email(name, email).order(order_by)
+      end
+
       def all(*args)
         if args.any?
           restrict(*args)
@@ -39,13 +43,18 @@ describe ROM::Relation::Lazy do
 
   describe '#method_missing' do
     it 'forwards to relation and auto-curries' do
-      relation = users.by_name_and_email('Jane')
+      relation = users.by_name_and_email_sorted('Jane')
 
-      expect(relation.name).to eql(:by_name_and_email)
+      expect(relation.name).to eql(:by_name_and_email_sorted)
       expect(relation.curry_args).to eql(['Jane'])
 
-      expect(relation['jane@doe.org']).to match_array(
-        rom.relations.users.by_name_and_email('Jane', 'jane@doe.org')
+      relation = relation['jane@doe.org']
+
+      expect(relation.name).to eql(:by_name_and_email_sorted)
+      expect(relation.curry_args).to eql(['Jane', 'jane@doe.org'])
+
+      expect(relation[:email]).to match_array(
+        rom.relations.users.by_name_and_email_sorted('Jane', 'jane@doe.org', :email)
       )
     end
 

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -26,11 +26,25 @@ describe ROM::Relation::Lazy do
       relation = users.by_name
 
       expect(relation.name).to eql(:by_name)
-      expect(relation['Jane'].call).to eql(rom.relations.users.by_name('Jane'))
+      expect(relation['Jane'].to_a).to eql(rom.relations.users.by_name('Jane').to_a)
     end
 
     it 'returns relation' do
-      expect(users.call).to eql(rom.relations.users)
+      expect(users.call.to_a).to eql(rom.relations.users.to_a)
+    end
+
+    describe 'using mappers' do
+      subject(:users) { rom.relations.users.to_lazy(mappers: mappers) }
+
+      let(:name_list) { proc { |r| r.map { |t| t[:name] } } }
+      let(:upcaser) { proc { |r| r.map(&:upcase) } }
+      let(:mappers) { { name_list: name_list, upcaser: upcaser } }
+
+      it 'sends relation through mappers' do
+        relation = users.map_with(:name_list, :upcaser).by_name('Jane')
+
+        expect(relation.call.to_a).to eql(['JANE'])
+      end
     end
   end
 

--- a/spec/unit/rom/relation/lazy_spec.rb
+++ b/spec/unit/rom/relation/lazy_spec.rb
@@ -81,6 +81,10 @@ describe ROM::Relation::Lazy do
       expect(users.call.to_a).to eql(rom.relations.users.to_a)
     end
 
+    it 'does not allow currying on already curried relation' do
+      expect { users.by_name.by_email }.to raise_error(NoMethodError, /by_email/)
+    end
+
     describe 'using mappers' do
       subject(:users) { rom.relations.users.to_lazy(mappers: mappers) }
 

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe ROM::Relation::Loaded do
   include_context 'users and tasks'
 
-  subject(:users) { ROM::Relation::Loaded.new(rom.relations.users, mappers) }
-
-  let(:mappers) { {} }
+  subject(:users) { ROM::Relation::Loaded.new(rom.relations.users) }
 
   before { setup.relation(:users) }
 
@@ -46,31 +44,6 @@ describe ROM::Relation::Loaded do
       rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
 
       expect { users.one! }.to raise_error(ROM::TupleCountMismatchError)
-    end
-  end
-
-  describe '#as' do
-    let(:mappers) { { email_list: email_mapper, upcase: upcase_mapper } }
-    let(:email_mapper) { proc { |data| data.map { |t| t[:email] } } }
-    let(:upcase_mapper) { proc { |data| data.map(&:upcase) } }
-
-    it 'maps relation using specified mapper' do
-      expect(users.as(:email_list)).to match_array(
-        %w(joe@doe.org jane@doe.org)
-      )
-    end
-
-    it 'allows mappping with multiple mappers' do
-      expect(users.as(:email_list, :upcase)).to match_array(
-        %w(JOE@DOE.ORG JANE@DOE.ORG)
-      )
-    end
-
-    describe 'enumerable chaining' do
-      it 'allows chain enumerable method calls' do
-        result = users.as(:email_list).take(1).map(&:upcase)
-        expect(result).to match_array(%w(JOE@DOE.ORG))
-      end
     end
   end
 end

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -22,28 +22,5 @@ describe ROM::Relation::Loaded do
     end
   end
 
-  describe '#one' do
-    it 'returns first tuple' do
-      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
-      expect(users.one).to eql(name: 'Jane', email: 'jane@doe.org')
-    end
-
-    it 'raises error when there is more than one tuple' do
-      expect { users.one }.to raise_error(ROM::TupleCountMismatchError)
-    end
-  end
-
-  describe '#one!' do
-    it 'returns first tuple' do
-      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
-      expect(users.one!).to eql(name: 'Jane', email: 'jane@doe.org')
-    end
-
-    it 'raises error when there is no tuples' do
-      rom.relations.users.delete(name: 'Jane', email: 'jane@doe.org')
-      rom.relations.users.delete(name: 'Joe', email: 'joe@doe.org')
-
-      expect { users.one! }.to raise_error(ROM::TupleCountMismatchError)
-    end
-  end
+  it_behaves_like 'a relation that returns one tuple'
 end

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -18,7 +18,7 @@ describe ROM::Relation::Loaded do
     end
 
     it 'returns enumerator when block is not provided' do
-      expect(users.each.to_a).to eql(users.relation.to_a)
+      expect(users.each.to_a).to eql(users.collection.to_a)
     end
   end
 

--- a/spec/unit/rom/relation/loaded_spec.rb
+++ b/spec/unit/rom/relation/loaded_spec.rb
@@ -22,5 +22,7 @@ describe ROM::Relation::Loaded do
     end
   end
 
-  it_behaves_like 'a relation that returns one tuple'
+  it_behaves_like 'a relation that returns one tuple' do
+    let(:relation) { users }
+  end
 end


### PR DESCRIPTION
This adds a new API on top of `Relation` called `Relation::Lazy` which provides following features:

* ability to treat relations as callable "function" objects
* ability to compose two relations with left-to-right data pipelining
* ability to pass relations through mappers using the same left-to-right data pipelining
* lazy relations support auto-curry so you can do things like `user_by_id = users.by_id; user_by_id[1]`

This new API is used when you access relations via `rom.relation(:rel_name)`:

``` ruby
users = rom.relation(:users) # returns lazy-users

entity_users = users.map_with(:entities)
 # or
entity_users = users.as(:entites)

# then this works
entity_users.by_id(1)

# or partially-applied
entity_user_by_id = entity_users.by_id
entity_user_by_id[1]
```