### PR TITLE
Clean up some Rubocop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Style/Lambda:
 Style/MultilineBlockChain:
   Enabled: false
 
+# Multiline operation chains are indented
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 # Result::Success and Result::Failure use > for callbacks
 Style/OpMethod:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   Exclude:
     - tmp/**/*
+    - vendor/**/*
 
 Style/BlockDelimiters:
   EnforcedStyle: semantic
@@ -35,10 +36,6 @@ Style/AlignParameters:
 Style/AsciiComments:
   Enabled: false
 
-# Allow using braces for value-returning blocks
-Style/Blocks:
-  Enabled: false
-
 # Documentation checked by Inch CI
 Style/Documentation:
   Enabled: false
@@ -59,10 +56,6 @@ Style/MultilineBlockChain:
 Style/OpMethod:
   Exclude:
     - lib/rom/command_registry.rb
-
-# Even a single escaped slash can be confusing
-Style/RegexpLiteral:
-  MaxSlashes: 0
 
 # Don’t introduce semantic fail/raise distinction
 Style/SignalException:

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -39,7 +39,7 @@ end
 
 def users_with_combined_tasks
   @users_with_combined_tasks ||= rom.relation(:users).as(:user_with_combined_tasks)
-    .combine(rom.relation(:tasks).for_users)
+                                 .combine(rom.relation(:tasks).for_users)
 end
 
 def hr

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -39,7 +39,7 @@ end
 
 def users_with_combined_tasks
   @users_with_combined_tasks ||= rom.relation(:users).as(:user_with_combined_tasks)
-                                 .combine(rom.relation(:tasks).for_users)
+    .combine(rom.relation(:tasks).for_users)
 end
 
 def hr

--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -84,7 +84,7 @@ module ROM
     # @option options [Symbol] :adapter (:default) first adapter to check for plugin
     #
     # @api public
-    def self.use(plugin, options = {})
+    def self.use(plugin, _options = {})
       ROM.plugin_registry.commands.fetch(plugin, adapter).apply_to(self)
     end
 

--- a/lib/rom/pipeline.rb
+++ b/lib/rom/pipeline.rb
@@ -77,7 +77,8 @@ module ROM
 
       # @api private
       def initialize(left, right)
-        @left, @right = left, right
+        @left = left
+        @right = right
       end
 
       # Compose this composite with another object

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -128,7 +128,7 @@ module ROM
       # @option options [Symbol] :adapter (:default) first adapter to check for plugin
       #
       # @api public
-      def use(plugin, options = {})
+      def use(plugin, _options = {})
         ROM.plugin_registry.relations.fetch(plugin, adapter).apply_to(self)
       end
 

--- a/lib/rom/support/deprecations.rb
+++ b/lib/rom/support/deprecations.rb
@@ -8,7 +8,7 @@ module ROM
             #{self.class}##{old_name} is deprecated and will be removed in 1.0.0.
             Please use #{self.class}##{new_name} instead.
             #{msg}
-            #{caller.detect { |l| !l.include?('lib/rom')}}
+            #{caller.detect { |l| !l.include?('lib/rom') }}
           MSG
           __send__(new_name, *args, &block)
         end

--- a/spec/integration/mappers/group_spec.rb
+++ b/spec/integration/mappers/group_spec.rb
@@ -162,7 +162,6 @@ describe 'Mapper definition DSL' do
     it 'allows defining grouped attributes with the same name as their keys' do
       setup.mappers do
         define(:with_tasks, parent: :users) do
-
           attribute :name
           attribute :email
 

--- a/spec/integration/multi_repo_spec.rb
+++ b/spec/integration/multi_repo_spec.rb
@@ -36,8 +36,8 @@ describe 'Using in-memory repositories for cross-repo access' do
     repositories[:right][:tasks] << { user_id: 2, title: 'Have fun' }
 
     user_and_tasks = rom.relation(:users_and_tasks)
-                     .by_user('Jane')
-                     .as(:users_and_tasks)
+      .by_user('Jane')
+      .as(:users_and_tasks)
 
     expect(user_and_tasks).to match_array([
       { user_id: 2, name: 'Jane', tasks: [{ title: 'Have fun' }] }

--- a/spec/shared/materializable.rb
+++ b/spec/shared/materializable.rb
@@ -1,10 +1,12 @@
 shared_examples_for 'materializable relation' do
   describe '#each' do
     it 'yields objects' do
-      count = relation.to_a.count
+      count = relation.to_a.size
       result = []
 
-      relation.each { |object| result << object }
+      relation.each do |object|
+        result << object
+      end
 
       expect(result.count).to eql(count)
     end

--- a/spec/unit/rom/mapper_spec.rb
+++ b/spec/unit/rom/mapper_spec.rb
@@ -30,7 +30,10 @@ describe ROM::Mapper do
   describe '.registry' do
     it 'builds mapper class registry for base and virtual relations' do
       users = Class.new(ROM::Mapper) { relation(:users) }
-      entity = Class.new(ROM::Mapper) { relation(:users); register_as(:entity) }
+      entity = Class.new(ROM::Mapper) do
+        relation(:users)
+        register_as(:entity)
+      end
       active = Class.new(users) { relation(:active) }
       admins = Class.new(users) { relation(:admins) }
       custom = Class.new(users) { register_as(:custom) }

--- a/spec/unit/rom/relation/lazy/combine_spec.rb
+++ b/spec/unit/rom/relation/lazy/combine_spec.rb
@@ -101,7 +101,7 @@ describe ROM::Relation::Lazy, '#combine' do
     ]
 
     user_with_tasks_and_tags = users.by_name('Jane')
-                               .combine(tasks.for_users, tags.for_users)
+      .combine(tasks.for_users, tags.for_users)
 
     result = user_with_tasks_and_tags >> map_user_with_tasks_and_tags
 
@@ -121,7 +121,7 @@ describe ROM::Relation::Lazy, '#combine' do
     ]
 
     user_with_tasks = users.by_name('Jane')
-                      .combine(tasks.for_users.combine(tags.for_tasks))
+      .combine(tasks.for_users.combine(tags.for_tasks))
 
     result = user_with_tasks >> map_user_with_tasks
 


### PR DESCRIPTION
##### Modified configuration for Rubocop a bit:

* ignore vendored files
* removed `Blocks` section
* removed RegexpLiteral section
* added MultilineOperationIndentation section

##### Cleaned up a few Rubocop offenses

* ~~Align operands in multi-line assignments~~
* _Indent_ operands in multi-line operation chains
* Modify arguments to indicate if they won't be used
* Remove parallel assignment
* Add a space inside curly braces for blocks
* Remove extra line from block body beginning
* Use Array#size instead of Array#count
* Replace {} with do/end for procedural block
* Remove semicolon as expression terminator


###### _Edit (5/26/2015):_

  * _`added MultilineOperationIndentation section`_
  * _`Indent operands in multi-line operation chains`_