### PR TITLE
Raise errors when configuring a mapper ambiguously

### DIFF
--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -163,6 +163,13 @@ module ROM
       #
       # @api public
       def wrap(*args, &block)
+        if args.first.is_a?(Hash) && block_given?
+          raise ROM::MapperMisconfigured, 'Cannot configure `wrap` using both options and a block'
+        end
+        if args.first.is_a?(Hash) && args.first[:mapper]
+          raise ROM::MapperMisconfigured, 'Cannot configure `wrap` using both options and a mapper'
+        end
+
         with_name_or_options(*args) do |name, options, mapper|
           wrap_options = { type: :hash, wrap: true }.update(options)
 

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -163,12 +163,7 @@ module ROM
       #
       # @api public
       def wrap(*args, &block)
-        if args.first.is_a?(Hash) && block_given?
-          raise ROM::MapperMisconfiguredError, 'Cannot configure `wrap` using both options and a block'
-        end
-        if args.first.is_a?(Hash) && args.first[:mapper]
-          raise ROM::MapperMisconfiguredError, 'Cannot configure `wrap` using both options and a mapper'
-        end
+        ensure_mapper_configuration('wrap', args, block_given?)
 
         with_name_or_options(*args) do |name, options, mapper|
           wrap_options = { type: :hash, wrap: true }.update(options)
@@ -230,6 +225,8 @@ module ROM
       #
       # @api public
       def group(*args, &block)
+        ensure_mapper_configuration('group', args, block_given?)
+
         with_name_or_options(*args) do |name, options, mapper|
           group_options = { type: :array, group: true }.update(options)
 
@@ -460,6 +457,20 @@ module ROM
         dsl = self.class.new([], @options.merge(options))
         dsl.instance_exec(&block) unless block.nil?
         dsl
+      end
+
+      # Ensure the mapping configuration isn't ambiguous
+      #
+      # @api private
+      def ensure_mapper_configuration(method_name, args, block_present)
+        if args.first.is_a?(Hash) && block_present
+          raise MapperMisconfiguredError,
+                "Cannot configure `#{method_name}#` using both options and a block"
+        end
+        if args.first.is_a?(Hash) && args.first[:mapper]
+          raise MapperMisconfiguredError,
+                "Cannot configure `#{method_name}#` using both options and a mapper"
+        end
       end
     end
   end

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -164,10 +164,10 @@ module ROM
       # @api public
       def wrap(*args, &block)
         if args.first.is_a?(Hash) && block_given?
-          raise ROM::MapperMisconfigured, 'Cannot configure `wrap` using both options and a block'
+          raise ROM::MapperMisconfiguredError, 'Cannot configure `wrap` using both options and a block'
         end
         if args.first.is_a?(Hash) && args.first[:mapper]
-          raise ROM::MapperMisconfigured, 'Cannot configure `wrap` using both options and a mapper'
+          raise ROM::MapperMisconfiguredError, 'Cannot configure `wrap` using both options and a mapper'
         end
 
         with_name_or_options(*args) do |name, options, mapper|

--- a/spec/unit/rom/mapper/dsl_spec.rb
+++ b/spec/unit/rom/mapper/dsl_spec.rb
@@ -236,14 +236,14 @@ describe ROM::Mapper do
     it 'raises an exception when using a block and options to define attributes' do
       expect {
         mapper.wrap(city: [:name]) { attribute :other_name }
-      }.to raise_error(ROM::MapperMisconfigured)
+      }.to raise_error(ROM::MapperMisconfiguredError)
     end
 
     it 'raises an exception when using options and a mapper to define attributes' do
       task_mapper = Class.new(ROM::Mapper) { attribute :title }
       expect {
         mapper.wrap city: [:name], mapper: task_mapper
-      }.to raise_error(ROM::MapperMisconfigured)
+      }.to raise_error(ROM::MapperMisconfiguredError)
     end
   end
 

--- a/spec/unit/rom/mapper/dsl_spec.rb
+++ b/spec/unit/rom/mapper/dsl_spec.rb
@@ -232,6 +232,19 @@ describe ROM::Mapper do
 
       expect(header).to eql(expected_header)
     end
+
+    it 'raises an exception when using a block and options to define attributes' do
+      expect {
+        mapper.wrap(city: [:name]) { attribute :other_name }
+      }.to raise_error(ROM::MapperMisconfigured)
+    end
+
+    it 'raises an exception when using options and a mapper to define attributes' do
+      task_mapper = Class.new(ROM::Mapper) { attribute :title }
+      expect {
+        mapper.wrap city: [:name], mapper: task_mapper
+      }.to raise_error(ROM::MapperMisconfigured)
+    end
   end
 
   describe '#group' do

--- a/spec/unit/rom/mapper/dsl_spec.rb
+++ b/spec/unit/rom/mapper/dsl_spec.rb
@@ -263,6 +263,19 @@ describe ROM::Mapper do
 
       expect(header).to eql(expected_header)
     end
+
+    it 'raises an exception when using a block and options to define attributes' do
+      expect {
+        mapper.group(cities: [:name]) { attribute :other_name }
+      }.to raise_error(ROM::MapperMisconfiguredError)
+    end
+
+    it 'raises an exception when using options and a mapper to define attributes' do
+      task_mapper = Class.new(ROM::Mapper) { attribute :title }
+      expect {
+        mapper.group cities: [:name], mapper: task_mapper
+      }.to raise_error(ROM::MapperMisconfiguredError)
+    end
   end
 
   describe 'top-level :prefix option' do


### PR DESCRIPTION
When I was perusing the docs I came across [these](https://github.com/rom-rb/rom-rb.org/blob/guides/source/doc-pages/guides/basics/mappers/wrapping.md#edge-cases-1):

> Don't define attributes inline along with the :mapper option! In this case the mapper won't be applied:

and 

> Don't use block along with the :mapper option! All definitions from inside the block will be ignored:


Instead of using documentation to let a developer know about a potential misuse I think it'd be better if the code told the dev. Plus this way it'll fail faster and the dev won't have figure out why his/her mapper isn't being used.