### PR TITLE
Use #eq instead of #match_array to test memory adapter #order

### DIFF
--- a/spec/unit/rom/memory/dataset_spec.rb
+++ b/spec/unit/rom/memory/dataset_spec.rb
@@ -44,7 +44,7 @@ describe ROM::Memory::Dataset do
 
   describe '#order' do
     it 'sorts data using provided attribute names' do
-      expect(dataset.order(:name)).to match_array([
+      expect(dataset.order(:name).to_a).to eq([
         { name: 'Jade', email: 'jade@doe.org', age: 11 },
         { name: 'Jane', email: 'jane@doe.org', age: 10 },
         { name: 'Joe', email: 'joe@doe.org', age: 12 }


### PR DESCRIPTION
The original test wasn't asserting that sorted values were being returned in any particular order. This happens because `#match_array` is simply checking the values in the array, not the specific ordering of the data structure (this is probably why `#match_array` has been aliased to the more meaningful `#contain_exactly` in more recent versions of Rspec).

You can verify this by running the following, which should fail, but passes:

```ruby
  describe '#order' do
    it 'sorts data using provided attribute names' do
      expect(dataset.order(:name)).to match_array([
        { name: 'Jade', email: 'jade@doe.org', age: 11 },
        { name: 'Jane', email: 'jane@doe.org', age: 10 },
        { name: 'Joe', email: 'joe@doe.org', age: 12 }
      ])
    end

    it 'ignores order of array values in comparison' do
      expect(dataset.order(:name)).to match_array([
        { name: 'Jane', email: 'jane@doe.org', age: 10 },
        { name: 'Jade', email: 'jade@doe.org', age: 11 },
        { name: 'Joe', email: 'joe@doe.org', age: 12 }
      ])
    end
  end
```