### PR TITLE
ROM::Global => ROM::Environment (multi-env)

### DIFF
--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -19,9 +19,8 @@ require 'rom/commands'
 # default mapper processor using Transproc gem
 require 'rom/processor/transproc'
 
-# support for global-style setup
-require 'rom/global'
-require 'rom/setup'
+# rom environments
+require 'rom/environment'
 
 # TODO: consider to make this part optional and don't require it here
 require 'rom/setup_dsl/setup'
@@ -30,9 +29,20 @@ require 'rom/setup_dsl/setup'
 require 'rom/env'
 
 module ROM
-  extend Global
+  @environment = ROM::Environment.new
 
-  RelationRegistry = Class.new(Registry)
+  class << self
+    def method_missing(method, *args, &block)
+      if @environment.respond_to?(method)
+        @environment.__send__(method, *args, &block)
+      else
+        super
+      end
+    end
+    def respond_to_missing?(method, _include_private = false)
+      @environment.respond_to?(method) || super
+    end
+  end
 end
 
 # register core plugins

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -31,8 +31,8 @@ require 'rom/environment'
 # TODO: consider to make this part optional and don't require it here
 require 'rom/setup_dsl/setup'
 
-# env with registries
-require 'rom/env'
+# container with registries
+require 'rom/container'
 
 # register core plugins
 require 'rom/environment_plugins/auto_registration'

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -13,6 +13,7 @@ require 'rom/support/guarded_inheritance_hook'
 require 'rom/support/inheritance_hook'
 
 # core parts
+require 'rom/environment_plugin'
 require 'rom/plugin'
 require 'rom/relation'
 require 'rom/mapper'
@@ -33,6 +34,10 @@ require 'rom/setup_dsl/setup'
 # env with registries
 require 'rom/env'
 
+# register core plugins
+require 'rom/environment_plugins/auto_registration'
+require 'rom/plugins/relation/registry_reader'
+
 module ROM
   extend Global
 
@@ -51,15 +56,11 @@ module ROM
       @environment.respond_to?(method) || super
     end
   end
+
+  plugins do
+    register :auto_registration, ROM::EnvironmentPlugins::AutoRegistration, type: :environment
+    register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
+  end
+
+  use :auto_registration
 end
-
-# register core plugins
-require 'rom/plugins/relation/registry_reader'
-
-ROM.plugins do
-  register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
-end
-
-ROM::Relation.on(:inherited) { |relation| ROM.register_relation(relation) }
-ROM::Command.on(:inherited) { |command| ROM.register_command(command) }
-ROM::Mapper.on(:inherited) { |mapper| ROM.register_mapper(mapper) }

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -9,6 +9,8 @@ require 'rom/support/registry'
 require 'rom/support/options'
 require 'rom/support/class_macros'
 require 'rom/support/class_builder'
+require 'rom/support/guarded_inheritance_hook'
+require 'rom/support/inheritance_hook'
 
 # core parts
 require 'rom/plugin'
@@ -51,3 +53,6 @@ require 'rom/plugins/relation/registry_reader'
 ROM.plugins do
   register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
 end
+ROM::Relation.on(:inherited) { |relation| ROM.register_relation(relation) }
+ROM::Command.on(:inherited) { |command| ROM.register_command(command) }
+ROM::Mapper.on(:inherited) { |mapper| ROM.register_mapper(mapper) }

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -21,6 +21,9 @@ require 'rom/commands'
 # default mapper processor using Transproc gem
 require 'rom/processor/transproc'
 
+# rom Global
+require 'rom/global'
+
 # rom environments
 require 'rom/environment'
 
@@ -31,6 +34,8 @@ require 'rom/setup_dsl/setup'
 require 'rom/env'
 
 module ROM
+  extend Global
+
   @environment = ROM::Environment.new
 
   class << self
@@ -41,6 +46,7 @@ module ROM
         super
       end
     end
+
     def respond_to_missing?(method, _include_private = false)
       @environment.respond_to?(method) || super
     end
@@ -53,6 +59,7 @@ require 'rom/plugins/relation/registry_reader'
 ROM.plugins do
   register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
 end
+
 ROM::Relation.on(:inherited) { |relation| ROM.register_relation(relation) }
 ROM::Command.on(:inherited) { |command| ROM.register_command(command) }
 ROM::Mapper.on(:inherited) { |mapper| ROM.register_mapper(mapper) }

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -61,6 +61,4 @@ module ROM
     register :auto_registration, ROM::EnvironmentPlugins::AutoRegistration, type: :environment
     register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
   end
-
-  use :auto_registration
 end

--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -6,6 +6,7 @@ module ROM
   # @private
   class Command < Commands::Abstract
     extend ClassMacros
+    extend ROM::Support::GuardedInheritanceHook
 
     include Equalizer.new(:relation, :options)
 
@@ -14,15 +15,6 @@ module ROM
     input Hash
     validator proc {}
     result :many
-
-    # Registers Create/Update/Delete descendant classes during the setup phase
-    #
-    # @api private
-    def self.inherited(klass)
-      super
-      return if klass.superclass == ROM::Command
-      ROM.register_command(klass)
-    end
 
     # Return adapter specific sub-class based on the adapter identifier
     #

--- a/lib/rom/commands/graph/class_interface.rb
+++ b/lib/rom/commands/graph/class_interface.rb
@@ -7,9 +7,9 @@ module ROM
       module ClassInterface
         # Build a command graph recursively
         #
-        # This is used by `Env#command` when array with options is passed in
+        # This is used by `Container#command` when array with options is passed in
         #
-        # @param [Registry] registry The command registry from env
+        # @param [Registry] registry The command registry from container
         # @param [Array] options The options array
         # @param [Array] path The path for input evaluator proc
         #

--- a/lib/rom/container.rb
+++ b/lib/rom/container.rb
@@ -6,7 +6,7 @@ module ROM
   # Exposes defined gateways, relations and mappers
   #
   # @api public
-  class Env
+  class Container
     extend Deprecations
     include Equalizer.new(:gateways, :relations, :mappers, :commands)
 

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -1,40 +1,17 @@
 require 'rom/setup'
 require 'rom/repository'
-require 'rom/plugin_registry'
-
-require 'rom/environment/plugin_dsl'
 
 module ROM
   # Globally accessible public interface exposed via ROM module
   #
   # @api public
   class Environment
-    # @api private
-    def initialize
-      @adapters = {}
-      @gateways = {}
-      @plugin_registry = PluginRegistry.new
-    end
-    # An internal adapter identifier => adapter module map used by setup
-    #
-    # @return [Hash<Symbol=>Module>]
-    #
-    # @api private
-    attr_reader :adapters
-
     # An internal gateway => identifier map used by the setup
     #
     # @return [Hash]
     #
     # @api private
     attr_reader :gateways
-
-    # An internal identifier => plugin map used by the setup
-    #
-    # @return [Hash]
-    #
-    # @api private
-    attr_reader :plugin_registry
 
     # Setup object created during env setup phase
     #
@@ -51,6 +28,16 @@ module ROM
     #
     # @api public
     attr_reader :env
+
+    # @api private
+    def initialize
+      @gateways = {}
+    end
+
+    # @api private
+    def adapters
+      ROM.adapters
+    end
 
     # Starts the setup process for relations, mappers and commands.
     #
@@ -172,19 +159,6 @@ module ROM
       boot.mappers(*args, &block)
     end
 
-    # Global plugin setup DSL
-    #
-    # @example
-    #   rom = ROM::Environment.new
-    #   rom.plugins do
-    #     register :publisher, Plugin::Publisher, type: :command
-    #   end
-    #
-    # @example
-    def plugins(*args, &block)
-      PluginDSL.new(plugin_registry, *args, &block)
-    end
-
     # Finalize the setup and store default global env under ROM.env
     #
     # @example
@@ -202,19 +176,6 @@ module ROM
       self
     ensure
       @boot = nil
-    end
-
-    # Register adapter namespace under a specified identifier
-    #
-    # @param [Symbol] identifier
-    # @param [Class,Module] adapter
-    #
-    # @return [self]
-    #
-    # @api private
-    def register_adapter(identifier, adapter)
-      adapters[identifier] = adapter
-      self
     end
 
     # Relation subclass registration during setup phase

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -39,6 +39,18 @@ module ROM
       ROM.adapters
     end
 
+    # @api private
+    def plugin_registry
+      ROM.plugin_registry
+    end
+
+    # Apply
+    #
+    # @api public
+    def use(plugin)
+      plugin_registry.environment.fetch(plugin).apply_to(self)
+    end
+
     # Starts the setup process for relations, mappers and commands.
     #
     # @overload setup(type, *args)

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -13,7 +13,7 @@ module ROM
     # @api private
     attr_reader :gateways
 
-    # Setup object created during env setup phase
+    # Setup object created during setup phase
     #
     # This gets set to nil after setup is finalized
     #
@@ -22,12 +22,13 @@ module ROM
     # @api private
     attr_reader :boot
 
-    # Return global default ROM environment configured by the setup
+    # Return ROM container configured by the setup
     #
-    # @return [Env]
+    # @return [Container]
     #
     # @api public
-    attr_reader :env
+    attr_reader :container
+    alias_method :env, :container
 
     # @api private
     def initialize
@@ -104,8 +105,8 @@ module ROM
     #     end
     #   end
     #
-    #   rom.finalize # builds the env
-    #   rom.env # returns the env registry
+    #   rom.finalize # builds the container
+    #   rom.container # returns the container registry
     #
     # @api public
     def setup(*args, &block)
@@ -171,20 +172,21 @@ module ROM
       boot.mappers(*args, &block)
     end
 
-    # Finalize the setup and store default global env under ROM.env
+    # Finalize the setup and store default global container under 
+    # ROM::Environmrnt#container
     #
     # @example
     #   rom = ROM::Environment.new
     #   rom.setup(:memory)
     #   rom.finalize # => rom
     #   rom.boot # => nil
-    #   rom.env # => the env
+    #   rom.container # => the container
     #
     # @return [ROM]
     #
     # @api public
     def finalize
-      @env = boot.finalize
+      @container = boot.finalize
       self
     ensure
       @boot = nil

--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -2,24 +2,19 @@ require 'rom/setup'
 require 'rom/repository'
 require 'rom/plugin_registry'
 
-require 'rom/global/plugin_dsl'
+require 'rom/environment/plugin_dsl'
 
 module ROM
   # Globally accessible public interface exposed via ROM module
   #
   # @api public
-  module Global
-    # Set base global registries in ROM constant
-    #
+  class Environment
     # @api private
-    def self.extended(rom)
-      super
-
-      rom.instance_variable_set('@adapters', {})
-      rom.instance_variable_set('@gateways', {})
-      rom.instance_variable_set('@plugin_registry', PluginRegistry.new)
+    def initialize
+      @adapters = {}
+      @gateways = {}
+      @plugin_registry = PluginRegistry.new
     end
-
     # An internal adapter identifier => adapter module map used by setup
     #
     # @return [Hash<Symbol=>Module>]
@@ -79,37 +74,39 @@ module ROM
     #
     # @example
     #   # Use the in-memory adapter shipped with ROM as the default gateway.
-    #   env = ROM.setup(:memory, 'memory://test')
+    #   rom = ROM::Environment.new
+    #   env = rom.setup(:memory, 'memory://test')
     #   # Use `rom-sql` with an in-memory sqlite database as default gateway.
-    #   ROM.setup(:sql, 'sqlite::memory')
+    #   rom.setup(:sql, 'sqlite::memory')
     #   # Registers a `default` and a `warehouse` gateway.
-    #   env = ROM.setup(
+    #   env = rom.setup(
     #     default: [:sql, 'sqlite::memory'],
     #     warehouse: [:sql, 'postgres://localhost/warehouse']
     #   )
     #
     # @example A full environment
     #
-    #   ROM.setup(:memory, 'memory://test')
+    #   rom = ROM::Environment.new
+    #   rom.setup(:memory, 'memory://test')
     #
-    #   ROM.relation(:users) do
+    #   rom.relation(:users) do
     #     # ...
     #   end
     #
-    #   ROM.mappers do
+    #   rom.mappers do
     #     define(:users) do
     #       # ...
     #     end
     #   end
     #
-    #   ROM.commands(:users) do
+    #   rom.commands(:users) do
     #     define(:create) do
     #       # ...
     #     end
     #   end
     #
-    #   ROM.finalize # builds the env
-    #   ROM.env # returns the env registry
+    #   rom.finalize # builds the env
+    #   rom.env # returns the env registry
     #
     # @api public
     def setup(*args, &block)
@@ -127,9 +124,10 @@ module ROM
     # Global relation setup DSL
     #
     # @example
-    #   ROM.setup(:memory)
+    #   rom = ROM::Environment.new
+    #   rom.setup(:memory)
     #
-    #   ROM.relation(:users) do
+    #   rom.relation(:users) do
     #     def by_name(name)
     #       restrict(name: name)
     #     end
@@ -143,9 +141,10 @@ module ROM
     # Global commands setup DSL
     #
     # @example
-    #   ROM.setup(:memory)
+    #   rom = ROM::Environment.new
+    #   rom.setup(:memory)
     #
-    #   ROM.commands(:users) do
+    #   rom.commands(:users) do
     #     define(:create) do
     #       # ..
     #     end
@@ -159,9 +158,10 @@ module ROM
     # Global mapper setup DSL
     #
     # @example
-    #   ROM.setup(:memory)
+    #   rom = ROM::Environment.new
+    #   rom.setup(:memory)
     #
-    #   ROM.mappers do
+    #   rom.mappers do
     #     define(:uses) do
     #       # ..
     #     end
@@ -175,7 +175,8 @@ module ROM
     # Global plugin setup DSL
     #
     # @example
-    #   ROM.plugins do
+    #   rom = ROM::Environment.new
+    #   rom.plugins do
     #     register :publisher, Plugin::Publisher, type: :command
     #   end
     #
@@ -187,10 +188,11 @@ module ROM
     # Finalize the setup and store default global env under ROM.env
     #
     # @example
-    #   ROM.setup(:memory)
-    #   ROM.finalize # => ROM
-    #   ROM.boot # => nil
-    #   ROM.env # => the env
+    #   rom = ROM::Environment.new
+    #   rom.setup(:memory)
+    #   rom.finalize # => rom
+    #   rom.boot # => nil
+    #   rom.env # => the env
     #
     # @return [ROM]
     #

--- a/lib/rom/environment/plugin_dsl.rb
+++ b/lib/rom/environment/plugin_dsl.rb
@@ -1,5 +1,5 @@
 module ROM
-  module Global
+  class Environment
     # plugin registration DSL
     #
     # @private

--- a/lib/rom/environment_plugin.rb
+++ b/lib/rom/environment_plugin.rb
@@ -1,0 +1,17 @@
+require 'rom/plugin_base'
+
+module ROM
+  # EnvironmentPlugin is a simple object used to store environment plugin configurations
+  #
+  # @private
+  class EnvironmentPlugin < PluginBase
+    # Apply this plugin to the provided environment
+    #
+    # @param [ROM::Environment] environment
+    #
+    # @api private
+    def apply_to(environment)
+      mod.apply(environment)
+    end
+  end
+end

--- a/lib/rom/environment_plugins/auto_registration.rb
+++ b/lib/rom/environment_plugins/auto_registration.rb
@@ -1,0 +1,17 @@
+module ROM
+  module EnvironmentPlugins
+    # Automatically registers relations, mappers and commands as they are defined
+    #
+    # For now this plugin is always enabled
+    #
+    # @api public
+    module AutoRegistration
+      # @api private
+      def self.apply(environment)
+        ROM::Relation.on(:inherited) { |relation| environment.register_relation(relation) }
+        ROM::Command.on(:inherited) { |command| environment.register_command(command) }
+        ROM::Mapper.on(:inherited) { |mapper| environment.register_mapper(mapper) }
+      end
+    end
+  end
+end

--- a/lib/rom/global.rb
+++ b/lib/rom/global.rb
@@ -1,0 +1,58 @@
+require 'rom/plugin_registry'
+require 'rom/global/plugin_dsl'
+
+module ROM
+  # Globally accessible public interface exposed via ROM module
+  #
+  # @api public
+  module Global
+    # Set base global registries in ROM constant
+    #
+    # @api private
+    def self.extended(rom)
+      super
+
+      rom.instance_variable_set('@adapters', {})
+      rom.instance_variable_set('@plugin_registry', PluginRegistry.new)
+    end
+
+    # An internal adapter identifier => adapter module map used by setup
+    #
+    # @return [Hash<Symbol=>Module>]
+    #
+    # @api private
+    attr_reader :adapters
+
+    # An internal identifier => plugin map used by the setup
+    #
+    # @return [Hash]
+    #
+    # @api private
+    attr_reader :plugin_registry
+
+    # Global plugin setup DSL
+    #
+    # @example
+    #   ROM.plugins do
+    #     register :publisher, Plugin::Publisher, type: :command
+    #   end
+    #
+    # @example
+    def plugins(*args, &block)
+      PluginDSL.new(plugin_registry, *args, &block)
+    end
+
+    # Register adapter namespace under a specified identifier
+    #
+    # @param [Symbol] identifier
+    # @param [Class,Module] adapter
+    #
+    # @return [self]
+    #
+    # @api private
+    def register_adapter(identifier, adapter)
+      adapters[identifier] = adapter
+      self
+    end
+  end
+end

--- a/lib/rom/global/plugin_dsl.rb
+++ b/lib/rom/global/plugin_dsl.rb
@@ -1,5 +1,5 @@
 module ROM
-  class Environment
+  module Global
     # plugin registration DSL
     #
     # @private

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -5,6 +5,7 @@ module ROM
   #
   # @private
   class Mapper
+    extend ROM::Support::InheritanceHook
     include DSL
     include Equalizer.new(:transformers, :header)
 
@@ -24,14 +25,6 @@ module ROM
     #
     # @api private
     attr_reader :header
-
-    # Register suclasses during setup phase
-    #
-    # @api private
-    def self.inherited(klass)
-      super
-      ROM.register_mapper(klass)
-    end
 
     # @return [Hash] registered processors
     #

--- a/lib/rom/plugin.rb
+++ b/lib/rom/plugin.rb
@@ -1,27 +1,13 @@
+require 'rom/plugin_base'
+
 module ROM
   # Plugin is a simple object used to store plugin configurations
   #
   # @private
-  class Plugin
-    # @return [Module] a module representing the plugin
-    #
-    # @api private
-    attr_reader :mod
-
-    # @return [Hash] configuration options
-    #
-    # @api private
-    attr_reader :options
-
-    # @api private
-    def initialize(mod, options)
-      @mod      = mod
-      @options  = options
-    end
-
+  class Plugin < PluginBase
     # Apply this plugin to the provided class
     #
-    # @param klass [Class]
+    # @param [Class] klass
     #
     # @api private
     def apply_to(klass)

--- a/lib/rom/plugin_base.rb
+++ b/lib/rom/plugin_base.rb
@@ -1,0 +1,31 @@
+module ROM
+  # Abstract plugin base
+  #
+  # @private
+  class PluginBase
+    # @return [Module] a module representing the plugin
+    #
+    # @api private
+    attr_reader :mod
+
+    # @return [Hash] configuration options
+    #
+    # @api private
+    attr_reader :options
+
+    # @api private
+    def initialize(mod, options)
+      @mod      = mod
+      @options  = options
+    end
+
+    # Apply this plugin to the provided class
+    #
+    # @param [Mixed] base
+    #
+    # @api private
+    def apply_to(base)
+      raise NotImplementedError, "#{self.class}#apply_to not implemented"
+    end
+  end
+end

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -20,6 +20,7 @@ module ROM
   # @api public
   class Relation
     extend ClassInterface
+    extend ROM::Support::GuardedInheritanceHook
 
     include Options
     include Equalizer.new(:dataset)

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -12,10 +12,10 @@ module ROM
   # however, is considered private and should not be used outside of the
   # relation instance.
   #
-  # ROM builds sub-classes of this class for every relation defined in the env
-  # for easy inspection and extensibility - every gateway can provide extensions
-  # for those sub-classes but there is always a vanilla relation instance stored
-  # in the schema registry.
+  # ROM builds sub-classes of this class for every relation defined in the 
+  # environment for easy inspection and extensibility - every gateway can
+  # provide extensions for those sub-classes but there is always a vanilla
+  # relation instance stored in the schema registry.
   #
   # @api public
   class Relation

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -43,7 +43,7 @@ module ROM
           # A set with public method names that return "virtual" relations
           #
           # Only those methods are exposed directly on relations return by
-          # Env#relation interface
+          # Container#relation interface
           #
           # @return [Set]
           #
@@ -188,7 +188,7 @@ module ROM
       # Hook to finalize a relation after its instance was created
       #
       # @api private
-      def finalize(_env, _relation)
+      def finalize(_container, _relation)
         # noop
       end
     end

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -89,8 +89,6 @@ module ROM
             self.class.gateway
           end
         end
-
-        ROM.register_relation(klass)
       end
 
       # Return adapter-specific relation subclass

--- a/lib/rom/relation_registry.rb
+++ b/lib/rom/relation_registry.rb
@@ -1,0 +1,4 @@
+module ROM
+  class RelationRegistry < Registry
+  end
+end

--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -7,7 +7,7 @@ module ROM
   # @api public
   class Setup
     extend Deprecations
-    include Equalizer.new(:gateways, :env)
+    include Equalizer.new(:gateways, :container)
 
     # @return [Hash] configured gateways
     #
@@ -39,10 +39,11 @@ module ROM
     # @api private
     attr_reader :command_classes
 
-    # @return [Env] finalized env after setup phase is over
+    # @return [Conainer] finalized container after setup phase is over
     #
     # @api private
-    attr_reader :env
+    attr_reader :container
+    alias_method :env, :container
 
     # @api private
     def initialize(gateways, default_adapter = nil)
@@ -51,21 +52,21 @@ module ROM
       @relation_classes = []
       @mapper_classes = []
       @command_classes = []
-      @env = nil
+      @container = nil
     end
 
     # Finalize the setup
     #
-    # @return [Env] frozen env with access to gateways, relations,
-    #                mappers and commands
+    # @return [Container] frozen container with access to gateways, 
+    #                relations, mappers and commands
     #
     # @api public
     def finalize
-      raise EnvAlreadyFinalizedError if env
+      raise EnvAlreadyFinalizedError if container
       finalize = Finalize.new(
         gateways, relation_classes, mapper_classes, command_classes
       )
-      @env = finalize.run!
+      @container = finalize.run!
     end
 
     # Return gateway identified by name

--- a/lib/rom/setup/finalize.rb
+++ b/lib/rom/setup/finalize.rb
@@ -7,11 +7,11 @@ require 'rom/relation_registry'
 require 'rom/command_registry'
 require 'rom/mapper_registry'
 
-require 'rom/env'
+require 'rom/container'
 
 module ROM
   class Setup
-    # This giant builds an environment using defined classes for core parts of ROM
+    # This giant builds an container using defined classes for core parts of ROM
     #
     # It is used by the setup object after it's done gathering class definitions
     #
@@ -44,7 +44,7 @@ module ROM
       #
       # This creates relations, mappers and commands
       #
-      # @return [Env]
+      # @return [Container]
       #
       # @api private
       def run!
@@ -54,7 +54,7 @@ module ROM
         mappers = load_mappers
         commands = load_commands(relations)
 
-        Env.new(gateways, relations, mappers, commands)
+        Container.new(gateways, relations, mappers, commands)
       end
 
       private

--- a/lib/rom/setup/finalize.rb
+++ b/lib/rom/setup/finalize.rb
@@ -3,6 +3,7 @@ require 'rom/mapper'
 require 'rom/command'
 
 require 'rom/support/registry'
+require 'rom/relation_registry'
 require 'rom/command_registry'
 require 'rom/mapper_registry'
 

--- a/lib/rom/support/guarded_inheritance_hook.rb
+++ b/lib/rom/support/guarded_inheritance_hook.rb
@@ -1,0 +1,21 @@
+require 'rom/support/publisher'
+
+module ROM
+  module Support
+    module GuardedInheritanceHook
+      def self.extended(base)
+        base.class_eval <<-RUBY
+          class << self
+            include ROM::Support::Publisher
+
+            def inherited(klass)
+              super
+              return if klass.superclass == #{base}
+              #{base}.__send__(:broadcast, :inherited, klass)
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/lib/rom/support/inheritance_hook.rb
+++ b/lib/rom/support/inheritance_hook.rb
@@ -1,0 +1,20 @@
+require 'rom/support/publisher'
+
+module ROM
+  module Support
+    module InheritanceHook
+      def self.extended(base)
+        base.class_eval <<-RUBY
+          class << self
+            include ROM::Support::Publisher
+
+            def inherited(klass)
+              super
+              #{base}.__send__(:broadcast, :inherited, klass)
+            end
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/lib/rom/support/publisher.rb
+++ b/lib/rom/support/publisher.rb
@@ -1,0 +1,11 @@
+require 'wisper'
+
+module ROM
+  module Support
+    module Publisher
+      def self.included(klass)
+        klass.__send__(:include, Wisper::Publisher)
+      end
+    end
+  end
+end

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'transproc', '~> 0.3', '>= 0.3.0'
   gem.add_runtime_dependency 'equalizer', '~> 0.0', '>= 0.0.9'
+  gem.add_runtime_dependency 'wisper', '~> 1.6', '>= 1.6.0'
 
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rspec', '~> 3.3'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,3 +46,5 @@ RSpec.configure do |config|
     ConstantLeakFinder.find(example)
   end
 end
+
+ROM.use :auto_registration

--- a/spec/unit/rom/container_spec.rb
+++ b/spec/unit/rom/container_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ROM::Env do
+describe ROM::Container do
   include_context 'users and tasks'
 
   before do
@@ -75,7 +75,7 @@ describe ROM::Env do
       expect {
         result = rom.read(:users) { |r| r.by_name('Jane') }.as(:name_list)
         expect(result.call).to match_array([{ name: 'Jane' }])
-      }.to output(/^ROM::Env#read is deprecated/).to_stderr
+      }.to output(/^ROM::Container#read is deprecated/).to_stderr
     end
   end
 

--- a/spec/unit/rom/setup_spec.rb
+++ b/spec/unit/rom/setup_spec.rb
@@ -82,7 +82,7 @@ describe ROM::Setup do
       it 'resets boot to nil' do
         setup = ROM.setup(:memory)
 
-        allow(setup).to receive(:env).and_raise(StandardError)
+        allow(setup).to receive(:container).and_raise(StandardError)
 
         expect { ROM.finalize }.to raise_error(StandardError)
         expect(ROM.boot).to be(nil)


### PR DESCRIPTION
This PR removes the auto-registration on inherited hooks and is a step towards removing the ROM global interface, allowing for multi-env and removing a lot of the global state. Auto-registration can still be achieved as @krisleech's `wisper` broadcasts `inherited` messages on the relevant class (`ROM::Relation`, `ROM::Mapper`, `ROM::Command`) when inherited.

```ruby
rom = ROM::Environment.new
rom.setup(:memory)

class Users < ROM::Memory::Relation
  dataset :users
end

class UserMapper < ROM::Mapper
  relation :users
  register_as :entity
  model Struct.new(:id, :name)
  attribute :id
  attribute :name
end

class CreateUser < ROM::Memory::Commands::Create
  relation :users
  register_as :create
  result :one
end

# Define relations/mappers/commands
rom.register_relation(Users)
rom.register_mapper(UserMapper)
rom.register_command(CreateUser)

memory1 = rom.finalize.env

rom = ROM::Environment.new
rom.setup(:memory)

# Define relations/mappers/commands

rom.register_relation(Users)
rom.register_mapper(UserMapper)
rom.register_command(CreateUser)

memory2 = rom.finalize.env

memory1.command(:users).create.call(id: 1, email: 'memory1@memory1.com')
memory2.command(:users).create.call(id: 2, email: 'memory2@memory2.com')
memory1.relation(:users).to_a
# => [{:id=>1, :email=>"memory1@memory1.com"}]
memory2.relation(:users).to_a
# => [{:id=>2, :email=>"memory2@memory2.com"}]
```
This gives much more freedom to the user as they can create multiple environments which will work completely independently of each other.

Currently the `ROM` module delegates to an instance `ROM::Environment` on `method_missing` for registering relations, mappers and commands - the idea is to add deprecation warnings when this happens to give people time to make the transition.

~~Without `ROM` delegating to the environment instance, `ROM::Relation[:adapter]` and friends will no longer work, as the adapter won't be registered, we could return a wrapper to lazily evaluate this when the class is registered. In addition to this, `ROM.register_adapter` will no longer be relevant, and it would be down to the user or integration to register the adapter, I like this approach as the user has the freedom to specify the identifier under which the adapter will be registered, but feel free to shout loudly if you disagree.~~

See also #289, which adds environment plugins, and an `auto_register` plugin which will register relations, mappers and commands with an environment that it is applied on as they are created.