### PR TITLE
Add 'fold' feature to AttributeDSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 
 * Support for passing a block for custom coercion to `attribute` (gotar)
+* `fold` mapping operation which groups keys from input tuples to array
+  of values from the first of listed keys (nepalez)
 * Adapter `Relation` and command classes can specify `adapter` identifier
   which allows using adapter-specific plugins w/o the need to specify adapter
   when calling `use` (solnic)

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'transproc', github: 'solnic/transproc'
+
 group :console do
   gem 'pry'
   gem 'pg', platforms: [:mri]

--- a/lib/rom/header/attribute.rb
+++ b/lib/rom/header/attribute.rb
@@ -47,6 +47,8 @@ module ROM
           Unwrap
         elsif type.equal?(:hash)
           meta[:wrap] ? Wrap : Hash
+        elsif meta[:fold]
+          Group
         elsif type.equal?(:array)
           meta[:group] ? Group : Array
         else

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -171,6 +171,26 @@ module ROM
         end
       end
 
+      # Define an embedded hash attribute that requires "fold" transformation
+      #
+      # Typically this is used in sql context to fold single joined field
+      # to the array of values.
+      #
+      # @example
+      #   dsl = AttributeDSL.new([])
+      #
+      #   dsl.fold(tags: [:name])
+      #
+      # @see AttributeDSL#embedded
+      #
+      # @api public
+      def fold(*args)
+        with_name_or_options(*args) do |name, *|
+          fold_options = { type: :array, fold: true }
+          dsl(name, fold_options)
+        end
+      end
+
       # Define an embedded combined attribute that requires "combine" transformation
       #
       # Typically this can be used to process results of eager-loading

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -194,6 +194,7 @@ module ROM
           name = attribute.name
           header = attribute.header
           keys = attribute.tuple_keys
+          fold = attribute.meta[:fold]
 
           other = header.groups
 
@@ -201,9 +202,13 @@ module ROM
             ops << t(:group, name, keys)
             ops << t(:map_array, t(:map_value, name, FILTER_EMPTY))
 
-            ops << other.map { |attr|
-              t(:map_array, t(:map_value, name, visit_group(attr, true)))
-            }
+            if fold
+              ops << t(:map_array, t(:fold, name, keys.first))
+            else
+              ops << other.map { |attr|
+                t(:map_array, t(:map_value, name, visit_group(attr, true)))
+              }
+            end
           end
         else
           visit_array(attribute)

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'transproc', '~> 0.2', '>= 0.2.1'
+  gem.add_runtime_dependency 'transproc', '~> 0.2', '>= 0.2.2'
   gem.add_runtime_dependency 'equalizer', '~> 0.0', '>= 0.0.9'
 
   gem.add_development_dependency 'rake', '~> 10.3'

--- a/spec/integration/mappers/fold_spec.rb
+++ b/spec/integration/mappers/fold_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'Mapper definition DSL' do
+  include_context 'users and tasks'
+
+  let(:header) { mapper.header }
+
+  describe 'folded relation mapper' do
+    before do
+      setup.relation(:tasks) do
+        def with_users
+          join(users)
+        end
+      end
+
+      setup.relation(:users) do
+        def with_tasks
+          join(tasks)
+        end
+      end
+    end
+
+    let(:rom) { setup.finalize }
+    let(:actual) do
+      rom.relation(:users).with_tasks.map_with(:users).to_a
+    end
+
+    it 'groups all attributes and folds the first key' do
+      setup.mappers do
+        define(:users) do
+          fold tasks: [:title, :priority]
+        end
+      end
+
+      expect(actual).to eql [
+        { name: 'Joe', email: 'joe@doe.org', tasks: ['be nice', 'sleep well'] },
+        { name: 'Jane', email: 'jane@doe.org', tasks: ['be cool'] }
+      ]
+    end
+
+    it 'is sensitive to the order of keys' do
+      setup.mappers do
+        define(:users) do
+          fold priorities: [:priority, :title]
+        end
+      end
+
+      expect(actual).to eql [
+        { name: 'Joe', email: 'joe@doe.org', priorities: [1, 2] },
+        { name: 'Jane', email: 'jane@doe.org', priorities: [2] }
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Addressing #199, #200 and #220

The `fold` is a kind of group that provides array of values, extracted
from a first attribute of grouped tuples:

```ruby
  users.with_tasks.to_a
  # [{ name: "Joe", title: "be nice" }, { name: "Joe", title: "sleep well" }]

  class UsersMapper < ROM::Mapper
    attribute :name
    fold tasks: [:task]
  end

  users.as(:users).to_a
  # => [{ name: "Joe", tasks: ["be nice", "sleep well"] }]
```
Unlike `group` the `fold` doesn't support block syntax and nesting.