### PR TITLE
[REPRO] set up failing acceptance spec for update commands

### DIFF
--- a/lib/rom/commands/abstract.rb
+++ b/lib/rom/commands/abstract.rb
@@ -79,7 +79,7 @@ module ROM
       # @api public
       def curry(*args)
         if curry_args.empty? && args.first.is_a?(Graph::InputEvaluator)
-          Lazy.new(self, args.first)
+          Lazy.new(self, *args)
         else
           self.class.build(relation, options.merge(curry_args: args))
         end

--- a/lib/rom/commands/abstract.rb
+++ b/lib/rom/commands/abstract.rb
@@ -79,7 +79,7 @@ module ROM
       # @api public
       def curry(*args)
         if curry_args.empty? && args.first.is_a?(Graph::InputEvaluator)
-          Lazy.new(self, *args)
+          Lazy[self].new(self, *args)
         else
           self.class.build(relation, options.merge(curry_args: args))
         end

--- a/lib/rom/commands/graph/class_interface.rb
+++ b/lib/rom/commands/graph/class_interface.rb
@@ -37,7 +37,7 @@ module ROM
             if cmd_opts.is_a?(Hash)
               cmd_opts.to_a.first
             else
-              [cmd_opts, {}]
+              [cmd_opts]
             end
 
           command = registry[relation][name]

--- a/lib/rom/commands/graph/class_interface.rb
+++ b/lib/rom/commands/graph/class_interface.rb
@@ -24,7 +24,7 @@ module ROM
 
         # @api private
         def build_command(registry, spec, other, path)
-          name, nodes = other
+          cmd_opts, nodes = other
 
           key, relation =
             if spec.is_a?(Hash)
@@ -33,11 +33,18 @@ module ROM
               [spec, spec]
             end
 
+          name, opts =
+            if cmd_opts.is_a?(Hash)
+              cmd_opts.to_a.first
+            else
+              [cmd_opts, {}]
+            end
+
           command = registry[relation][name]
           tuple_path = Array[*path] << key
           input_proc = InputEvaluator.build(tuple_path, nodes)
 
-          command = command.with(input_proc)
+          command = command.with(input_proc, opts)
 
           if nodes
             if nodes.all? { |node| node.is_a?(Array) }

--- a/lib/rom/commands/lazy.rb
+++ b/lib/rom/commands/lazy.rb
@@ -50,13 +50,15 @@ module ROM
         size = args.size
 
         if size > 1 && last.is_a?(Array)
-          last.map.with_index do |item, index|
-            input = evaluator.call(first, index)
+          last.map.with_index do |parent, index|
+            children = evaluator.call(first, index)
 
             if command.is_a?(Create)
-              command.call(input, item)
+              command.call(children, parent)
             elsif command.is_a?(Update)
-              raise NotImplementedError
+              children.map do |child|
+                restricted_command[command, parent, child].call(child, parent)
+              end
             end
           end.reduce(:concat)
         else

--- a/lib/rom/commands/lazy.rb
+++ b/lib/rom/commands/lazy.rb
@@ -67,7 +67,8 @@ module ROM
                 command.public_send(view, *view_args(first, index)).call
               end
             else
-              raise NotImplementedError
+              restricted_command = command.public_send(view, *view_args(first))
+              restricted_command.call
             end
           end
         end

--- a/lib/rom/commands/lazy/create.rb
+++ b/lib/rom/commands/lazy/create.rb
@@ -1,0 +1,23 @@
+module ROM
+  module Commands
+    class Lazy
+      class Create < Lazy
+        def call(*args)
+          first = args.first
+          last = args.last
+          size = args.size
+
+          if size > 1 && last.is_a?(Array)
+            last.map.with_index do |parent, index|
+              children = evaluator.call(first, index)
+              command_proc[command, parent, children].call(children, parent)
+            end.reduce(:concat)
+          else
+            input = evaluator.call(first)
+            command.call(input, *args[1..size-1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/commands/lazy/delete.rb
+++ b/lib/rom/commands/lazy/delete.rb
@@ -1,0 +1,27 @@
+module ROM
+  module Commands
+    class Lazy
+      class Delete < Lazy
+        def call(*args)
+          first = args.first
+          last = args.last
+          size = args.size
+
+          if size > 1 && last.is_a?(Array)
+            raise NotImplementedError
+          else
+            input = evaluator.call(first)
+
+            if input.is_a?(Array)
+              input.map do |item|
+                command_proc[command, *(size > 1 ? [last, item] : [input])].call
+              end
+            else
+              command_proc[command, input].call
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/commands/lazy/update.rb
+++ b/lib/rom/commands/lazy/update.rb
@@ -1,0 +1,34 @@
+module ROM
+  module Commands
+    class Lazy
+      class Update < Lazy
+        def call(*args)
+          first = args.first
+          last = args.last
+          size = args.size
+
+          if size > 1 && last.is_a?(Array)
+            last.map.with_index do |parent, index|
+              children = evaluator.call(first, index)
+
+              children.map do |child|
+                command_proc[command, parent, child].call(child, parent)
+              end
+            end.reduce(:concat)
+          else
+            input = evaluator.call(first)
+
+            if input.is_a?(Array)
+              input.map.with_index do |item, index|
+                command_proc[command, last, item].call(item, *args[1..size-1])
+              end
+            else
+              command_proc[command, *(size > 1 ? [last, input] : [input])]
+                .call(input, *args[1..size-1])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/commands/graph_spec.rb
+++ b/spec/integration/commands/graph_spec.rb
@@ -218,15 +218,15 @@ describe 'Building up a command graph for nested input' do
     update = rom.command([
       { user: :users },
       [
-        { update: [:by_name, ['user.name']] },
+        { update: -> cmd, user { cmd.by_name(user[:name]) } },
         [
           [
             { completed: :tasks },
-            [{ complete: [:by_user_and_title, ['user.name', 'user.tasks.title']] }]
+            [{ complete: -> cmd, user, task { cmd.by_user_and_title(user[:name], task[:title]) } }]
           ],
           [
             :tasks,
-            [{ update: [:by_user, ['user.name']] }]
+            [{ update: -> cmd, user, task { cmd.by_user_and_title(user[:name], task[:title]) } }]
           ]
         ]
       ]

--- a/spec/unit/rom/commands/lazy_spec.rb
+++ b/spec/unit/rom/commands/lazy_spec.rb
@@ -12,7 +12,11 @@ describe ROM::Commands::Lazy do
   let(:evaluator) { -> input { input[:user] } }
 
   before do
-    setup.relation(:tasks)
+    setup.relation(:tasks) do
+      def by_title(title)
+        restrict(title: title)
+      end
+    end
 
     setup.relation(:users) do
       def by_name(name)
@@ -34,14 +38,16 @@ describe ROM::Commands::Lazy do
   end
 
   describe '#call' do
-    subject(:command) { ROM::Commands::Lazy.new(create_user, evaluator) }
+    context 'with a create command' do
+      subject(:command) { ROM::Commands::Lazy.new(create_user, evaluator) }
 
-    it 'evaluates the input and calls command' do
-      command.call(user)
+      it 'evaluates the input and calls command' do
+        command.call(user)
 
-      expect(rom.relation(:users)).to match_array([
-        { name: 'Jane' }
-      ])
+        expect(rom.relation(:users)).to match_array([
+          { name: 'Jane' }
+        ])
+      end
     end
   end
 
@@ -76,7 +82,7 @@ describe ROM::Commands::Lazy do
       ])
     end
 
-    it 'return original response if it was not a command' do
+    it 'returns original response if it was not a command' do
       response = command.result
       expect(response).to be(:many)
     end

--- a/spec/unit/rom/commands/lazy_spec.rb
+++ b/spec/unit/rom/commands/lazy_spec.rb
@@ -197,6 +197,55 @@ describe ROM::Commands::Lazy do
       end
     end
 
+    context 'with an update command for many parents and their children' do
+      subject(:command) do
+        ROM::Commands::Lazy.new(
+          update_task,
+          evaluator,
+          [:by_user_and_title, ['users.name', 'users.tasks.title']]
+        )
+      end
+
+      let(:evaluator) { -> input, index { input[:users][index][:tasks] } }
+
+      let(:input) do
+        { users: [
+          {
+            name: 'Jane',
+            tasks: [
+              { title: 'Jane Task One', priority: 1 },
+              { title: 'Jane Task Two', priority: 2 }
+            ]
+          },
+          {
+            name: 'Joe',
+            tasks: [{ title: 'Joe Task One', priority: 1 }]
+          }
+        ]}
+      end
+
+      before do
+        create_user[name: 'Jane']
+        create_user[name: 'Joe']
+
+        create_task[user: 'Jane', title: 'Jane Task One']
+        create_task[user: 'Jane', title: 'Jane Task Two']
+        create_task[user: 'Joe', title: 'Joe Task One']
+
+        pending 'not implemented yet'
+      end
+
+      it 'evaluates the input and calls its command' do
+        command.call(input, input[:users])
+
+        expect(rom.relation(:tasks)).to match_array([
+          { user: 'Jane', title: 'Jane Task One', priority: 1 },
+          { user: 'Jane', title: 'Jane Task Two', priority: 2 },
+          { user: 'Joe', title: 'Joe Task One', priority: 1 }
+        ])
+      end
+    end
+
     context 'with a delete command' do
       subject(:command) do
         ROM::Commands::Lazy.new(delete_user, evaluator, [:by_name, ['user.name']])

--- a/spec/unit/rom/commands/lazy_spec.rb
+++ b/spec/unit/rom/commands/lazy_spec.rb
@@ -202,7 +202,7 @@ describe ROM::Commands::Lazy do
         ROM::Commands::Lazy.new(
           update_task,
           evaluator,
-          [:by_user_and_title, ['users.name', 'users.tasks.title']]
+          -> command, user, task { command.by_user_and_title(user[:name], task[:title]) }
         )
       end
 
@@ -231,8 +231,6 @@ describe ROM::Commands::Lazy do
         create_task[user: 'Jane', title: 'Jane Task One']
         create_task[user: 'Jane', title: 'Jane Task Two']
         create_task[user: 'Joe', title: 'Joe Task One']
-
-        pending 'not implemented yet'
       end
 
       it 'evaluates the input and calls its command' do

--- a/spec/unit/rom/commands/lazy_spec.rb
+++ b/spec/unit/rom/commands/lazy_spec.rb
@@ -74,7 +74,7 @@ describe ROM::Commands::Lazy do
 
   describe '#call' do
     context 'with a create command' do
-      subject(:command) { ROM::Commands::Lazy.new(create_user, evaluator) }
+      subject(:command) { ROM::Commands::Lazy[create_user].new(create_user, evaluator) }
 
       it 'evaluates the input and calls command' do
         command.call(input)
@@ -85,7 +85,7 @@ describe ROM::Commands::Lazy do
 
     context 'with a create command for many child tuples' do
       subject(:command) do
-        ROM::Commands::Lazy.new(create_tasks, evaluator)
+        ROM::Commands::Lazy[create_tasks].new(create_tasks, evaluator)
       end
 
       let(:evaluator) { -> input, index { input[:users][index][:tasks] } }
@@ -116,7 +116,7 @@ describe ROM::Commands::Lazy do
 
     context 'with an update command' do
       subject(:command) do
-        ROM::Commands::Lazy.new(
+        ROM::Commands::Lazy[update_user].new(
           update_user, evaluator, -> cmd, user { cmd.by_name(user[:name]) })
       end
 
@@ -134,7 +134,7 @@ describe ROM::Commands::Lazy do
 
     context 'with an update command for a child tuple' do
       subject(:command) do
-        ROM::Commands::Lazy.new(
+        ROM::Commands::Lazy[update_task].new(
           update_task,
           evaluator,
           -> cmd, user, task { cmd.by_user(user[:name]).by_title(task[:title]) }
@@ -164,7 +164,7 @@ describe ROM::Commands::Lazy do
 
     context 'with an update command for child tuples' do
       subject(:command) do
-        ROM::Commands::Lazy.new(
+        ROM::Commands::Lazy[update_task].new(
           update_task,
           evaluator,
           -> cmd, user, task { cmd.by_user(user[:name]).by_title(task[:title]) }
@@ -200,7 +200,7 @@ describe ROM::Commands::Lazy do
 
     context 'with an update command for many parents and their children' do
       subject(:command) do
-        ROM::Commands::Lazy.new(
+        ROM::Commands::Lazy[update_task].new(
           update_task,
           evaluator,
           -> cmd, user, task { cmd.by_user(user[:name]).by_title(task[:title]) }
@@ -247,7 +247,7 @@ describe ROM::Commands::Lazy do
 
     context 'with a delete command' do
       subject(:command) do
-        ROM::Commands::Lazy.new(
+        ROM::Commands::Lazy[delete_user].new(
           delete_user,
           evaluator,
           -> cmd, user { cmd.by_name(user[:name]) }
@@ -270,7 +270,7 @@ describe ROM::Commands::Lazy do
   end
 
   describe '#>>' do
-    subject(:command) { ROM::Commands::Lazy.new(create_user, evaluator) }
+    subject(:command) { ROM::Commands::Lazy[create_user].new(create_user, evaluator) }
 
     it 'composes with another command' do
       expect(command >> create_task).to be_instance_of(ROM::Commands::Composite)
@@ -278,7 +278,7 @@ describe ROM::Commands::Lazy do
   end
 
   describe '#combine' do
-    subject(:command) { ROM::Commands::Lazy.new(create_user, evaluator) }
+    subject(:command) { ROM::Commands::Lazy[create_user].new(create_user, evaluator) }
 
     it 'combines with another command' do
       expect(command.combine(create_task)).to be_instance_of(ROM::Commands::Graph)
@@ -286,7 +286,7 @@ describe ROM::Commands::Lazy do
   end
 
   describe '#method_missing' do
-    subject(:command) { ROM::Commands::Lazy.new(update_user, evaluator) }
+    subject(:command) { ROM::Commands::Lazy[update_user].new(update_user, evaluator) }
 
     it 'returns original response if it was not a command' do
       response = command.result


### PR DESCRIPTION
This is a failing spec to demonstrate #312 

There are a couple of things that end up happening here;

Most notably, there's no particular way to actually filter the remove
commands, so the first failure case ends up removing _all_ tasks.
This can arguably be fixed from within the execute method of the remove
task, but most command bases don't provide an easy way to _internally_
modify the relation that gets used by the execute method.

There's a related filtering problem where updates are concerned, which
should be exercised and demonstrated by this spec as well, but the
specific failure is masked by the unfiltered delete.