### PR TITLE
Allow to call `#restrict` with array as value

### DIFF
--- a/lib/rom/memory/dataset.rb
+++ b/lib/rom/memory/dataset.rb
@@ -31,7 +31,15 @@ module ROM
       # @api public
       def restrict(criteria = nil)
         if criteria
-          find_all { |tuple| criteria.all? { |k, v| tuple[k].eql?(v) } }
+          find_all do |tuple|
+            criteria.all? do |k, v|
+              if v.is_a?(Array)
+                v.include?(tuple[k])
+              else
+                tuple[k].eql?(v)
+              end
+            end
+          end
         else
           find_all { |tuple| yield(tuple) }
         end

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -49,6 +49,13 @@ describe ROM::Memory::Relation do
         { name: 'Joe', email: 'joe@doe.org', age: 12 }
       ])
     end
+
+    it 'allows to use array as value' do
+      expect(relation.restrict(age: [10, 11])).to match_array([
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Jade', email: 'jade@doe.org', age: 11 }
+      ])
+    end
   end
 
   describe '#order' do


### PR DESCRIPTION
```ruby
relation.restrict(id: [1,2,3,4])
```