### PR TITLE
Transproc processor refactoring

### DIFF
--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -3,6 +3,8 @@ require 'transproc/all'
 require 'rom/processor'
 
 require 'rom/processor/transproc/combine_processor'
+require 'rom/processor/transproc/attributes_processor'
+require 'rom/processor/transproc/rows_processor'
 
 module ROM
   class Processor
@@ -31,11 +33,6 @@ module ROM
       # @api private
       attr_reader :mapping
 
-      # @return [Proc] row-processing proc
-      #
-      # @api private
-      attr_reader :row_proc
-
       # Default no-op row_proc
       EMPTY_FN = -> tuple { tuple }.freeze
 
@@ -60,7 +57,6 @@ module ROM
         @header = header
         @model = header.model
         @mapping = header.mapping
-        initialize_row_proc
       end
 
       # Coerce mapper header to a transproc data mapping function
@@ -85,292 +81,15 @@ module ROM
       end
 
       def rows_processor
-        t(:map_array, row_proc) if row_proc
+        RowsProcessor.new(header).to_transproc
       end
 
       def header_postprocessor
-        header.postprocessed.map(&method(:visit_with_preprocess))
+        AttributesProcessor.new(header.postprocessed).to_transproc
       end
 
       def header_preprocessor
-        header.preprocessed.map(&method(:visit_with_preprocess))
-      end
-
-      def visit_with_preprocess(attr)
-        visit(attr, true)
-      end
-
-      # Visit an attribute from the header
-      #
-      # This forwards to a specialized visitor based on the attribute type
-      #
-      # @param [Header::Attribute] attribute
-      # @param [Array] args Allows to send `preprocess: true`
-      #
-      # @api private
-      def visit(attribute, *args)
-        type = attribute.class.name.split('::').last.downcase
-        send("visit_#{type}", attribute, *args)
-      end
-
-      # Visit plain attribute
-      #
-      # It will call block transformation if it's used
-      #
-      # If it's a typed attribute a coercion transformation is added
-      #
-      # @param [Header::Attribute] attribute
-      #
-      # @api private
-      def visit_attribute(attribute)
-        coercer = attribute.meta[:coercer]
-        if coercer
-          t(:map_value, attribute.name, coercer)
-        elsif attribute.typed?
-          t(:map_value, attribute.name, t(:"to_#{attribute.type}"))
-        end
-      end
-
-      # Visit hash attribute
-      #
-      # @param [Header::Attribute::Hash] attribute
-      #
-      # @api private
-      def visit_hash(attribute)
-        with_row_proc(attribute) do |row_proc|
-          t(:map_value, attribute.name, row_proc)
-        end
-      end
-
-      # Visit combined attribute
-      #
-      # @api private
-      def visit_combined(attribute)
-        op = with_row_proc(attribute) do |row_proc|
-          array_proc =
-            if attribute.type == :hash
-              t(:map_array, row_proc) >> -> arr { arr.first }
-            else
-              t(:map_array, row_proc)
-            end
-
-          t(:map_value, attribute.name, array_proc)
-        end
-
-        if op
-          op
-        elsif attribute.type == :hash
-          t(:map_value, attribute.name, -> arr { arr.first })
-        end
-      end
-
-      # Visit array attribute
-      #
-      # @param [Header::Attribute::Array] attribute
-      #
-      # @api private
-      def visit_array(attribute)
-        with_row_proc(attribute) do |row_proc|
-          t(:map_value, attribute.name, t(:map_array, row_proc))
-        end
-      end
-
-      # Visit wrapped hash attribute
-      #
-      # :nest transformation is added to handle wrapping
-      #
-      # @param [Header::Attribute::Wrap] attribute
-      #
-      # @api private
-      def visit_wrap(attribute)
-        name = attribute.name
-        keys = attribute.tuple_keys
-
-        compose do |ops|
-          ops << t(:nest, name, keys)
-          ops << visit_hash(attribute)
-        end
-      end
-
-      # Visit unwrap attribute
-      #
-      # :unwrap transformation is added to handle unwrapping
-      #
-      # @param [Header::Attributes::Unwrap]
-      #
-      # @api private
-      def visit_unwrap(attribute)
-        name = attribute.name
-        keys = attribute.pop_keys
-
-        compose do |ops|
-          ops << visit_hash(attribute)
-          ops << t(:unwrap, name, keys)
-        end
-      end
-
-      # Visit group hash attribute
-      #
-      # :group transformation is added to handle grouping during preprocessing.
-      # Otherwise we simply use array visitor for the attribute.
-      #
-      # @param [Header::Attribute::Group] attribute
-      # @param [Boolean] preprocess true if we are building a relation preprocessing
-      #                             function that is applied to the whole relation
-      #
-      # @api private
-      def visit_group(attribute, preprocess = false)
-        if preprocess
-          name = attribute.name
-          header = attribute.header
-          keys = attribute.tuple_keys
-
-          others = header.preprocessed
-
-          compose do |ops|
-            ops << t(:group, name, keys)
-            ops << t(:map_array, t(:map_value, name, FILTER_EMPTY))
-            ops << others.map { |attr|
-              t(:map_array, t(:map_value, name, visit(attr, true)))
-            }
-          end
-        else
-          visit_array(attribute)
-        end
-      end
-
-      # Visit ungroup attribute
-      #
-      # :ungroup transforation is added to handle ungrouping during preprocessing.
-      # Otherwise we simply use array visitor for the attribute.
-      #
-      # @param [Header::Attribute::Ungroup] attribute
-      # @param [Boolean] preprocess true if we are building a relation preprocessing
-      #                             function that is applied to the whole relation
-      #
-      # @api private
-      def visit_ungroup(attribute, preprocess = false)
-        if preprocess
-          name = attribute.name
-          header = attribute.header
-          keys = attribute.pop_keys
-
-          others = header.postprocessed
-
-          compose do |ops|
-            ops << others.map { |attr|
-              t(:map_array, t(:map_value, name, visit(attr, true)))
-            }
-            ops << t(:ungroup, name, keys)
-          end
-        else
-          visit_array(attribute)
-        end
-      end
-
-      # Visit fold hash attribute
-      #
-      # :fold transformation is added to handle folding during preprocessing.
-      #
-      # @param [Header::Attribute::Fold] attribute
-      # @param [Boolean] preprocess true if we are building a relation preprocessing
-      #                             function that is applied to the whole relation
-      #
-      # @api private
-      def visit_fold(attribute, preprocess = false)
-        if preprocess
-          name = attribute.name
-          keys = attribute.tuple_keys
-
-          compose do |ops|
-            ops << t(:group, name, keys)
-            ops << t(:map_array, t(:map_value, name, FILTER_EMPTY))
-            ops << t(:map_array, t(:fold, name, keys.first))
-          end
-        end
-      end
-
-      # Visit unfold hash attribute
-      #
-      # :unfold transformation is added to handle unfolding during preprocessing.
-      #
-      # @param [Header::Attribute::Unfold] attribute
-      # @param [Boolean] preprocess true if we are building a relation preprocessing
-      #                             function that is applied to the whole relation
-      #
-      # @api private
-      def visit_unfold(attribute, preprocess = false)
-        if preprocess
-          name = attribute.name
-          header = attribute.header
-          keys = attribute.pop_keys
-          key = keys.first
-
-          others = header.postprocessed
-
-          compose do |ops|
-            ops << others.map { |attr|
-              t(:map_array, t(:map_value, name, visit(attr, true)))
-            }
-            ops << t(:map_array, t(:map_value, name, t(:insert_key, key)))
-            ops << t(:map_array, t(:reject_keys, [key] - [name]))
-            ops << t(:ungroup, name, [key])
-          end
-        end
-      end
-
-      # Visit excluded attribute
-      #
-      # @param [Header::Attribute::Exclude] attribute
-      #
-      # @api private
-      def visit_exclude(attribute)
-        t(:reject_keys, [attribute.name])
-      end
-
-      # Build row_proc
-      #
-      # This transproc function is applied to each row in a dataset
-      #
-      # @api private
-      def initialize_row_proc
-        @row_proc = compose { |ops|
-          process_header_keys(ops)
-
-          ops << t(:rename_keys, mapping) if header.aliased?
-          ops << header.map { |attr| visit(attr) }
-          ops << t(:constructor_inject, model) if model
-        }
-      end
-
-      # Process row_proc header keys
-      #
-      # @api private
-      def process_header_keys(ops)
-        if header.reject_keys
-          all_keys = header.tuple_keys + header.non_primitives.map(&:key)
-          ops << t(:accept_keys, all_keys)
-        end
-        ops
-      end
-
-      # Yield row proc for a given attribute if any
-      #
-      # @param [Header::Attribute] attribute
-      #
-      # @api private
-      def with_row_proc(attribute)
-        row_proc = row_proc_from(attribute)
-        yield(row_proc) if row_proc
-      end
-
-      # Build a row_proc from a given attribute
-      #
-      # This is used by embedded attribute visitors
-      #
-      # @api private
-      def row_proc_from(attribute)
-        new(attribute.header).row_proc
+        AttributesProcessor.new(header.preprocessed).to_transproc
       end
 
       # Return a new instance of the processor

--- a/lib/rom/processor/transproc.rb
+++ b/lib/rom/processor/transproc.rb
@@ -5,6 +5,8 @@ require 'rom/processor'
 require 'rom/processor/transproc/combine_processor'
 require 'rom/processor/transproc/attributes_processor'
 require 'rom/processor/transproc/rows_processor'
+require 'rom/processor/transproc/preprocessor'
+require 'rom/processor/transproc/postprocessor'
 
 module ROM
   class Processor
@@ -66,37 +68,17 @@ module ROM
       # @api private
       def to_transproc
         compose(EMPTY_FN) do |ops|
-          processors.each { |processor| ops << send(processor) }
+          processors.each { |processor| ops << processor.new(@header).to_transproc }
         end
       end
 
       private
 
-      def processors
-        [:combine_processor, :header_preprocessor, :rows_processor, :header_postprocessor]
-      end
-
-      def combine_processor
-        CombineProcessor.new(header.combined).to_transproc
-      end
-
-      def rows_processor
-        RowsProcessor.new(header).to_transproc
-      end
-
-      def header_postprocessor
-        AttributesProcessor.new(header.postprocessed).to_transproc
-      end
-
-      def header_preprocessor
-        AttributesProcessor.new(header.preprocessed).to_transproc
-      end
-
-      # Return a new instance of the processor
+      # List of processors
       #
       # @api private
-      def new(*args)
-        self.class.new(*args)
+      def processors
+        [CombineProcessor, Preprocessor, RowsProcessor, Postprocessor]
       end
     end
   end

--- a/lib/rom/processor/transproc/attribute.rb
+++ b/lib/rom/processor/transproc/attribute.rb
@@ -52,22 +52,7 @@ module ROM
         #
         # @api private
         def visit_combined
-          op = with_row_proc do |row_proc|
-            array_proc =
-              if type == :hash
-                t(:map_array, row_proc) >> -> arr { arr.first }
-              else
-                t(:map_array, row_proc)
-              end
-
-            t(:map_value, name, array_proc)
-          end
-
-          if op
-            op
-          elsif type == :hash
-            t(:map_value, name, -> arr { arr.first })
-          end
+          process_combined_with_row_proc || process_combined
         end
 
         # Visit array attribute
@@ -234,6 +219,20 @@ module ROM
         # @api private
         def attribute_type
           @attribute.class.name.split('::').last.downcase
+        end
+
+        def process_combined
+          t(:map_value, name, combined_proc)
+        end
+
+        def process_combined_with_row_proc
+          with_row_proc do |row_proc|
+            t(:map_value, name, t(:map_array, row_proc) >> combined_proc)
+          end
+        end
+
+        def combined_proc
+          type == :hash ? -> arr { arr.first } : ROM::Processor::Transproc::EMPTY_FN
         end
       end
     end

--- a/lib/rom/processor/transproc/attribute.rb
+++ b/lib/rom/processor/transproc/attribute.rb
@@ -1,0 +1,228 @@
+module ROM
+  class Processor
+    class Transproc < Processor
+      class Attribute
+        include ::Transproc::Composer
+        extend Forwardable
+
+        def_delegators :@attribute, :name, :header, :tuple_keys, :pop_keys, :type, :typed?
+
+        # @param [Header::Attribute] attribute
+        # @param [Boolean] preprocess true if we are building a relation preprocessing
+        #                             function that is applied to the whole relation
+        #
+        # @api private
+        def initialize(attribute, preprocess = false)
+          @attribute = attribute
+          @preprocess = preprocess
+        end
+
+        # Process an attribute from the header
+        #
+        # This forwards to a specialized visitor based on the attribute type
+        #
+        # @api private
+        def to_transproc
+          send("process_#{attribute_type}")
+        end
+
+        private
+
+        # Process plain attribute
+        #
+        # It will call block transformation if it's used
+        #
+        # If it's a typed attribute a coercion transformation is added
+        #
+        # @api private
+        def process_attribute
+          t(:map_value, name, coercer) if coercer
+        end
+
+        # Process hash attribute
+        #
+        # @api private
+        def process_hash
+          with_row_proc do |row_proc|
+            t(:map_value, name, row_proc)
+          end
+        end
+
+        # Process combined attribute
+        #
+        # @api private
+        def process_combined
+          op = with_row_proc do |row_proc|
+            array_proc =
+              if type == :hash
+                t(:map_array, row_proc) >> -> arr { arr.first }
+              else
+                t(:map_array, row_proc)
+              end
+
+            t(:map_value, name, array_proc)
+          end
+
+          if op
+            op
+          elsif type == :hash
+            t(:map_value, name, -> arr { arr.first })
+          end
+        end
+
+        # Process array attribute
+        #
+        # @api private
+        def process_array
+          with_row_proc do |row_proc|
+            t(:map_value, name, t(:map_array, row_proc))
+          end
+        end
+
+        # Process wrapped hash attribute
+        #
+        # :nest transformation is added to handle wrapping
+        #
+        # @api private
+        def process_wrap
+          compose do |ops|
+            ops << t(:nest, name, tuple_keys)
+            ops << process_hash
+          end
+        end
+
+        # Process unwrap attribute
+        #
+        # :unwrap transformation is added to handle unwrapping
+        #
+        # @api private
+        def process_unwrap
+          compose do |ops|
+            ops << process_hash
+            ops << t(:unwrap, name, pop_keys)
+          end
+        end
+
+        # Process group hash attribute
+        #
+        # :group transformation is added to handle grouping during preprocessing.
+        # Otherwise we simply use array visitor for the attribute.
+        #
+        # @api private
+        def process_group
+          if @preprocess
+            others = header.preprocessed
+
+            compose do |ops|
+              ops << t(:group, name, tuple_keys)
+              ops << t(:map_array, t(:map_value, name, FILTER_EMPTY))
+              ops << others.map { |attr|
+                t(:map_array, t(:map_value, name, Attribute.new(attr, true).to_transproc))
+              }
+            end
+          else
+            process_array
+          end
+        end
+
+        # Process ungroup attribute
+        #
+        # :ungroup transforation is added to handle ungrouping during preprocessing.
+        # Otherwise we simply use array visitor for the attribute.
+        #
+        # @api private
+        def process_ungroup
+          if @preprocess
+            others = header.postprocessed
+
+            compose do |ops|
+              ops << others.map { |attr|
+                t(:map_array, t(:map_value, name, visit(attr, true)))
+              }
+              ops << t(:ungroup, name, pop_keys)
+            end
+          else
+            process_array
+          end
+        end
+
+        # Process fold hash attribute
+        #
+        # :fold transformation is added to handle folding during preprocessing.
+        #
+        # @api private
+        def process_fold
+          if @preprocess
+            compose do |ops|
+              ops << t(:group, name, tuple_keys)
+              ops << t(:map_array, t(:map_value, name, FILTER_EMPTY))
+              ops << t(:map_array, t(:fold, name, tuple_keys.first))
+            end
+          end
+        end
+
+        # Process unfold hash attribute
+        #
+        # :unfold transformation is added to handle unfolding during preprocessing.
+        #
+        # @api private
+        def process_unfold
+          if @preprocess
+            key = pop_keys.first
+            others = header.postprocessed
+
+            compose do |ops|
+              ops << others.map { |attr|
+                t(:map_array, t(:map_value, name, Attribute.new(attr, true).to_transproc))
+              }
+              ops << t(:map_array, t(:map_value, name, t(:insert_key, key)))
+              ops << t(:map_array, t(:reject_keys, [key] - [name]))
+              ops << t(:ungroup, name, [key])
+            end
+          end
+        end
+
+        # Process excluded attribute
+        #
+        # @api private
+        def process_exclude
+          t(:reject_keys, [name])
+        end
+
+        # Yield row proc for a given attribute if any
+        #
+        # @api private
+        def with_row_proc
+          row_proc = row_proc_from
+          yield(row_proc) if row_proc
+        end
+
+        # Build a row_proc from a given attribute
+        #
+        # This is used by embedded attribute visitors
+        #
+        # @api private
+        def row_proc_from
+          RowsProcessor.new(header).row_proc
+        end
+
+        def coercer
+          meta_coercer || type_coercer
+        end
+
+        def meta_coercer
+          @attribute.meta[:coercer]
+        end
+
+        def type_coercer
+          t(:"to_#{type}") if typed?
+        end
+
+        def attribute_type
+          @attribute.class.name.split('::').last.downcase
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/attribute.rb
+++ b/lib/rom/processor/transproc/attribute.rb
@@ -208,22 +208,33 @@ module ROM
           RowsProcessor.new(header).row_proc
         end
 
+        # Finds a proper coercer to user
+        #
+        # @api private
         def coercer
           meta_coercer || type_coercer
         end
 
+        # Coercer from attribute meta
+        #
+        # @api private
         def meta_coercer
           @attribute.meta[:coercer]
         end
 
+        # Typed coercer
+        #
+        # @api private
         def type_coercer
           t(:"to_#{type}") if typed?
         end
 
+        # Attribute class type
+        #
+        # @api private
         def attribute_type
           @attribute.class.name.split('::').last.downcase
         end
-
       end
     end
   end

--- a/lib/rom/processor/transproc/attributes_processor.rb
+++ b/lib/rom/processor/transproc/attributes_processor.rb
@@ -1,0 +1,19 @@
+require 'rom/processor/transproc/attribute'
+
+module ROM
+  class Processor
+    class Transproc < Processor
+      class AttributesProcessor
+
+        def initialize(attributes)
+          @attributes = attributes
+        end
+
+        def to_transproc
+          @attributes.map { |attr| Attribute.new(attr, true).to_transproc }
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/combine_processor.rb
+++ b/lib/rom/processor/transproc/combine_processor.rb
@@ -1,0 +1,19 @@
+require 'rom/processor/transproc/combined_attribute'
+
+module ROM
+  class Processor
+    class Transproc < Processor
+      class CombineProcessor
+        include ::Transproc::Helper
+
+        def initialize(combined)
+          @combined = combined
+        end
+
+        def to_transproc
+          t(:combine, @combined.map { |attribute| CombinedAttribute.new(attribute).to_transproc_args }) if @combined.any?
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/combine_processor.rb
+++ b/lib/rom/processor/transproc/combine_processor.rb
@@ -6,12 +6,18 @@ module ROM
       class CombineProcessor
         include ::Transproc::Helper
 
-        def initialize(combined)
-          @combined = combined
+        def initialize(header)
+          @header = header
         end
 
         def to_transproc
-          t(:combine, @combined.map { |attribute| CombinedAttribute.new(attribute).to_transproc_args }) if @combined.any?
+          t(:combine, combined.map { |attribute| CombinedAttribute.new(attribute).to_transproc_args }) if combined.any?
+        end
+
+        private
+
+        def combined
+          @header.combined
         end
       end
     end

--- a/lib/rom/processor/transproc/combined_attribute.rb
+++ b/lib/rom/processor/transproc/combined_attribute.rb
@@ -1,0 +1,29 @@
+module ROM
+  class Processor
+    class Transproc < Processor
+      class CombinedAttribute
+        def initialize(attribute)
+          @attribute = attribute
+        end
+
+        def to_transproc_args
+          [@attribute.name, @attribute.meta[:keys], children].compact
+        end
+
+        private
+
+        def children
+          has_children? ? other.map { |child| CombinedAttribute.new(child).to_transproc_args } : nil
+        end
+
+        def has_children?
+          other.any?
+        end
+
+        def other
+          @attribute.header.combined
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/postprocessor.rb
+++ b/lib/rom/processor/transproc/postprocessor.rb
@@ -1,0 +1,15 @@
+module ROM
+  class Processor
+    class Transproc < Processor
+      class Postprocessor
+        def initialize(header)
+          @header = header
+        end
+
+        def to_transproc
+          AttributesProcessor.new(@header.postprocessed).to_transproc
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/preprocessor.rb
+++ b/lib/rom/processor/transproc/preprocessor.rb
@@ -1,0 +1,15 @@
+module ROM
+  class Processor
+    class Transproc < Processor
+      class Preprocessor
+        def initialize(header)
+          @header = header
+        end
+
+        def to_transproc
+          AttributesProcessor.new(@header.preprocessed).to_transproc
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/processor/transproc/rows_processor.rb
+++ b/lib/rom/processor/transproc/rows_processor.rb
@@ -1,0 +1,56 @@
+module ROM
+  class Processor
+    class Transproc < Processor
+      class RowsProcessor
+        include ::Transproc::Composer
+
+        # @return [Proc] row-processing proc
+        #
+        # @api private
+        # attr_reader :row_proc
+        attr_reader :row_proc
+
+        def initialize(header)
+          @header = header
+          initialize_row_proc
+        end
+
+        def to_transproc
+          t(:map_array, @row_proc) if @row_proc
+        end
+
+        private
+
+        # Build row_proc
+        #
+        # This transproc function is applied to each row in a dataset
+        #
+        # @api private
+        def initialize_row_proc
+          @row_proc = compose { |ops|
+            process_header_keys(ops)
+
+            ops << t(:rename_keys, @header.mapping) if @header.aliased?
+            ops << @header.map { |attr| visit(attr) }
+            ops << t(:constructor_inject, @header.model) if @header.model
+          }
+        end
+
+        def visit(attr)
+          ROM::Processor::Transproc::Attribute.new(attr).to_transproc
+        end
+
+        # Process row_proc header keys
+        #
+        # @api private
+        def process_header_keys(ops)
+          if @header.reject_keys
+            all_keys = @header.tuple_keys + @header.non_primitives.map(&:key)
+            ops << t(:accept_keys, all_keys)
+          end
+          ops
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR doesn't add any new features it's just refactoring making Transporc processor class "A" on code climate. I used it as a refactoring practice.

Few things:
- sometimes it doesn't do exactly the same (e.g. `visit_combined` method - but the specs passes :/
- I'm not sure about so many delegates on `Transproc::Attribute` class
- sometimes it is less explicit (e.g. `process_postprocessed` method)
- I'm not sure about introducing `CombineProcessor`, `AttributesProcessor`, `Preprocessor`. I wanted all processors' to accept `header` in the initializer. But on the other hand they seems to be not necessary addition.

Please let me know what you think about it.

Codeclimate analyze: https://codeclimate.com/github/martinciu/rom/compare/transproc-processor-refactoring#ratings