### PR TITLE
Use Unsound::Control.try for CommandRegistry#try

### DIFF
--- a/lib/rom/commands/abstract.rb
+++ b/lib/rom/commands/abstract.rb
@@ -70,6 +70,15 @@ module ROM
       end
       alias_method :[], :call
 
+      # Allow a command to be used where procs are accepted
+      #
+      # @return [Proc]
+      #
+      # @api public
+      def to_proc
+        lambda { |*args| call(*args) }
+      end
+
       # Curry this command with provided args
       #
       # Curried command can be called without args

--- a/lib/rom/commands/composite.rb
+++ b/lib/rom/commands/composite.rb
@@ -30,6 +30,15 @@ module ROM
       end
       alias_method :[], :call
 
+      # Allow a composite to be used where procs are accepted
+      #
+      # @return [Proc]
+      #
+      # @api public
+      def to_proc
+        lambda { |*args| call(*args) }
+      end
+
       # @api private
       def graph?
         left.is_a?(Graph)

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'equalizer', '~> 0.0', '>= 0.0.9'
   gem.add_runtime_dependency 'rom-support', '~> 0.1', '>= 0.1.0'
   gem.add_runtime_dependency 'rom-mapper', '~> 0.2', '>= 0.2.0'
+  gem.add_runtime_dependency 'unsound', '~> 0.0'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rspec', '~> 3.3'

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -85,8 +85,16 @@ describe 'Commands / Create' do
   it 'returns validation object with errors on failed validation' do
     result = users.try { users.create.call(name: 'Piotr') }
 
-    expect(result.error).to be_instance_of(Test::ValidationError)
-    expect(result.error.message).to eql(":name and :email are required")
+    result.either(
+      ->(error) {
+        expect(error).to be_instance_of(Test::ValidationError)
+        expect(error.message).to eql(":name and :email are required")
+      },
+      ->(_) {
+        raise "Expected validation to have failed"
+      }
+    )
+
     expect(rom.relations.users.count).to be(2)
   end
 

--- a/spec/integration/commands/delete_spec.rb
+++ b/spec/integration/commands/delete_spec.rb
@@ -20,7 +20,7 @@ describe 'Commands / Delete' do
 
     result = users.try { users.delete.call }
 
-    expect(result).to match_array([
+    expect(result.value).to match_array([
       { name: 'Jane', email: 'jane@doe.org' },
       { name: 'Joe', email: 'joe@doe.org' }
     ])
@@ -35,7 +35,7 @@ describe 'Commands / Delete' do
 
     result = users.try { users.delete.by_name('Joe').call }
 
-    expect(result).to match_array([{ name: 'Joe', email: 'joe@doe.org' }])
+    expect(result.value).to match_array([{ name: 'Joe', email: 'joe@doe.org' }])
 
     expect(rom.relation(:users)).to match_array([
       { name: 'Jane', email: 'jane@doe.org' },
@@ -49,7 +49,7 @@ describe 'Commands / Delete' do
 
     result = users.try { users.delete.by_name('Not here').call }
 
-    expect(result).to match_array([])
+    expect(result.value).to match_array([])
   end
 
   it 'returns deleted tuple when result is set to :one' do
@@ -73,7 +73,7 @@ describe 'Commands / Delete' do
 
     result = users.try { users.delete.call }
 
-    expect(result.error).to be_instance_of(ROM::TupleCountMismatchError)
+    expect(result.value).to be_instance_of(ROM::TupleCountMismatchError)
 
     expect(rom.relations.users.to_a).to match_array([
       { name: 'Jane', email: 'jane@doe.org' },

--- a/spec/integration/commands/error_handling_spec.rb
+++ b/spec/integration/commands/error_handling_spec.rb
@@ -12,8 +12,8 @@ describe 'Commands / Error handling'  do
 
   it 'rescues from ROM::CommandError' do
     result = false
-    expect(users.try { raise ROM::CommandError } >-> _test { result = true })
-      .to be_instance_of(ROM::Commands::Result::Failure)
+    expect(users.try { raise ROM::CommandError }.and_then { |_test| result = true })
+      .to be_instance_of(Unsound::Data::Left)
     expect(result).to be(false)
   end
 

--- a/spec/unit/rom/command_registry_spec.rb
+++ b/spec/unit/rom/command_registry_spec.rb
@@ -20,25 +20,25 @@ describe 'ROM::CommandRegistry' do
     it 'returns a success result object on successful execution' do
       result = users.try { users.create.call(name: 'Jane') }
 
-      expect(result).to match_array([{ name: 'Jane' }])
+      expect(result.value).to eq([{ name: 'Jane' }])
     end
 
     it 'returns a success result on successful curried-command execution' do
       result = users.try { users.create.curry(name: 'Jane') }
 
-      expect(result).to match_array([{ name: 'Jane' }])
+      expect(result.value).to eq([{ name: 'Jane' }])
     end
 
     it 'returns a failure result object on failed execution' do
       result = users.try { users.create.call({}) }
 
-      expect(result.value).to be(nil)
+      expect(result.value).to be_kind_of(ROM::CommandError)
     end
 
     it 'returns a failure result on unsuccessful curried-command execution' do
       result = users.try { users.create.curry({}) }
 
-      expect(result.value).to be(nil)
+      expect(result.value).to be_kind_of(ROM::CommandError)
     end
 
     it 'allows checking if a command is available using respond_to?' do


### PR DESCRIPTION
A potential alternative to https://github.com/rom-rb/rom/pull/149/files.

I built a small [gem](https://github.com/pdswan/unsound) around the concept of `Either` and the versions of `try` implemented in `ROM::CommandRegistry` and in https://github.com/txus/kleisli in order to genericize. 

I considered just *using* kliesli (given some of the conceptual overlap I assume it's been evaluated before), but wasn't comfortable with the default global helpers and wasn't a huge fan of separating `Try` from `Either`.

Is this direction at all appealing? Happy to polish off any rough edges and add collaborators if it is.

Cheers!