### PR TITLE
Update fold

### DIFF
--- a/lib/rom/header.rb
+++ b/lib/rom/header.rb
@@ -107,6 +107,15 @@ module ROM
       by_type(Group)
     end
 
+    # Return all Fold attributes
+    #
+    # @return [Array<Fold>]
+    #
+    # @api private
+    def folds
+      by_type(Fold)
+    end
+
     # Return all Wrap attributes
     #
     # @return [Array<Wrap>]

--- a/lib/rom/header/attribute.rb
+++ b/lib/rom/header/attribute.rb
@@ -45,12 +45,16 @@ module ROM
           Combined
         elsif meta[:unwrap]
           Unwrap
-        elsif type.equal?(:hash)
-          meta[:wrap] ? Wrap : Hash
-        elsif meta[:fold]
+        elsif meta[:wrap]
+          Wrap
+        elsif meta[:group]
           Group
+        elsif meta[:fold]
+          Fold
+        elsif type.equal?(:hash)
+          Hash
         elsif type.equal?(:array)
-          meta[:group] ? Group : Array
+          Array
         else
           self
         end
@@ -158,5 +162,9 @@ module ROM
     # Group is a special type of Array attribute that requires grouping
     # transformation
     Group = Class.new(Array)
+
+    # Fold is a special type of Array attribute that requires folding
+    # transformation
+    Fold = Class.new(Array)
   end
 end

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -204,10 +204,10 @@ module ROM
       # @see AttributeDSL#embedded
       #
       # @api public
-      def fold(*args)
+      def fold(*args, &block)
         with_name_or_options(*args) do |name, *|
           fold_options = { type: :array, fold: true }
-          dsl(name, fold_options)
+          dsl(name, fold_options, &block)
         end
       end
 

--- a/spec/integration/mappers/fold_spec.rb
+++ b/spec/integration/mappers/fold_spec.rb
@@ -50,5 +50,21 @@ describe 'Mapper definition DSL' do
         { name: 'Jane', email: 'jane@doe.org', priorities: [2] }
       ]
     end
+
+    it 'accepts the block syntax' do
+      setup.mappers do
+        define(:users) do
+          fold :priorities do
+            attribute :priority
+            attribute :title
+          end
+        end
+      end
+
+      expect(actual).to eql [
+        { name: 'Joe', email: 'joe@doe.org', priorities: [1, 2] },
+        { name: 'Jane', email: 'jane@doe.org', priorities: [2] }
+      ]
+    end
   end
 end


### PR DESCRIPTION
Allow block syntax for `fold` operation. Just in the same way as for groups. Now:
```ruby
  fold :tasks do
    attribute :title
    attribute :priority
  end
```
does the same as:

```ruby
  fold tasks: [:title, :priority]
```
Also I understood, that I hasted with coupling of Fold and Group in the same attribute earlier. This was a bad abstraction. That's why I separated `Fold` attribute from the `Group` one.

This provided some duplication in code, that I'm going to deal with earlier, after all "nested" attributes will be done: `group`, `ungroup`, `fold`, `unfold`, `wrap`, `unwrap`. Then I'm planning to add some tests to cover their interaction and to do necessary refactoring.

Sounds like a plan, yes.