### PR TITLE
Make auto-registration use namespace value

### DIFF
--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -8,7 +8,7 @@ module ROM
   class AutoRegistration
     include Options
 
-    option :namespace, reader: true, type: [TrueClass, FalseClass], default: true
+    option :namespace, reader: true, type: [String, FalseClass], default: false
 
     attr_reader :globs, :directory
 
@@ -44,7 +44,7 @@ module ROM
     def const_name(entity, file)
       name =
         if namespace
-          file.gsub("#{directory.dirname}/", '')
+          "#{namespace}/#{entity}/#{File.basename(file, '.rb')}"
         else
           file.gsub("#{directory}/#{entity}/", '')
         end.gsub('.rb', '')

--- a/spec/unit/rom/auto_registration_spec.rb
+++ b/spec/unit/rom/auto_registration_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ROM::Setup, '#auto_registration' do
 
   context 'with namespace turned on' do
     before do
-      setup.auto_registration(SPEC_ROOT.join('fixtures/lib/persistence').to_s)
+      setup.auto_registration(
+        SPEC_ROOT.join('fixtures/lib/persistence').to_s,
+        namespace: 'Persistence')
     end
 
     describe '#relations' do
@@ -30,7 +32,7 @@ RSpec.describe ROM::Setup, '#auto_registration' do
 
   context 'with namespace turned off' do
     before do
-      setup.auto_registration(SPEC_ROOT.join('fixtures/app'), namespace: false)
+      setup.auto_registration(SPEC_ROOT.join('fixtures/app'))
     end
 
     describe '#relations' do


### PR DESCRIPTION
The auto-registration code was using the namespace value as a boolean
and actually inferring the target module name from the provided
directory name. This behavior doesn't seem intuitive (if desirable it
could be set through an additional option, like `infer_namespace: true`)
and contradicts the documentation on the website, which says the
namespace option is a string.

The referenced documentation is here: http://rom-rb.org/learn/advanced/flat-style/
![image](https://cloud.githubusercontent.com/assets/15716/13552628/de5353e0-e338-11e5-9f66-6baed68c7304.png)