### PR TITLE
Add hook methods to linter

### DIFF
--- a/lib/rom/lint/linter.rb
+++ b/lib/rom/lint/linter.rb
@@ -36,7 +36,9 @@ module ROM
       #
       # @api public
       def lint(name)
+        before_lint
         public_send name
+        after_lint
         true # for assertions
       end
 
@@ -58,6 +60,18 @@ module ROM
       # @api private
       def complain(*args)
         raise Failure, *args
+      end
+
+      # Hook method executed before each lint method run
+      #
+      # @api private
+      def before_lint
+      end
+
+      # Hook method executed after each lint method run
+      #
+      # @api private
+      def after_lint
       end
     end
   end

--- a/lib/rom/lint/repository.rb
+++ b/lib/rom/lint/repository.rb
@@ -31,6 +31,7 @@ module ROM
         @identifier = identifier
         @repository = repository
         @uri = uri
+        @repository_instance = setup_repository_instance
       end
 
       # Lint: Ensure that +repository+ setups up its instance
@@ -63,15 +64,30 @@ module ROM
         complain "#{repository_instance} must respond to dataset?"
       end
 
+      private
+
+      # Repository instance
+      #
+      # @api private
+      attr_reader :repository_instance
+
       # Setup repository instance
       #
-      # @api public
-      def repository_instance
+      # @api private
+      def setup_repository_instance
         if uri
           ROM::Repository.setup(identifier, uri)
         else
           ROM::Repository.setup(identifier)
         end
+      end
+
+      # Run Repository#disconnect
+      #
+      # @api private
+      def after_lint
+        super
+        repository_instance.disconnect
       end
     end
   end


### PR DESCRIPTION
We are leaking connections in `rom-sql` during specs.

Linter could automatically call `Repository#disconnect` after each lint method run to avoid this leakage.

WDYT?

/cc @solnic @elskwid 