### PR TITLE
Add adapter setting to Gateway

### DIFF
--- a/lib/rom/gateway.rb
+++ b/lib/rom/gateway.rb
@@ -3,6 +3,10 @@ module ROM
   #
   # @api public
   class Gateway
+    extend ClassMacros
+
+    defines :adapter
+
     # Return connection object
     #
     # @return [Object] type varies depending on the gateway
@@ -89,6 +93,18 @@ module ROM
       else
         adapter.const_get(:Repository)
       end
+    end
+
+    # Returns the adapter, defined for the class
+    #
+    # @return [Symbol]
+    #
+    # @api public
+    def adapter
+      self.class.adapter || raise(
+        MissingAdapterIdentifierError,
+        "gateway class +#{self}+ is missing the adapter identifier"
+      )
     end
 
     # A generic interface for setting up a logger

--- a/lib/rom/memory/gateway.rb
+++ b/lib/rom/memory/gateway.rb
@@ -13,6 +13,8 @@ module ROM
     #
     # @api public
     class Gateway < ROM::Gateway
+      adapter :memory
+
       # @return [Object] default logger
       #
       # @api public

--- a/spec/unit/rom/gateway_spec.rb
+++ b/spec/unit/rom/gateway_spec.rb
@@ -87,4 +87,32 @@ describe ROM::Gateway do
       expect(gateway.disconnect).to be(nil)
     end
   end
+
+  describe '.adapter' do
+    let(:gateway_class) { Class.new(ROM::Gateway) }
+
+    it 'gets/sets the adapter' do
+      expect { gateway_class.adapter :custom }
+        .to change { gateway_class.adapter }
+        .from(nil)
+        .to(:custom)
+    end
+  end
+
+  describe "#adapter" do
+    before { Test::CustomGateway = Class.new(ROM::Gateway) }
+
+    let(:gateway) { Test::CustomGateway.new }
+
+    it 'returns class adapter' do
+      Test::CustomGateway.adapter :custom
+      expect(gateway.adapter).to eql :custom
+    end
+
+    it 'requires the adapter to be defined' do
+      expect { gateway.adapter }.to raise_error(
+        ROM::MissingAdapterIdentifierError, /Test::CustomGateway/
+      )
+    end
+  end # describe #adapter
 end


### PR DESCRIPTION
    class ROM::CustomAdapter::Gateway < ROM::Gateway
      adapter :custom_adapter
    end

    ROM::CustomAdapter::Gateway.adapter     # => :custom_adapter
    ROM::CustomAdapter::Gateway.new.adapter # => :custom_adapter

Also added `adapter :memory` setting to memory adapter.

The `.adapter` is not required for backward-compatibility.
But if it hasn't been set, then calling `#adapter` (instance method) will
raise the exception.

    ROM::ImperfectAdapter::Gateway = Class.new(ROM::Gateway)
    ROM::ImperfectAdapter.new.adapter
    # => raises #<ROM::MissingAdapterIdentifierError ...>

== Added

* ROM::Gateway extends ROM::Support::ClassMacros
* ROM::Gateway.adapter (getter/setter)
* ROM::Gateway#adapter (getter only)