### PR TITLE
README: link Guides properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ full power of your datastore.
 Learn more:
 
 * [Introduction](http://rom-rb.org/introduction/)
-* [Guides](http://rom-rb.org/introduction/)
+* [Guides](http://rom-rb.org/guides/)
 * [Tutorials](http://rom-rb.org/tutorials/)
 
 ## Adapters


### PR DESCRIPTION
The current ‘Guides’ link in the README links to the introduction; this makes it link to guides. :)