### PR TITLE
WIP Dynamic gateways

### DIFF
--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -91,6 +91,15 @@ module ROM
       to_enum.to_a
     end
 
+    # Point a relation to a custom gateway
+    #
+    # @return A new relation targeting the new gateway
+    #
+    # @api public
+    def from(gateway)
+      __new__(gateway.dataset(self.class.name))
+    end
+
     # Return if this relation is curried
     #
     # @return [false]

--- a/spec/unit/rom/relation_spec.rb
+++ b/spec/unit/rom/relation_spec.rb
@@ -208,4 +208,12 @@ describe ROM::Relation do
       expect(new_relation.options).to include(custom_opts)
     end
   end
+
+  describe "#from" do
+    it "accept's a new gateway to fetch data from" do
+      gateway = double(dataset: ROM::Memory::Dataset.new([jane]) )
+
+      expect(relation.from(gateway).to_a).to eql([jane])
+    end
+  end
 end


### PR DESCRIPTION
Hi,

Posting this here to get some feedback since it's the first time I'm hacking on ROM :wink:

This PR adds `Relation#from` method which get's a relation and "re-target it" to a new gateway.

Current usage sample:
```ruby
ROM.use :auto_registration

ROM.setup(
  default: [:sql, 'postgres://master-server/default'],
  slave: [:sql, 'postgres://slave-server/default']
)

class Posts < ROM::Relation[:sql]
end

rom = ROM.finalize.env

# To query post's from :slave server
rom.relation(:posts).from(rom.gateways[:slave])

# Or from an arbitrary server
gateway = ROM::SQL::Gateway.new('postgres://some-other-server/database')
rom.relation(:posts).from(gateways)
```

It's pretty simple, yet it enables ROM to query from a database slave, to handle sharding, or to support a multi-database multi-tenant architecture

The problem I see right now is that this looses the current relation's scope (ie. if you do `relation.where(something).from(gateway)` the where gets lost)

And a cool feature could be to accept a symbol to fetch the gateway from the container to get something more like:
```
rom.relation(:posts).from(:slave)
```
