### PR TITLE
Move actual register calls into AutoRegistration class via new method…

### DIFF
--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -46,10 +46,7 @@ module ROM
     end
 
     def auto_registration(directory, options = {})
-      auto_registration = AutoRegistration.new(directory, options)
-      auto_registration.relations.map { |r| register_relation(r) }
-      auto_registration.commands.map { |r| register_command(r) }
-      auto_registration.mappers.map { |r| register_mapper(r) }
+      AutoRegistration.new(directory, options).register_on(self)
     end
   end
 end

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -20,6 +20,12 @@ module ROM
       }]
     end
 
+    def register_on(configuration)
+      configuration.register_relation(*relations)
+      configuration.register_command(*commands)
+      configuration.register_mapper(*mappers)
+    end
+
     def relations
       load_entities(:relations)
     end


### PR DESCRIPTION
… #register_on

This will allow someone to easily subclass AutoRegistration with a minimal amount of fuss. 
