### PR TITLE
Removed support for grouping under the same name as one of keys

### DIFF
--- a/spec/integration/mappers/group_spec.rb
+++ b/spec/integration/mappers/group_spec.rb
@@ -158,26 +158,5 @@ describe 'Mapper definition DSL' do
         ])
       )
     end
-
-    it 'allows defining grouped attributes with the same name as their keys' do
-      setup.mappers do
-        define(:with_tasks, parent: :users) do
-          attribute :name
-          attribute :email
-
-          group title: [:title, :priority]
-        end
-      end
-
-      rom = setup.finalize
-
-      jane = rom.relation(:users).with_tasks.map_with(:with_tasks).to_a.last
-
-      expect(jane).to eql(
-        name: 'Jane',
-        email: 'jane@doe.org',
-        title: [{ title: 'be cool', priority: 2 }]
-      )
-    end
   end
 end


### PR DESCRIPTION
This feature cannot be supported because grouping to the existing key
is treated like updating the existing group.

```ruby
  group email: [:email] # not supported (can cause undesired results)
```