### PR TITLE
Fix `unwrap` to deal with deep nesting

### DIFF
--- a/lib/rom/header.rb
+++ b/lib/rom/header.rb
@@ -35,6 +35,11 @@ module ROM
     # @api private
     attr_reader :tuple_keys
 
+    # @return [Array] all attribute names that are popping from a tuple
+    #
+    # @api private
+    attr_reader :pop_keys
+
     # Coerce array with attribute definitions into a header object
     #
     # @param [Array<Array>] input attribute name/option pairs
@@ -62,6 +67,7 @@ module ROM
       @attributes = attributes
       initialize_mapping
       initialize_tuple_keys
+      initialize_pop_keys
     end
 
     # Iterate over attributes
@@ -175,6 +181,13 @@ module ROM
     # @api private
     def initialize_tuple_keys
       @tuple_keys = mapping.keys + non_primitives.flat_map(&:tuple_keys)
+    end
+
+    # Set all tuple keys from all attributes popping from Unwrap and Ungroup
+    #
+    # @api private
+    def initialize_pop_keys
+      @pop_keys = mapping.values + non_primitives.flat_map(&:tuple_keys)
     end
   end
 end

--- a/lib/rom/header/attribute.rb
+++ b/lib/rom/header/attribute.rb
@@ -143,6 +143,10 @@ module ROM
       def tuple_keys
         header.tuple_keys
       end
+
+      def pop_keys
+        header.pop_keys
+      end
     end
 
     # Array is an embedded attribute type

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -173,7 +173,7 @@ module ROM
       # @api private
       def visit_unwrap(attribute)
         name = attribute.name
-        keys = attribute.header.map(&:name)
+        keys = attribute.pop_keys
 
         compose do |ops|
           ops << visit_hash(attribute)

--- a/spec/unit/rom/processor/transproc_spec.rb
+++ b/spec/unit/rom/processor/transproc_spec.rb
@@ -323,6 +323,25 @@ describe ROM::Processor::Transproc do
         end
       end
     end
+
+    context 'deeply' do
+      let(:attributes) do
+        [
+          ['user', type: :hash, unwrap: true, header: [
+            ['name'],
+            ['title'],
+            ['task', type: :hash, unwrap: true, header: [['title']]]
+          ]]
+        ]
+      end
+
+      it 'returns unwrapped tuples' do
+        expect(transproc[relation]).to eql([
+          { 'name' => 'Leo', 'title' => 'Task 1' },
+          { 'name' => 'Joe', 'title' => 'Task 2' }
+        ])
+      end
+    end
   end
 
   context 'grouping tuples' do


### PR DESCRIPTION
Ogres are like onions:

```ruby
  unwrap :contact do
    unwrap :email
      attribute :email, from: :address
    end
  end

  users.first
  # => { contact: { email: { address: "joe@doo.com" } } }
  users.as(:users).first
  # => { email: "joe@doo.com" }
```

think, `unwrap` is ready. 

I have plans for `ungroup` (slightly more coverage), `prefix` and `exclude`, but not sure this is for 8.0.0