### PR TITLE
Fix CommandRegistry#respond_to?

### DIFF
--- a/lib/rom/command_registry.rb
+++ b/lib/rom/command_registry.rb
@@ -109,6 +109,13 @@ module ROM
 
     private
 
+    # Allow checking if a certain command is available using dot-notation
+    #
+    # @api private
+    def respond_to_missing?(name, include_private = false)
+      registry.key?(name) || super
+    end
+
     # Allow retrieving commands using dot-notation
     #
     # @api private

--- a/spec/unit/rom/command_registry_spec.rb
+++ b/spec/unit/rom/command_registry_spec.rb
@@ -40,5 +40,9 @@ describe 'ROM::CommandRegistry' do
 
       expect(result.value).to be(nil)
     end
+
+    it 'allows checking if a command is available using respond_to?' do
+      expect(users).to respond_to(:create)
+    end
   end
 end


### PR DESCRIPTION
The `0.6.1` release has broken the `respond_to?` method in the `CommandRegistry`.
This fixes it.