### PR TITLE
Update mutant dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :tools do
   gem 'byebug'
 
   platform :mri do
-    gem 'mutant', '>= 0.7.7', github: 'mbj/mutant'
-    gem 'mutant-rspec'
+    gem 'mutant-rspec', '~> 0.7.9'
   end
 end


### PR DESCRIPTION
Dunno if you guys actively use mutant. But if so, you should:

* Remove the `github` option from Gemfile, because:
  * I'll fuck up master sometimes, even for days (maybe without noticing) making it hard for, especially beginners, to bundle this repo
  * Not depend on the API in master / CLI, since only releases are "right shifted semversioned".
* Not explicitly pull the `mutant` dependency, as shown in the [installation instructions](https://github.com/mbj/mutant#installation)
* If I fuck up dependencies in a way (less likely the next month, because of me working on a commercial ruby project) mutant prevents `parser` updates: Raise a ticket, or drop mutant from this repo.