### PR TITLE
Allow grouping attributes with the name of existing field:

### DIFF
--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -265,7 +265,7 @@ module ROM
         dsl = new(options, &block)
         header = dsl.header
         add_attribute(name, options.update(header: header))
-        header.each { |attr| exclude(attr.key) }
+        header.each { |attr| exclude(attr.key) unless name == attr.key }
       end
 
       # Define attributes from the `name => attributes` hash syntax
@@ -277,7 +277,7 @@ module ROM
         hash.each do |name, header|
           with_attr_options(name, options) do |attr_options|
             add_attribute(name, attr_options.update(header: header.zip))
-            header.each { |attr| exclude(attr) }
+            header.each { |attr| exclude(attr) unless name == attr }
           end
         end
       end

--- a/spec/integration/mappers/group_spec.rb
+++ b/spec/integration/mappers/group_spec.rb
@@ -158,5 +158,27 @@ describe 'Mapper definition DSL' do
         ])
       )
     end
+
+    it 'allows defining grouped attributes with the same name as their keys' do
+      setup.mappers do
+        define(:with_tasks, parent: :users) do
+
+          attribute :name
+          attribute :email
+
+          group title: [:title, :priority]
+        end
+      end
+
+      rom = setup.finalize
+
+      jane = rom.relation(:users).with_tasks.map_with(:with_tasks).to_a.last
+
+      expect(jane).to eql(
+        name: 'Jane',
+        email: 'jane@doe.org',
+        title: [{ title: 'be cool', priority: 2 }]
+      )
+    end
   end
 end


### PR DESCRIPTION
This is a fix for the case a group has just the same name as one of its fields.

```ruby
class UsersMapper < ROM::Mapper
  group agenda: [:agenda]
end
```

Badly needs for somebody to review it!