### PR TITLE
Support `exclude` attribute from root

### DIFF
--- a/lib/rom/header/attribute.rb
+++ b/lib/rom/header/attribute.rb
@@ -162,6 +162,9 @@ module ROM
     # transformation
     Unfold = Class.new(Array)
 
+    # Exclude is a special type of Attribute to be removed
+    Exclude = Class.new(Attribute)
+
     # TYPE_MAP is a (hash) map of ROM::Header identifiers to ROM::Header types
     #
     # @private
@@ -174,7 +177,8 @@ module ROM
       fold: Fold,
       unfold: Unfold,
       hash: Hash,
-      array: Array
+      array: Array,
+      exclude: Exclude
     }
   end
 end

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -297,6 +297,15 @@ module ROM
         end
       end
 
+      # Visit excluded attribute
+      #
+      # @param [Header::Attribute::Exclude] attribute
+      #
+      # @api private
+      def visit_exclude(attribute)
+        t(:reject_keys, [attribute.name])
+      end
+
       # @api private
       def combined_args(attribute)
         other = attribute.header.combined

--- a/spec/integration/mappers/definition_dsl_spec.rb
+++ b/spec/integration/mappers/definition_dsl_spec.rb
@@ -84,7 +84,12 @@ describe 'Mapper definition DSL' do
     end
 
     it 'inherits the attributes from the parent by default' do
-      expect(header.keys).to eql([:email])
+      expect(header.keys).to eql([:name, :email])
+    end
+
+    it 'excludes an inherited attribute when requested' do
+      name = header.attributes[:name]
+      expect(name).to be_kind_of ROM::Header::Exclude
     end
 
     it 'builds a new model' do

--- a/spec/integration/mappers/exclude_spec.rb
+++ b/spec/integration/mappers/exclude_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'rom/memory'
+
+describe 'Mapper definition DSL' do
+  let(:setup) { ROM.setup(:memory) }
+  let(:rom)   { ROM.finalize.env   }
+
+  before do
+    setup.relation(:users)
+
+    users = setup.default.dataset(:users)
+
+    users.insert(name: 'Joe', email: 'joe@doe.com')
+    users.insert(name: 'Jane', email: 'jane@doe.com')
+  end
+
+  describe 'exclude' do
+    let(:mapped_users) { rom.relation(:users).as(:users).to_a }
+
+    it 'removes the attribute' do
+      setup.mappers do
+        define(:users) { exclude :email }
+      end
+
+      expect(mapped_users).to eql [{ name: 'Joe' }, { name: 'Jane' }]
+    end
+  end
+end


### PR DESCRIPTION
Renamed old `exclude` to `remove` and made it private. Implemented the `exclude` as a special type of attribute that removes key.

This allows using `exclude` from the root, so now we can either whitelist (with `reject_keys`) or blacklist (with `exclude`) attributes.

```ruby
class UserMapper < ROM::Mapper
  relation :users
  register_as :users

  exclude :password
end
```