### PR TITLE
Added ability to define custom namespace with String

### DIFF
--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -1,3 +1,8 @@
+
+require 'rom/setup/auto_registration_strategies/base'
+require 'rom/setup/auto_registration_strategies/no_namespace'
+require 'rom/setup/auto_registration_strategies/with_namespace'
+require 'rom/setup/auto_registration_strategies/custom_namespace'
 require 'rom/setup/auto_registration'
 
 module ROM

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -57,9 +57,9 @@ module ROM
     end
 
     class CustomNamespaceStrategy
-      def initialize(namespace:, file:)
-        @namespace, @file = namespace, file
-      end
+      include Options
+      option :file, reader: true, type: String
+      option :namespace, reader: true, type: String
 
       def call
         "#{namespace}::#{Inflector.camelize(filename).sub(EXTENSION_REGEX, '')}"
@@ -75,9 +75,9 @@ module ROM
     end
 
     class WithNamespaceStrategy
-      def initialize(directory:, file:)
-        @directory, @file = directory, file
-      end
+      include Options
+      option :directory, reader: true, type: Pathname
+      option :file, reader: true, type: String
 
       def call
         Inflector.camelize(
@@ -91,9 +91,10 @@ module ROM
     end
 
     class NoNamespaceStrategy
-      def initialize(directory:, file:, entity:)
-        @directory, @file, @entity = directory, file, entity
-      end
+      include Options
+      option :directory, reader: true, type: Pathname
+      option :file, reader: true, type: String
+      option :entity, reader: true, type: Symbol
 
       def call
         Inflector.camelize(

--- a/lib/rom/setup/auto_registration_strategies/base.rb
+++ b/lib/rom/setup/auto_registration_strategies/base.rb
@@ -1,0 +1,10 @@
+module ROM
+  module AutoRegistrationStrategies
+    class Base
+      EXTENSION_REGEX = /\.rb$/.freeze
+
+      include Options
+      option :file, reader: true, type: String
+    end
+  end
+end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -1,0 +1,17 @@
+module ROM
+  module AutoRegistrationStrategies
+    class CustomNamespace < Base
+      option :namespace, reader: true, type: String
+
+      def call
+        "#{namespace}::#{Inflector.camelize(filename).sub(EXTENSION_REGEX, '')}"
+      end
+
+      private
+
+      def filename
+        Pathname.new(file).basename.to_s
+      end
+    end
+  end
+end

--- a/lib/rom/setup/auto_registration_strategies/no_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/no_namespace.rb
@@ -1,0 +1,14 @@
+module ROM
+  module AutoRegistrationStrategies
+    class NoNamespace < Base
+      option :directory, reader: true, type: Pathname
+      option :entity, reader: true, type: Symbol
+
+      def call
+        Inflector.camelize(
+          file.sub(/^#{directory}\/#{entity}\//, '').sub(EXTENSION_REGEX, '')
+        )
+      end
+    end
+  end
+end

--- a/lib/rom/setup/auto_registration_strategies/with_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/with_namespace.rb
@@ -1,0 +1,13 @@
+module ROM
+  module AutoRegistrationStrategies
+    class WithNamespace < Base
+      option :directory, reader: true, type: Pathname
+
+      def call
+        Inflector.camelize(
+          file.sub(/^#{directory.dirname}\//, '').sub(EXTENSION_REGEX, '')
+        )
+      end
+    end
+  end
+end

--- a/spec/fixtures/custom/commands/create_user.rb
+++ b/spec/fixtures/custom/commands/create_user.rb
@@ -1,0 +1,6 @@
+module My
+  module Namespace
+    class CreateUser
+    end
+  end
+end

--- a/spec/fixtures/custom/mappers/user_list.rb
+++ b/spec/fixtures/custom/mappers/user_list.rb
@@ -1,0 +1,6 @@
+module My
+  module Namespace
+    class UserList
+    end
+  end
+end

--- a/spec/fixtures/custom/relations/users.rb
+++ b/spec/fixtures/custom/relations/users.rb
@@ -1,0 +1,6 @@
+module My
+  module Namespace
+    class Users
+    end
+  end
+end

--- a/spec/unit/rom/auto_registration_spec.rb
+++ b/spec/unit/rom/auto_registration_spec.rb
@@ -117,5 +117,37 @@ RSpec.describe ROM::Setup, '#auto_registration' do
         end
       end
     end
+
+    context 'with custom namespace' do
+      before do
+        setup.auto_registration(
+          SPEC_ROOT.join('fixtures/custom'),
+          component_dirs: {
+            relations: :relations,
+            mappers: :mappers,
+            commands: :commands
+          },
+          namespace: 'My::Namespace'
+        )
+      end
+
+      describe '#relations' do
+        it 'loads files and returns constants' do
+          expect(setup.relation_classes).to eql([My::Namespace::Users])
+        end
+      end
+
+      describe '#commands' do
+        it 'loads files and returns constants' do
+          expect(setup.command_classes).to eql([My::Namespace::CreateUser])
+        end
+      end
+
+      describe '#mappers' do
+        it 'loads files and returns constants' do
+          expect(setup.mapper_classes).to eql([My::Namespace::UserList])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Referencing issue #353 

I added ability to register namespaces via string and moved constant creation to strategies. Few questions:
* ~~Is it okay to use kw args or should I use Options module here?~~
* Should I move internal classes to separate files?
* Is the strategy approach okay here?

One benefit I see with strategies, that we can later pass our own to make it even more customisable as mentioned in #353 

Let me know what you thin and Ill be happy to adjust the code

**EDIT:**
I see that test suite expects Ruby 2.0, so changed the strategy classes to use ROM Options module