### PR TITLE
Fix `unwrap` to allow renaming the rest of wrapped attribute

### DIFF
--- a/lib/rom/header.rb
+++ b/lib/rom/header.rb
@@ -134,16 +134,16 @@ module ROM
       by_type(Wrap)
     end
 
-    # Return all non-primitive attributes
+    # Return all non-primitive attributes that don't require mapping
     #
-    # @return [Array<Group,Fold,Ungroup,Unfold,Wrap>]
+    # @return [Array<Group,Fold,Ungroup,Unfold,Wrap,Unwrap>]
     #
     # @api private
     def non_primitives
-      preprocessed + postprocessed + wraps
+      preprocessed + wraps
     end
 
-    # Return all primitive attributes that doesn't nest other ones
+    # Return all primitive attributes that require mapping
     #
     # @return [Array<Attribute>]
     #

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -157,8 +157,14 @@ module ROM
       #
       # @api public
       def unwrap(*args, &block)
-        with_name_or_options(*args) do |name, options|
-          dsl(name, { type: :hash, unwrap: true }.update(options), &block)
+        with_name_or_options(*args) do |name, options, mapper|
+          unwrap_options = { type: :hash, unwrap: true }.update(options)
+
+          if mapper
+            attributes_from_mapper(mapper, name, unwrap_options)
+          else
+            dsl(name, unwrap_options, &block)
+          end
         end
       end
 

--- a/spec/integration/mappers/unwrap_spec.rb
+++ b/spec/integration/mappers/unwrap_spec.rb
@@ -78,7 +78,7 @@ describe 'Mapper definition DSL' do
           attribute :title
           attribute :priority
 
-          unwrap :user do
+          unwrap :contact, from: :user do
             attribute :task_user_name, from: :name
           end
         end
@@ -92,7 +92,7 @@ describe 'Mapper definition DSL' do
                             priority: 2,
                             name: 'Jane',
                             task_user_name: 'Jane',
-                            user: { email: 'jane@doe.org' })
+                            contact: { email: 'jane@doe.org' })
     end
   end
 end

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -269,6 +269,62 @@ describe ROM::Processor::Transproc do
     end
   end
 
+  context 'unwrapping tuples' do
+    let(:relation) do
+      [
+        { 'user' => { 'name' => 'Leo', 'task' => { 'title' => 'Task 1' } } },
+        { 'user' => { 'name' => 'Joe', 'task' => { 'title' => 'Task 2' } } }
+      ]
+    end
+
+    context 'when no mapping is needed' do
+      let(:attributes) do
+        [
+          ['user', type: :hash, unwrap: true, header: [['name'], ['task']]]
+        ]
+      end
+
+      it 'returns unwrapped tuples' do
+        expect(transproc[relation]).to eql([
+          { 'name' => 'Leo', 'task' => { 'title' => 'Task 1' } },
+          { 'name' => 'Joe', 'task' => { 'title' => 'Task 2' } }
+        ])
+      end
+    end
+
+    context 'partially' do
+      context 'without renaming the rest of the wrap' do
+        let(:attributes) do
+          [
+            ['user', type: :hash, unwrap: true, header: [['task']]]
+          ]
+        end
+
+        it 'returns unwrapped tuples' do
+          expect(transproc[relation]).to eql([
+            { 'user' => { 'name' => 'Leo' }, 'task' => { 'title' => 'Task 1' } },
+            { 'user' => { 'name' => 'Joe' }, 'task' => { 'title' => 'Task 2' } }
+          ])
+        end
+      end
+
+      context 'with renaming the rest of the wrap' do
+        let(:attributes) do
+          [
+            ['man', from: 'user', type: :hash, unwrap: true, header: [['task']]]
+          ]
+        end
+
+        it 'returns unwrapped tuples' do
+          expect(transproc[relation]).to eql([
+            { 'man' => { 'name' => 'Leo' }, 'task' => { 'title' => 'Task 1' } },
+            { 'man' => { 'name' => 'Joe' }, 'task' => { 'title' => 'Task 2' } }
+          ])
+        end
+      end
+    end
+  end
+
   context 'grouping tuples' do
     let(:relation) do
       [


### PR DESCRIPTION
Example:

```ruby
  unwrap :contact, from: :user do
    attribute :name
  end

  user.first
  # => { user: { name: "Joe", email: "joe@doe.com" }
  user.as(:users).first
  # => { name: "Joe", contact: { email: "joe@doe.com" } }
```

Also applied to `ungroup` (yet uncovered).