### PR TITLE
Extend `#restrict`

### DIFF
--- a/lib/rom/memory/dataset.rb
+++ b/lib/rom/memory/dataset.rb
@@ -30,18 +30,15 @@ module ROM
       #
       # @api public
       def restrict(criteria = nil)
-        if criteria
-          find_all do |tuple|
-            criteria.all? do |k, v|
-              if v.is_a?(Array)
-                v.include?(tuple[k])
-              else
-                tuple[k].eql?(v)
-              end
+        return find_all { |tuple| yield(tuple) } unless criteria
+        find_all do |tuple|
+          criteria.all? do |k, v|
+            case v
+            when Array then v.include?(tuple[k])
+            when Regexp then tuple[k].match(v)
+            else tuple[k].eql?(v)
             end
           end
-        else
-          find_all { |tuple| yield(tuple) }
         end
       end
 

--- a/spec/unit/rom/memory/relation_spec.rb
+++ b/spec/unit/rom/memory/relation_spec.rb
@@ -50,8 +50,15 @@ describe ROM::Memory::Relation do
       ])
     end
 
-    it 'allows to use array as value' do
+    it 'allows to use array as a value' do
       expect(relation.restrict(age: [10, 11])).to match_array([
+        { name: 'Jane', email: 'jane@doe.org', age: 10 },
+        { name: 'Jade', email: 'jade@doe.org', age: 11 }
+      ])
+    end
+
+    it 'allows to use regexp as a value' do
+      expect(relation.restrict(name: /\w{4}/)).to match_array([
         { name: 'Jane', email: 'jane@doe.org', age: 10 },
         { name: 'Jade', email: 'jade@doe.org', age: 11 }
       ])


### PR DESCRIPTION
Allow restrict to be called will regexp.

```ruby
relation.restrict(name: /\w{4}/)
```