### PR TITLE
[WIP] Raise error when registering after finalization.

### DIFF
--- a/lib/rom/environment.rb
+++ b/lib/rom/environment.rb
@@ -197,8 +197,23 @@ module ROM
       boot.mappers(*args, &block)
     end
 
+    # Null boot object installed upon finalization.
+    class FinalizedBoot
+      def register_relation(klass)
+        raise ROM::EnvAlreadyFinalizedError
+      end
+
+      def register_mapper(klass)
+        raise ROM::EnvAlreadyFinalizedError
+      end
+
+      def register_command(klass)
+        raise ROM::EnvAlreadyFinalizedError
+      end
+    end
+
     # Finalize the setup and store default global container under
-    # ROM::Environmrnt#container
+    # ROM::Environment#container
     #
     # @example
     #   rom = ROM::Environment.new
@@ -214,7 +229,7 @@ module ROM
       @container = boot.finalize
       self
     ensure
-      @boot = nil
+      @boot = FinalizedBoot.new
     end
 
     # Relation subclass registration during setup phase

--- a/spec/unit/rom/setup_spec.rb
+++ b/spec/unit/rom/setup_spec.rb
@@ -183,6 +183,19 @@ describe ROM::Setup do
         expect { ROM.finalize }.to raise_error(StandardError)
         expect(ROM.boot).to be(nil)
       end
+
+      it 'raises an error when registering relations afterward' do
+        ROM.setup(:memory).finalize
+
+        # I am not sure what this message should say
+        error_message_pattern = /.*/
+
+        expect {
+          Class.new(ROM::Relation[:memory]) do
+            register_as :registered_after_finalize
+          end
+        }.to raise_error(ROM::EnvAlreadyFinalizedError, error_message_pattern)
+      end
     end
 
     context 'empty setup' do


### PR DESCRIPTION
I hit the Gitter room last night after spending some time confused about the silent dropping of registrations after `ROM.env.finalize` was called.

I poked in some code that I thought might raise an exception like @solnic described. It doesn’t seem to address my case (at least as I expressed it in my spec) and it does trigger a number of failures in other specs.

So please peek at this failing state of the code and provide guidance on where this could go. I’m happy to update this with improvements or a better approach. I can also update the other failing specs if it turns out that this is right and they’re wrong somehow.