### PR TITLE
Fix memory's create/delete unit tests

### DIFF
--- a/spec/unit/rom/memory/commands/create_spec.rb
+++ b/spec/unit/rom/memory/commands/create_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 require 'rom/memory'
 
-describe ROM::Memory::Commands::Delete do
+describe ROM::Memory::Commands::Create do
   include_context 'users and tasks'
 
-  subject(:command) { ROM::Memory::Commands::Delete.build(users) }
+  subject(:command) { ROM::Memory::Commands::Create.build(users) }
 
   let(:users) { rom.relations[:users] }
 

--- a/spec/unit/rom/memory/commands/delete_spec.rb
+++ b/spec/unit/rom/memory/commands/delete_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 require 'rom/memory'
 
-describe ROM::Memory::Commands::Create do
+describe ROM::Memory::Commands::Delete do
   include_context 'users and tasks'
 
-  subject(:command) { ROM::Memory::Commands::Create.build(users) }
+  subject(:command) { ROM::Memory::Commands::Delete.build(users) }
 
   let(:users) { rom.relations[:users] }
 


### PR DESCRIPTION
The `unit/rom/memory/commands/create_spec.rb` and
`unit/rom/memory/commands/delete_spec.rb` were reversed;
`create_spec.rb` tested the Delete command and `delete_spec.rb` tested
the Create command.

Reverse the filenames.