### PR TITLE
Replace thread_safe with concurrent-ruby in memory storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :test do
   gem 'virtus'
   gem 'anima', '~> 0.2.0'
   gem 'minitest'
-  gem 'thread_safe'
   gem 'inflecto', '~> 0.0', '>= 0.0.2'
 
   platforms :rbx do

--- a/lib/rom/memory/storage.rb
+++ b/lib/rom/memory/storage.rb
@@ -1,8 +1,5 @@
-begin
-  require 'thread_safe'
-rescue LoadError
-  raise LoadError, 'Please install the `thread_safe` gem.'
-end
+require 'concurrent/hash'
+require 'concurrent/array'
 
 require 'rom/memory/dataset'
 
@@ -21,7 +18,7 @@ module ROM
 
       # @api private
       def initialize
-        @data = ThreadSafe::Hash.new
+        @data = Concurrent::Hash.new
       end
 
       # @return [Dataset]
@@ -37,7 +34,7 @@ module ROM
       #
       # @api private
       def create_dataset(name)
-        data[name] = Dataset.new(ThreadSafe::Array.new)
+        data[name] = Dataset.new(Concurrent::Array.new)
       end
 
       # Check if there's dataset under specified key

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.license       = 'MIT'
 
+  gem.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   gem.add_runtime_dependency 'dry-types', '~> 0.7'
   gem.add_runtime_dependency 'rom-support', '~> 1.0.0'


### PR DESCRIPTION
Keep in mind that concurrent-ruby is a dry-t dependency.