### PR TITLE
Add support for mapping command results (refs #185)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 group :test do
   gem 'virtus'
+  gem 'anima'
   gem 'minitest'
   gem 'thread_safe'
   gem 'activesupport'

--- a/lib/rom/command_registry.rb
+++ b/lib/rom/command_registry.rb
@@ -7,6 +7,13 @@ module ROM
   class CommandRegistry < Registry
     include Commands
 
+    attr_reader :options
+
+    def initialize(elements, options = {})
+      super(elements)
+      @options = options
+    end
+
     # Try to execute a command in a block
     #
     # @yield [command] Passes command to the block
@@ -30,6 +37,26 @@ module ROM
       end
     rescue CommandError => e
       Result::Failure.new(e)
+    end
+
+    def [](name)
+      command = super
+      mapper = options[:mapper]
+      if mapper
+        command.curry >> mapper
+      else
+        command
+      end
+    end
+
+    # @api private
+    def as(mapper_name)
+      with(mapper: options[:mappers][mapper_name])
+    end
+
+    # @api private
+    def with(new_options)
+      self.class.new(elements, options.merge(new_options))
     end
   end
 end

--- a/lib/rom/commands/abstract.rb
+++ b/lib/rom/commands/abstract.rb
@@ -57,6 +57,7 @@ module ROM
           tuples
         end
       end
+      alias_method :[], :call
 
       # Curry this command with provided args
       #

--- a/lib/rom/commands/composite.rb
+++ b/lib/rom/commands/composite.rb
@@ -29,8 +29,17 @@ module ROM
       #
       # @api public
       def call(*args)
-        right.call(left.call(*args))
+        if result == :one
+          if right.is_a?(Command)
+            right.call([left.call(*args)].first)
+          else
+            right.call([left.call(*args)]).first
+          end
+        else
+          right.call(left.call(*args))
+        end
       end
+      alias_method :[], :call
 
       # Compose another composite command from self and other
       #
@@ -41,6 +50,11 @@ module ROM
       # @api public
       def >>(other)
         self.class.new(self, other)
+      end
+
+      # @api private
+      def result
+        left.result
       end
     end
   end

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -103,7 +103,11 @@ module ROM
     #
     # @api public
     def command(name)
-      commands[name]
+      if mappers.elements.key?(name)
+        commands[name].with(mappers: mappers[name])
+      else
+        commands[name]
+      end
     end
   end
 end

--- a/lib/rom/env.rb
+++ b/lib/rom/env.rb
@@ -63,7 +63,7 @@ module ROM
           relations[name]
         end
 
-      if mappers.elements.key?(name)
+      if mappers.key?(name)
         relation.to_lazy(mappers: mappers[name])
       else
         relation.to_lazy
@@ -99,11 +99,15 @@ module ROM
     #
     # @example
     #
+    #   # plain command returning tuples
     #   rom.command(:users).create
+    #
+    #   # allow auto-mapping using registered mappers
+    #   rom.command(:users).as(:entity)
     #
     # @api public
     def command(name)
-      if mappers.elements.key?(name)
+      if mappers.key?(name)
         commands[name].with(mappers: mappers[name])
       else
         commands[name]

--- a/lib/rom/support/registry.rb
+++ b/lib/rom/support/registry.rb
@@ -33,7 +33,11 @@ module ROM
     private
 
     def method_missing(name, *)
-      elements.fetch(name) { super }
+      if elements.key?(name)
+        self[name]
+      else
+        super
+      end
     end
   end
 end

--- a/lib/rom/support/registry.rb
+++ b/lib/rom/support/registry.rb
@@ -12,14 +12,18 @@ module ROM
 
     attr_reader :elements, :name
 
-    def initialize(elements = {})
+    def initialize(elements = {}, name = self.class.name)
       @elements = elements
-      @name = self.class.name
+      @name = name
     end
 
     def each(&block)
       return to_enum unless block
       elements.each { |element| yield(element) }
+    end
+
+    def key?(name)
+      elements.key?(name)
     end
 
     def [](key)
@@ -33,11 +37,7 @@ module ROM
     private
 
     def method_missing(name, *)
-      if elements.key?(name)
-        self[name]
-      else
-        super
-      end
+      elements.fetch(name) { super }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ if RUBY_ENGINE == "rbx"
 end
 
 require 'rom'
+require 'anima'
 
 begin
   require 'byebug'


### PR DESCRIPTION
Basically making this work:

``` ruby
rom.command(:users).as(:entity).create[name: 'Jane']
```