### PR TITLE
Allow ordering relations with empty fields

### DIFF
--- a/lib/rom/memory/dataset.rb
+++ b/lib/rom/memory/dataset.rb
@@ -57,9 +57,8 @@ module ROM
         options = names.last.is_a?(Hash) ? names.pop : {}
         place   = options[:nils_first] ? -1 : 1
         compare = ->(a, b) {
-          return  place if a.nil?
-          return -place if b.nil?
-          a <=> b
+          return a <=> b unless a.nil? ^ b.nil?
+          a.nil? ? place : -place
         }
 
         sort do |a, b|

--- a/lib/rom/memory/dataset.rb
+++ b/lib/rom/memory/dataset.rb
@@ -50,11 +50,12 @@ module ROM
       #   Names of fields to order tuples by
       #
       # @option [Boolean] :nils_first (false)
-      #   Whether nil values should be placed before other ones
+      #   Whether `nil` values should be placed before others
       #
       # @api public
-      def order(*names, nils_first: false)
-        place   = nils_first ? -1 : 1
+      def order(*names)
+        options = names.last.is_a?(Hash) ? names.pop : {}
+        place   = options[:nils_first] ? -1 : 1
         compare = ->(a, b) {
           return  place if a.nil?
           return -place if b.nil?

--- a/lib/rom/memory/dataset.rb
+++ b/lib/rom/memory/dataset.rb
@@ -46,9 +46,24 @@ module ROM
 
       # Sort a dataset
       #
+      # @param [Array<Symbol>] names
+      #   Names of fields to order tuples by
+      #
+      # @option [Boolean] :nils_first (false)
+      #   Whether nil values should be placed before other ones
+      #
       # @api public
-      def order(*names)
-        sort_by { |tuple| tuple.values_at(*names) }
+      def order(*names, nils_first: false)
+        place   = nils_first ? -1 : 1
+        compare = ->(a, b) {
+          return  place if a.nil?
+          return -place if b.nil?
+          a <=> b
+        }
+
+        sort do |a, b|
+          names.map { |n| compare.call a[n], b[n] }.detect { |r| r != 0 } || 0
+        end
       end
 
       # Insert tuple into a dataset

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -12,7 +12,7 @@ describe ROM::Memory::Relation do
       { name: 'Jane', email: 'jane@doe.org', age: 10 },
       { name: 'Jade', email: 'jade@doe.org', age: 11 },
       { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
-      { name: 'Jack',                        age: 9  },
+      { name: 'Jack',                        age: 11 },
       { name: 'Jill', email: 'jill@doe.org'          },
       { name: 'John'                                 }
     ])
@@ -33,7 +33,7 @@ describe ROM::Memory::Relation do
         { name: 'Jane', age: 10 },
         { name: 'Jade', age: 11 },
         { name: 'Joe',  age: 12 },
-        { name: 'Jack', age: 9  },
+        { name: 'Jack', age: 11 },
         { name: 'Jill'          },
         { name: 'John'          }
       ])
@@ -52,42 +52,32 @@ describe ROM::Memory::Relation do
     it 'restricts data using block' do
       expect(relation.restrict { |tuple| tuple[:age].to_i > 10 }).to match_array([
         { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
+        { name: 'Jack',                        age: 11 }
       ])
     end
   end
 
   describe '#order' do
     it 'sorts data using provided attribute names' do
-      expect(relation.order(:email).to_a).to eq([
-        { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Jill', email: 'jill@doe.org'          },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
-        { name: 'Jack',                        age: 9  },
+      expect(relation.order(:age, :email).to_a).to eq([
+        { name: 'Jane', age: 10, email: 'jane@doe.org' },
+        { name: 'Jade', age: 11, email: 'jade@doe.org' },
+        { name: 'Jack', age: 11                        },
+        { name: 'Joe',  age: 12, email: 'joe@doe.org'  },
+        { name: 'Jill',          email: 'jill@doe.org' },
         { name: 'John'                                 }
       ])
     end
 
     it 'places nil before other values when required' do
-      expect(relation.order(:email, nils_first: true).to_a).to eq([
-        { name: 'Jack',                        age: 9  },
+      expect(relation.order(:age, :email, nils_first: true).to_a).to eq([
         { name: 'John'                                 },
-        { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Jill', email: 'jill@doe.org'          },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
-      ])
-    end
-
-    it 'sorts tuples by multiple fields' do
-      expect(relation.order(:age, :email).to_a).to eq([
-        { name: 'Jack',                        age: 9  },
-        { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
-        { name: 'Jill', email: 'jill@doe.org'          },
-        { name: 'John'                                 }
+        { name: 'Jill',          email: 'jill@doe.org' },
+        { name: 'Jane', age: 10, email: 'jane@doe.org' },
+        { name: 'Jack', age: 11                        },
+        { name: 'Jade', age: 11, email: 'jade@doe.org' },
+        { name: 'Joe',  age: 12, email: 'joe@doe.org'  }
       ])
     end
   end

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -13,6 +13,7 @@ describe ROM::Memory::Relation do
       { name: 'Jade', email: 'jade@doe.org', age: 11 },
       { name: 'Joe',  email: 'joe@doe.org', age: 12 },
       { name: 'Jack', email: nil, age: 9 },
+      { name: 'Jill', email: 'jill@doe.org' }
     ])
   end
 
@@ -31,7 +32,8 @@ describe ROM::Memory::Relation do
         { name: 'Jane', age: 10 },
         { name: 'Jade', age: 11 },
         { name: 'Joe', age: 12 },
-        { name: 'Jack', age: 9 }
+        { name: 'Jack', age: 9 },
+        { name: 'Jill' }
       ])
     end
   end
@@ -46,7 +48,7 @@ describe ROM::Memory::Relation do
     end
 
     it 'restricts data using block' do
-      expect(relation.restrict { |tuple| tuple[:age] > 10 }).to match_array([
+      expect(relation.restrict { |tuple| tuple[:age].to_i > 10 }).to match_array([
         { name: 'Jade', email: 'jade@doe.org', age: 11 },
         { name: 'Joe', email: 'joe@doe.org', age: 12 }
       ])
@@ -56,19 +58,31 @@ describe ROM::Memory::Relation do
   describe '#order' do
     it 'sorts data using provided attribute names' do
       expect(relation.order(:email).to_a).to eq([
-        { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
-        { name: 'Jack', email: nil, age: 9 }
+        { name: 'Jade', email: 'jade@doe.org', age: 11  },
+        { name: 'Jane', email: 'jane@doe.org', age: 10  },
+        { name: 'Jill', email: 'jill@doe.org'           },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12  },
+        { name: 'Jack', email: nil,            age: 9   }
       ])
     end
 
     it 'places nil before other values when required' do
       expect(relation.order(:email, nils_first: true).to_a).to eq([
-        { name: 'Jack', email: nil, age: 9 },
-        { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
+        { name: 'Jack', email: nil,            age: 9   },
+        { name: 'Jade', email: 'jade@doe.org', age: 11  },
+        { name: 'Jane', email: 'jane@doe.org', age: 10  },
+        { name: 'Jill', email: 'jill@doe.org'           },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12  }
+      ])
+    end
+
+    it 'sorts tuples by multiple fields' do
+      expect(relation.order(:age, :email).to_a).to eq([
+        { name: 'Jack', email: nil,            age: 9   },
+        { name: 'Jane', email: 'jane@doe.org', age: 10  },
+        { name: 'Jade', email: 'jade@doe.org', age: 11  },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12  },
+        { name: 'Jill', email: 'jill@doe.org' }
       ])
     end
   end

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -11,7 +11,8 @@ describe ROM::Memory::Relation do
     ROM::Memory::Dataset.new([
       { name: 'Jane', email: 'jane@doe.org', age: 10 },
       { name: 'Jade', email: 'jade@doe.org', age: 11 },
-      { name: 'Joe', email: 'joe@doe.org', age: 12 }
+      { name: 'Joe',  email: 'joe@doe.org', age: 12 },
+      { name: 'Jack', email: nil, age: 9 },
     ])
   end
 
@@ -29,7 +30,8 @@ describe ROM::Memory::Relation do
       expect(relation.project(:name, :age)).to match_array([
         { name: 'Jane', age: 10 },
         { name: 'Jade', age: 11 },
-        { name: 'Joe', age: 12 }
+        { name: 'Joe', age: 12 },
+        { name: 'Jack', age: 9 }
       ])
     end
   end
@@ -53,10 +55,20 @@ describe ROM::Memory::Relation do
 
   describe '#order' do
     it 'sorts data using provided attribute names' do
-      expect(relation.order(:name).to_a).to eq([
+      expect(relation.order(:email).to_a).to eq([
         { name: 'Jade', email: 'jade@doe.org', age: 11 },
         { name: 'Jane', email: 'jane@doe.org', age: 10 },
-        { name: 'Joe', email: 'joe@doe.org', age: 12 }
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
+        { name: 'Jack', email: nil, age: 9 }
+      ])
+    end
+
+    it 'places nil before other values when required' do
+      expect(relation.order(:email, nils_first: true).to_a).to eq([
+        { name: 'Jack', email: nil, age: 9 },
+        { name: 'Jade', email: 'jade@doe.org', age: 11 },
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
       ])
     end
   end

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -11,9 +11,10 @@ describe ROM::Memory::Relation do
     ROM::Memory::Dataset.new([
       { name: 'Jane', email: 'jane@doe.org', age: 10 },
       { name: 'Jade', email: 'jade@doe.org', age: 11 },
-      { name: 'Joe',  email: 'joe@doe.org', age: 12 },
-      { name: 'Jack', email: nil, age: 9 },
-      { name: 'Jill', email: 'jill@doe.org' }
+      { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
+      { name: 'Jack',                        age: 9  },
+      { name: 'Jill', email: 'jill@doe.org'          },
+      { name: 'John'                                 }
     ])
   end
 
@@ -31,9 +32,10 @@ describe ROM::Memory::Relation do
       expect(relation.project(:name, :age)).to match_array([
         { name: 'Jane', age: 10 },
         { name: 'Jade', age: 11 },
-        { name: 'Joe', age: 12 },
-        { name: 'Jack', age: 9 },
-        { name: 'Jill' }
+        { name: 'Joe',  age: 12 },
+        { name: 'Jack', age: 9  },
+        { name: 'Jill'          },
+        { name: 'John'          }
       ])
     end
   end
@@ -50,7 +52,7 @@ describe ROM::Memory::Relation do
     it 'restricts data using block' do
       expect(relation.restrict { |tuple| tuple[:age].to_i > 10 }).to match_array([
         { name: 'Jade', email: 'jade@doe.org', age: 11 },
-        { name: 'Joe', email: 'joe@doe.org', age: 12 }
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
       ])
     end
   end
@@ -58,31 +60,34 @@ describe ROM::Memory::Relation do
   describe '#order' do
     it 'sorts data using provided attribute names' do
       expect(relation.order(:email).to_a).to eq([
-        { name: 'Jade', email: 'jade@doe.org', age: 11  },
-        { name: 'Jane', email: 'jane@doe.org', age: 10  },
-        { name: 'Jill', email: 'jill@doe.org'           },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12  },
-        { name: 'Jack', email: nil,            age: 9   }
+        { name: 'Jade', email: 'jade@doe.org', age: 11 },
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Jill', email: 'jill@doe.org'          },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
+        { name: 'Jack',                        age: 9  },
+        { name: 'John'                                 }
       ])
     end
 
     it 'places nil before other values when required' do
       expect(relation.order(:email, nils_first: true).to_a).to eq([
-        { name: 'Jack', email: nil,            age: 9   },
-        { name: 'Jade', email: 'jade@doe.org', age: 11  },
-        { name: 'Jane', email: 'jane@doe.org', age: 10  },
-        { name: 'Jill', email: 'jill@doe.org'           },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12  }
+        { name: 'Jack',                        age: 9  },
+        { name: 'John'                                 },
+        { name: 'Jade', email: 'jade@doe.org', age: 11 },
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Jill', email: 'jill@doe.org'          },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 }
       ])
     end
 
     it 'sorts tuples by multiple fields' do
       expect(relation.order(:age, :email).to_a).to eq([
-        { name: 'Jack', email: nil,            age: 9   },
-        { name: 'Jane', email: 'jane@doe.org', age: 10  },
-        { name: 'Jade', email: 'jade@doe.org', age: 11  },
-        { name: 'Joe',  email: 'joe@doe.org',  age: 12  },
-        { name: 'Jill', email: 'jill@doe.org' }
+        { name: 'Jack',                        age: 9  },
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Jade', email: 'jade@doe.org', age: 11 },
+        { name: 'Joe',  email: 'joe@doe.org',  age: 12 },
+        { name: 'Jill', email: 'jill@doe.org'          },
+        { name: 'John'                                 }
       ])
     end
   end


### PR DESCRIPTION
Concerning #202 

By default `nil` values placed at the end, as @cflipse supposed.
Also added the option `nils_first: true` that places them at the beginning of the list.
