### PR TITLE
Make @directory a Pathname always

### DIFF
--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -14,9 +14,9 @@ module ROM
 
     def initialize(directory, options = EMPTY_HASH)
       super
-      @directory = directory
+      @directory = Pathname(directory)
       @globs = Hash[[:relations, :commands, :mappers].map { |name|
-        [name, Pathname(directory).join("#{name}/**/*.rb")]
+        [name, directory.join("#{name}/**/*.rb")]
       }]
     end
 


### PR DESCRIPTION
It appears to be expecting so, as '#dirname' is called on it further down.

