### PR TITLE
Update prefixing

### DIFF
--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -14,8 +14,7 @@ module ROM
     class AttributeDSL
       include ModelDSL
 
-      attr_reader :attributes, :options, :symbolize_keys, :prefix,
-        :prefix_separator, :reject_keys
+      attr_reader :attributes, :options, :symbolize_keys, :reject_keys
 
       # @param [Array] attributes accumulator array
       # @param [Hash] options
@@ -28,6 +27,38 @@ module ROM
         @prefix = options.fetch(:prefix)
         @prefix_separator = options.fetch(:prefix_separator)
         @reject_keys = options.fetch(:reject_keys)
+      end
+
+      # Redefine the prefix for the following attributes
+      #
+      # @example
+      #
+      #   dsl = AttributeDSL.new([])
+      #   dsl.attribute(:prefix, 'user')
+      #
+      # @api public
+      def prefix(value = Undefined)
+        if value.equal?(Undefined)
+          @prefix
+        else
+          @prefix = value
+        end
+      end
+
+      # Redefine the prefix separator for the following attributes
+      #
+      # @example
+      #
+      #   dsl = AttributeDSL.new([])
+      #   dsl.attribute(:prefix_separator, '.')
+      #
+      # @api public
+      def prefix_separator(value = Undefined)
+        if value.equal?(Undefined)
+          @prefix_separator
+        else
+          @prefix_separator = value
+        end
       end
 
       # Define a mapping attribute with its options and/or block
@@ -314,7 +345,10 @@ module ROM
       def with_attr_options(name, options = EMPTY_HASH)
         attr_options = options.dup
 
-        attr_options[:from] ||= :"#{prefix}#{prefix_separator}#{name}" if prefix
+        if @prefix
+          attr_options[:from] ||= "#{@prefix}#{@prefix_separator}#{name}"
+          attr_options[:from] = attr_options[:from].to_sym if name.is_a? Symbol
+        end
 
         if symbolize_keys
           attr_options.update(from: attr_options.fetch(:from) { name }.to_s)

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -225,7 +225,7 @@ module ROM
         if preprocess
           name = attribute.name
           header = attribute.header
-          keys = header.map(&:name)
+          keys = attribute.pop_keys
 
           others = header.postprocessed
 
@@ -275,9 +275,15 @@ module ROM
         if preprocess
           name = attribute.name
           header = attribute.header
-          key = header.keys.first
+          keys = attribute.pop_keys
+          key = keys.first
+
+          others = header.postprocessed
 
           compose do |ops|
+            ops << others.map { |attr|
+              t(:map_array, t(:map_value, name, visit(attr, true)))
+            }
             ops << t(:map_array, t(:map_value, name, t(:insert_key, key)))
             ops << t(:map_array, t(:reject_keys, [key] - [name]))
             ops << t(:ungroup, name, [key])

--- a/spec/integration/mappers/prefix_separator_spec.rb
+++ b/spec/integration/mappers/prefix_separator_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'rom/memory'
+
+describe 'Mapper definition DSL' do
+  let(:setup) { ROM.setup(:memory) }
+  let(:rom)   { ROM.finalize.env   }
+
+  before do
+    setup.relation(:users)
+
+    users = setup.default.dataset(:users)
+    users.insert(
+      user_id: 1,
+      user_name: 'Joe',
+      user_email: 'joe@doe.com',
+      'user.skype' => 'joe',
+      :'user.phone' => '1234567890'
+    )
+  end
+
+  describe 'prefix' do
+    subject(:mapped_users) { rom.relation(:users).as(:users).to_a }
+
+    it 'applies new separator to the attributes following it' do
+      setup.mappers do
+        define(:users) do
+
+          prefix :user
+          attribute :id
+          attribute :name
+          wrap :contacts do
+            attribute :email
+
+            prefix_separator '.'
+            attribute 'skype'
+            attribute :phone
+          end
+        end
+      end
+
+      expect(mapped_users).to eql [
+        {
+          id: 1,
+          name: 'Joe',
+          contacts: {
+            email: 'joe@doe.com',
+            'skype' => 'joe',
+            phone: '1234567890'
+          }
+        }
+      ]
+    end
+  end
+end

--- a/spec/integration/mappers/prefix_spec.rb
+++ b/spec/integration/mappers/prefix_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'rom/memory'
+
+describe 'Mapper definition DSL' do
+  let(:setup) { ROM.setup(:memory) }
+  let(:rom)   { ROM.finalize.env   }
+
+  before do
+    setup.relation(:users)
+
+    users = setup.default.dataset(:users)
+    users.insert(
+      user_id: 1,
+      user_name: 'Joe',
+      user_email: 'joe@doe.com',
+      contact_skype: 'joe',
+      contact_phone: '1234567890'
+    )
+  end
+
+  describe 'prefix' do
+    subject(:mapped_users) { rom.relation(:users).as(:users).to_a }
+
+    it 'applies new prefix to the attributes following it' do
+      setup.mappers do
+        define(:users) do
+
+          prefix :user
+          attribute :id
+          attribute :name
+          wrap :contacts do
+            attribute :email
+
+            prefix :contact
+            attribute :skype
+            attribute :phone
+          end
+        end
+      end
+
+      expect(mapped_users).to eql [
+        {
+          id: 1,
+          name: 'Joe',
+          contacts: { email: 'joe@doe.com', skype: 'joe', phone: '1234567890' }
+        }
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Make `prefix` and `prefix_separator` applicable inside the block …
Both operations affect attributes following them.

```ruby
  setup.mappers do
    define(:users) do
      prefix :user

      attribute :name
      wrap :contact do
        attribute :skype

        prefix :contact
        prefix_separator '.'
        attribute 'email'
      end
    end
  end

  users.first
  # => { user_name: 'Joe', user_skype: 'joe', 'contact.email' => 'joe@doe.org' }
  users.as(:users).first
  # => { user: 'Joe', contact: { skype: 'joe', 'email': 'joe@doe.org' } }
```
If the target key not symbolized, the prefixed source is treated as a string too