### PR TITLE
Improve LoadError on missing thread_safe gem

### DIFF
--- a/lib/rom/memory/storage.rb
+++ b/lib/rom/memory/storage.rb
@@ -1,4 +1,9 @@
-require 'thread_safe'
+begin
+  require 'thread_safe'
+rescue LoadError
+  raise LoadError, 'Please install the `thread_safe` gem.'
+end
+
 require 'rom/memory/dataset'
 
 module ROM


### PR DESCRIPTION
I see that the dependency on `thread_safe` was removed in 64f8171601753049d8b3c3b1524db58165c68d0e. It seems to there should be better error handling in the memory adapter now to make this dependency clearer.

Right now, if you try to use the memory adapter without `thread_safe`, this error is raised:

```
/[…]/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': \
cannot load such file -- thread_safe (LoadError)
```

With this patch applied, it looks like this:

```
/[…]/lib/rom/memory/storage.rb:4:in `rescue in <top (required)>': \
Please install the `thread_safe` gem. (LoadError)
```