### PR TITLE
Use tr instead of gsub

### DIFF
--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -147,7 +147,7 @@ module ROM
       # @api private
       def default_name
         return unless name
-        Inflector.underscore(name).gsub('/', '_').to_sym
+        Inflector.underscore(name).tr('/', '_').to_sym
       end
 
       # Build relation registry of specified descendant classes


### PR DESCRIPTION
According to this benchmark [1] tr is way faster compared to gsub
especially when just replacing a single character.

[1]: https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code