### PR TITLE
steps

### DIFF
--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -10,6 +10,7 @@ module ROM
   CommandError = Class.new(StandardError)
   TupleCountMismatchError = Class.new(CommandError)
   MapperMissingError = Class.new(StandardError)
+  MapperMisconfiguredError = Class.new(StandardError)
   UnknownPluginError = Class.new(StandardError)
   UnsupportedRelationError = Class.new(StandardError)
 

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -61,12 +61,7 @@ module ROM
       else
 
         step_transformers = steps.map do |s|
-          mapper = new(Mapper.processors.fetch(processor).build(s.header), s.header)
-          if mapper.transformer.is_a?(Transproc::Function) || mapper.transformer.is_a?(Transproc::Composite)
-            mapper.transformer
-          else
-            Transproc(mapper.transformer)
-          end
+          new(Mapper.processors.fetch(processor).build(s.header), s.header).transformer
         end.inject(:+)
 
         new(step_transformers, header)

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -56,14 +56,16 @@ module ROM
     #
     # @api private
     def self.build(header = self.header, processor = :transproc)
+      processor = Mapper.processors.fetch(processor)
+
       if steps.empty?
-        new(Mapper.processors.fetch(processor).build(header), header)
+        new(processor.build(header), header)
+      elsif attributes.any?
+        raise(MapperMisconfiguredError, "cannot mix outer attributes and steps")
       else
-
-        step_transformers = steps.map do |s|
-          new(Mapper.processors.fetch(processor).build(s.header), s.header).transformers.first
-        end
-
+        step_transformers = steps.map(&:header).map { |step_header|
+          new(processor.build(step_header), step_header).transformers.first
+        }
         new(step_transformers, header)
       end
     end

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -56,7 +56,21 @@ module ROM
     #
     # @api private
     def self.build(header = self.header, processor = :transproc)
-      new(Mapper.processors.fetch(processor).build(header), header)
+      if steps.empty?
+        new(Mapper.processors.fetch(processor).build(header), header)
+      else
+
+        step_transformers = steps.map do |s|
+          mapper = new(Mapper.processors.fetch(processor).build(s.header), s.header)
+          if mapper.transformer.is_a?(Transproc::Function) || mapper.transformer.is_a?(Transproc::Composite)
+            mapper.transformer
+          else
+            Transproc(mapper.transformer)
+          end
+        end.inject(:+)
+
+        new(step_transformers, header)
+      end
     end
 
     # @api private

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -105,8 +105,7 @@ module ROM
       #   end
       #
       # @api public
-      def step(options=EMPTY_HASH, &block)
-        raise(ArgumentError, "cannot mix outer attributes and steps") unless attributes.empty?
+      def step(options = EMPTY_HASH, &block)
         steps << new(options, &block)
       end
 

--- a/lib/rom/mapper/attribute_dsl.rb
+++ b/lib/rom/mapper/attribute_dsl.rb
@@ -14,7 +14,7 @@ module ROM
     class AttributeDSL
       include ModelDSL
 
-      attr_reader :attributes, :options, :symbolize_keys, :reject_keys
+      attr_reader :attributes, :options, :symbolize_keys, :reject_keys, :steps
 
       # @param [Array] attributes accumulator array
       # @param [Hash] options
@@ -27,6 +27,7 @@ module ROM
         @prefix = options.fetch(:prefix)
         @prefix_separator = options.fetch(:prefix_separator)
         @reject_keys = options.fetch(:reject_keys)
+        @steps = []
       end
 
       # Redefine the prefix for the following attributes
@@ -92,6 +93,21 @@ module ROM
       # @api public
       def exclude(*names)
         attributes.delete_if { |attr| names.include?(attr.first) }
+      end
+
+      # Perform transformations sequentially
+      #
+      # @example
+      #   dsl = AttributeDSL.new()
+      #
+      #   dsl.step do
+      #     attribute :name
+      #   end
+      #
+      # @api public
+      def step(options=EMPTY_HASH, &block)
+        raise(ArgumentError, "cannot mix outer attributes and steps") unless attributes.empty?
+        steps << new(options, &block)
       end
 
       # Define an embedded attribute

--- a/spec/integration/mappers/step_spec.rb
+++ b/spec/integration/mappers/step_spec.rb
@@ -1,65 +1,120 @@
 require 'spec_helper'
 
 describe 'Mapper definition DSL' do
-  include_context 'users and tasks'
+  let(:setup) { ROM.setup(:memory) }
+  let(:rom)   { ROM.finalize.env   }
 
-  let(:header) { mapper.header }
+  before do
+    setup.relation(:lists)
 
-  describe 'stepped mapper' do
-    before do
-      setup.relation(:tasks) do
-        def with_users
-          join(users)
-        end
-      end
+    setup.default.dataset(:lists).insert(
+      list_id: 1,
+      list_tasks: [
+        { user: 'Jacob', task_id: 1, task_title: 'be nice'    },
+        { user: 'Jacob', task_id: 2, task_title: 'sleep well' }
+      ]
+    )
+  end
 
-      setup.relation(:users) do
-        def with_tasks
-          join(tasks)
-        end
-      end
+  describe 'step' do
+    let(:mapped) { rom.relation(:lists).as(:lists).to_a }
 
+    it 'applies transformations one by one' do
       setup.mappers do
-        define(:users) do
+        define(:lists) do
+          step do
+            prefix 'list'
+            attribute :id
+            unfold :tasks
+          end
+
+          step do
+            unwrap :tasks do
+              attribute :task_id
+              attribute :name, from: :user
+              attribute :task_title
+            end
+          end
+
+          step do
+            group :tasks do
+              prefix 'task'
+              attribute :id
+              attribute :title
+            end
+          end
+
+          step do
+            wrap :user do
+              attribute :name
+              attribute :tasks
+            end
+          end
         end
       end
+
+      expect(mapped).to eql [
+        {
+          id: 1,
+          user: {
+            name: 'Jacob',
+            tasks: [
+              { id: 1, title: 'be nice'    },
+              { id: 2, title: 'sleep well' }
+            ]
+          }
+        }
+      ]
     end
 
-    it 'processes the mapper step by step' do
+    it 'applies settings from root' do
       setup.mappers do
-        define(:with_tasks, parent: :users) do
+        define(:lists) do
+
+          prefix 'list'
 
           step do
-            attribute :an_email, from: :email
+            attribute :id
+            attribute :tasks
           end
-
-          step do
-            attribute :name
-            attribute :title
-            attribute :priority
-            attribute :email, from: :an_email
-          end
-
-          step do
-            model name: 'Test::UserWithTasks'
-            attribute :name
-            attribute :email
-            group tasks: [:title, :priority]
-          end
-
         end
       end
 
-      rom = setup.finalize
-
-      Test::UserWithTasks.send(:include, Equalizer.new(:name, :email, :tasks))
-
-      jane = rom.relation(:users).with_tasks.map_with(:with_tasks).to_a.last
-
-      expect(jane.name).to eql('Jane')
-      expect(jane.email).to eql('jane@doe.org')
-      expect(jane.tasks).to eql([{ title: 'be cool', priority: 2 }])
+      expect(mapped).to eql [
+        {
+          id: 1,
+          tasks: [
+            { user: 'Jacob', task_id: 1, task_title: 'be nice'    },
+            { user: 'Jacob', task_id: 2, task_title: 'sleep well' }
+          ]
+        }
+      ]
     end
 
+    it 'cannot precede attributes' do
+      setup.mappers do
+        define(:lists) do
+          step do
+            unfold :tasks, from: :list_tasks
+          end
+          attribute :id, from: :list_id
+        end
+      end
+
+      expect { rom }.to raise_error ROM::MapperMisconfiguredError
+    end
+
+    it 'cannot succeed attributes' do
+      setup.mappers do
+        define(:lists) do
+          attribute :id, from: :list_id
+          step do
+            unfold :tasks, from: :list_tasks
+          end
+        end
+      end
+
+      expect { rom }.to raise_error ROM::MapperMisconfiguredError
+    end
   end
 end

--- a/spec/integration/mappers/step_spec.rb
+++ b/spec/integration/mappers/step_spec.rb
@@ -25,28 +25,27 @@ describe 'Mapper definition DSL' do
       end
     end
 
-    it 'allows defining grouped attributes via options hash' do
+    it 'processes the mapper step by step' do
       setup.mappers do
         define(:with_tasks, parent: :users) do
-          model name: 'Test::UserWithTasks'
 
-          #attribute :name
-          #attribute :email
+          step do
+            attribute :an_email, from: :email
+          end
 
-          #group tasks: [:title, :priority]
+          step do
+            attribute :name
+            attribute :title
+            attribute :priority
+            attribute :email, from: :an_email
+          end
+
           step do
             model name: 'Test::UserWithTasks'
             attribute :name
-          end
-
-          step do
             attribute :email
+            group tasks: [:title, :priority]
           end
-
-          #step do
-          #  model name: 'Test::UserWithTasks'
-          #  group tasks: [:title, :priority]
-          #end
 
         end
       end
@@ -57,13 +56,9 @@ describe 'Mapper definition DSL' do
 
       jane = rom.relation(:users).with_tasks.map_with(:with_tasks).to_a.last
 
-      expect(jane).to eql(
-        Test::UserWithTasks.new(
-          name: 'Jane',
-          email: 'jane@doe.org',
-          #tasks: [{ title: 'be cool', priority: 2 }]
-        )
-      )
+      expect(jane.name).to eql('Jane')
+      expect(jane.email).to eql('jane@doe.org')
+      expect(jane.tasks).to eql([{ title: 'be cool', priority: 2 }])
     end
 
   end

--- a/spec/integration/mappers/step_spec.rb
+++ b/spec/integration/mappers/step_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'Mapper definition DSL' do
+  include_context 'users and tasks'
+
+  let(:header) { mapper.header }
+
+  describe 'stepped mapper' do
+    before do
+      setup.relation(:tasks) do
+        def with_users
+          join(users)
+        end
+      end
+
+      setup.relation(:users) do
+        def with_tasks
+          join(tasks)
+        end
+      end
+
+      setup.mappers do
+        define(:users) do
+        end
+      end
+    end
+
+    it 'allows defining grouped attributes via options hash' do
+      setup.mappers do
+        define(:with_tasks, parent: :users) do
+          model name: 'Test::UserWithTasks'
+
+          #attribute :name
+          #attribute :email
+
+          #group tasks: [:title, :priority]
+          step do
+            model name: 'Test::UserWithTasks'
+            attribute :name
+            attribute :email
+          #  attribute :abcd
+          end
+
+          #step do
+          #  model name: 'Test::UserWithTasks'
+          #  group tasks: [:title, :priority]
+          #end
+
+        end
+      end
+
+      rom = setup.finalize
+
+      Test::UserWithTasks.send(:include, Equalizer.new(:name, :email, :tasks))
+
+      jane = rom.relation(:users).with_tasks.map_with(:with_tasks).to_a.last
+
+      expect(jane).to eql(
+        Test::UserWithTasks.new(
+          name: 'Jane',
+          email: 'jane@doe.org',
+          #tasks: [{ title: 'be cool', priority: 2 }]
+        )
+      )
+    end
+
+  end
+end

--- a/spec/integration/mappers/step_spec.rb
+++ b/spec/integration/mappers/step_spec.rb
@@ -37,8 +37,10 @@ describe 'Mapper definition DSL' do
           step do
             model name: 'Test::UserWithTasks'
             attribute :name
+          end
+
+          step do
             attribute :email
-          #  attribute :abcd
           end
 
           #step do


### PR DESCRIPTION
Have the ability to declare steps in a Mapper. This helps with the transformations are complex and not reusable.

```ruby
         step do
            prefix 'list'
            attribute :id
            unfold :tasks
          end

          step do
            unwrap :tasks do
              attribute :task_id
              attribute :name, from: :user
              attribute :task_title
            end
          end
```

#263 