### PR TITLE
Kill 16 alive mutants @ ROM::Relation

### DIFF
--- a/spec/unit/rom/relation_spec.rb
+++ b/spec/unit/rom/relation_spec.rb
@@ -177,5 +177,17 @@ describe ROM::Relation do
     it "returns a reference to itself" do
       expect(relation.relation).to eql(relation)
     end
+
+    it "displays a deprecation warning" do
+      warnings = [
+        "#relation deprecated and will be removed in 1.0.0.",
+        "all relations are now lazy"
+      ]
+      warning_message = warnings.join("\n")
+
+      expect {
+        relation.relation
+      }.to output(/#{warning_message}/).to_stderr
+    end
   end
 end

--- a/spec/unit/rom/relation_spec.rb
+++ b/spec/unit/rom/relation_spec.rb
@@ -172,4 +172,10 @@ describe ROM::Relation do
       expect(relation.to_a).to eql([jane, joe])
     end
   end
+
+  describe "#relation" do
+    it "returns a reference to itself" do
+      expect(relation.relation).to eql(relation)
+    end
+  end
 end


### PR DESCRIPTION
I don't know if this is somehow useful (because as the deprecation warning explains, it will be removed in v1.0.0). I guess I chose a bad method to start killing mutants, switching to useful ones (in another branch) now ;)

Anyways, this PR reduces the number of alive mutants from 32 to 16 (@ ROM::Relation)