### PR TITLE
Fix nested mappers when used with #embedded and type: hash

### DIFF
--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -92,8 +92,9 @@ module ROM
           mapper = options[:mapper]
 
           if mapper
+            embedded_options = { type: :array }.update(options)
             attributes_from_mapper(
-              mapper, name, { type: :array }.update(attr_options)
+              mapper, name, embedded_options.update(attr_options)
             )
           else
             dsl = new(options, &block)

--- a/spec/integration/mappers/reusing_mappers_spec.rb
+++ b/spec/integration/mappers/reusing_mappers_spec.rb
@@ -19,4 +19,25 @@ describe 'Reusing mappers' do
       { name: 'Jane', tasks: [{ title: 'One' }, { title: 'Two' }] }
     ])
   end
+
+  it 'allows using another mapper in an embbedded hash' do
+    class Test::PriorityMapper < ROM::Mapper
+      attribute :value, type: :integer
+      attribute :desc
+    end
+
+    class Test::TaskMapper < ROM::Mapper
+      attribute :title
+      embedded :priority, type: :hash, mapper: Test::PriorityMapper
+    end
+
+    mapper = Test::TaskMapper.build
+    relation = [{ title: 'Task One', priority: { value: '1' } }, { title: 'Task Two', priority: { value: '2' } }]
+    result = mapper.call(relation)
+
+    expect(result).to eql([
+      { title: 'Task One', priority: { value: 1 } },
+      { title: 'Task Two', priority: { value: 2 } }
+    ])
+  end
 end

--- a/spec/unit/rom/mapper/dsl_spec.rb
+++ b/spec/unit/rom/mapper/dsl_spec.rb
@@ -386,7 +386,7 @@ describe ROM::Mapper do
       let(:attributes) do
         [
           [:name],
-          [:task, type: :array, header: task_mapper.header]
+          [:task, type: :hash, header: task_mapper.header]
         ]
       end
 


### PR DESCRIPTION
- `AttributeDSL#embedded` allows `options[:type]` to be overwritten when `options[:mapper]` is passed in.

Example:

```ruby
class EntryMapper < ROM::Mapper
  attribute :id, type: :integer
end

class EntriesMapper < ROM::Mapper
  embedded :data, type: :hash, mapper: EntryMapper
end

tuples =  [{
  data: {
    id: '10'
  }
}]

EntriesMapper.build.call(tuples)

# [{ data: { id: 10 } }]
```