### PR TITLE
Add `#migrator` to `Gateway`

### DIFF
--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -11,6 +11,12 @@ module ROM
     end
   end
 
+  class MigratorNotPresentError < NotImplementedError
+    def initialize(adapter)
+      super "The #{adapter} adapter doesn't define a migrator"
+    end
+  end
+
   EnvAlreadyFinalizedError = Class.new(StandardError)
   RelationAlreadyDefinedError = Class.new(StandardError)
   NoRelationError = Class.new(StandardError)

--- a/lib/rom/gateway.rb
+++ b/lib/rom/gateway.rb
@@ -107,6 +107,21 @@ module ROM
       )
     end
 
+    # An adapter-specific migrator for the gateway
+    #
+    # @param [Object] args
+    #   Arguments required by a migrator's constructor along with a gateway
+    #
+    # @return [ROM::Migrator]
+    #
+    def migrator(*args)
+      adapter_klass  = ROM.adapters.fetch(adapter)
+      migrator_klass = adapter_klass.const_get(:Migrator)
+      migrator_klass.new(self, *args)
+    rescue NameError
+      raise MigratorNotPresentError.new(adapter) unless migrator_klass
+    end
+
     # A generic interface for setting up a logger
     #
     # @api public


### PR DESCRIPTION
The method instantiates and returns the migrator (if) provided by a corresponding adapter:

```ruby
setup = ROM.setup :cassandra, "127.0.0.1:9092"
# ...
setup.finalize
rom = setup.env
gateway = rom.gateways[:default]

gateway.migrator path: "db/migrate"
# => #<ROM::Cassandra::Migrator ...>
```

It is necessary for the `rom-migrator` plugin gem.