### PR TITLE
Allow to define block in mapper attribute

### DIFF
--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -30,17 +30,22 @@ module ROM
         @reject_keys = options.fetch(:reject_keys)
       end
 
-      # Define a mapping attribute with its options
+      # Define a mapping attribute with its options and/or block
       #
       # @example
       #   dsl = AttributeDSL.new([])
       #
       #   dsl.attribute(:name)
       #   dsl.attribute(:email, from: 'user_email')
+      #   dsl.attribute(:name do 'John' end)
+      #   dsl.attribute(:name do |t| t.upcase end)
       #
       # @api public
-      def attribute(name, options = EMPTY_HASH)
+      def attribute(name, options = EMPTY_HASH, &block)
         with_attr_options(name, options) do |attr_options|
+          raise ArgumentError,
+            "can't specify type and block at the same time" if options[:type] && block
+          attr_options.merge!(coercer: block) if block
           add_attribute(name, attr_options)
         end
       end
@@ -192,7 +197,7 @@ module ROM
           type: options.fetch(:type, :array),
           keys: options.fetch(:on),
           combine: true,
-          header: dsl.header,
+          header: dsl.header
         }
 
         add_attribute(name, attr_opts)

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -91,13 +91,17 @@ module ROM
 
       # Visit plain attribute
       #
+      # It will call block transformation if its used
+      #
       # If it's a typed attribute a coercion transformation is added
       #
       # @param [Header::Attribute] attribute
       #
       # @api private
       def visit_attribute(attribute)
-        if attribute.typed?
+        if attribute.meta[:coercer]
+          t(:map_value, attribute.name, attribute.meta[:coercer])
+        elsif attribute.typed?
           t(:map_value, attribute.name, t(:"to_#{attribute.type}"))
         end
       end

--- a/spec/integration/mappers/overwrite_attributes_value_spec.rb
+++ b/spec/integration/mappers/overwrite_attributes_value_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'rom/memory'
+
+describe 'Mappers / Attributes value' do
+  let(:setup) { ROM.setup(:memory) }
+
+  before do
+    setup.relation(:users)
+  end
+
+  it 'allows to manipulate attribute value' do
+    class Test::UserMapper < ROM::Mapper
+      relation :users
+
+      attribute :id
+      attribute :name, from: :first_name do
+        'John'
+      end
+      attribute :age do
+        9+9
+      end
+      attribute :weight do |t|
+        t+15
+      end
+    end
+
+    rom = setup.finalize
+
+    rom.relations.users << {
+      id: 123,
+      first_name: 'Jane',
+      weight: 75
+    }
+
+    jane = rom.relation(:users).as(:users).first
+
+    expect(jane).to eql(id: 123, name: 'John', weight: 90, age: 18)
+  end
+
+  it 'raise ArgumentError if type and block used at the same time' do
+    expect {
+      class Test::UserMapper < ROM::Mapper
+        relation :users
+
+        attribute :name, type: :string do
+          'John'
+        end
+      end
+    }.to raise_error(ArgumentError, "can't specify type and block at the same time")
+  end
+end


### PR DESCRIPTION
In block you can overwrite attribute value, or modify it:

```ruby
attribute :foo do 'John' end
attribute :foo do |t| t.upcase end
attribute :foo, from: :bar do 1+2 end
```