### PR TITLE
Add dry-core as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rom-support', git: 'https://github.com/rom-rb/rom-support.git', branch: 'do-not-load-constants'
+gem 'rom-mapper', git: 'https://github.com/rom-rb/rom-mapper.git', branch: 'dry-core'
+
 group :console do
   gem 'pry'
   gem 'pg', platforms: [:mri]

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rom-support', git: 'https://github.com/rom-rb/rom-support.git', branch: 'do-not-load-constants'
-gem 'rom-mapper', git: 'https://github.com/rom-rb/rom-mapper.git', branch: 'dry-core'
+gem 'rom-support', git: 'https://github.com/rom-rb/rom-support.git'
+gem 'rom-mapper', git: 'https://github.com/rom-rb/rom-mapper.git'
 
 group :console do
   gem 'pry'

--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -1,15 +1,18 @@
 require 'dry-equalizer'
+require 'dry/core/constants'
 
 require 'rom-support'
 require 'rom/version'
 require 'rom/constants'
 
+module ROM
+  include Dry::Core::Constants
+end
+
 # internal ROM support lib
-require 'rom/support/inflector'
 require 'rom/support/registry'
 require 'rom/support/options'
 require 'rom/support/class_macros'
-require 'rom/support/class_builder'
 require 'rom/support/inheritance_hook'
 
 # core parts

--- a/lib/rom/association_set.rb
+++ b/lib/rom/association_set.rb
@@ -1,5 +1,5 @@
 require 'rom/support/registry'
-require 'rom/support/inflector'
+require 'dry/core/inflector'
 
 module ROM
   class AssociationSet < ROM::Registry
@@ -19,7 +19,7 @@ module ROM
       if key?(key)
         super
       else
-        super(Inflector.singularize(key))
+        super(Dry::Core::Inflector.singularize(key))
       end
     end
   end

--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -1,4 +1,4 @@
-require 'rom/support/deprecations'
+require 'dry/core/deprecations'
 require 'rom/support/options'
 require 'rom/pipeline'
 
@@ -52,9 +52,10 @@ module ROM
         @validator
       else
         unless vp.equal?(DEFAULT_VALIDATOR)
-          Deprecations.announce(
+          Dry::Core::Deprecations.announce(
             "#{name}.validator",
-            'Please handle validation before calling commands'
+            'Please handle validation before calling commands',
+            tag: :rom
           )
         end
         super

--- a/lib/rom/commands/class_interface.rb
+++ b/lib/rom/commands/class_interface.rb
@@ -1,4 +1,5 @@
-require 'rom/support/class_builder'
+require 'dry/core/class_builder'
+require 'dry/core/inflector'
 
 module ROM
   # Base command class with factory class-level interface and setup-related logic
@@ -20,7 +21,7 @@ module ROM
       #
       # @api public
       def [](adapter)
-        adapter_namespace(adapter).const_get(Inflector.demodulize(name))
+        adapter_namespace(adapter).const_get(Dry::Core::Inflector.demodulize(name))
       end
 
       # Return namespaces that contains command subclasses of a specific adapter
@@ -65,8 +66,8 @@ module ROM
       #
       # @api public
       def create_class(name, type, &block)
-        klass = ClassBuilder
-          .new(name: "#{Inflector.classify(type)}[:#{name}]", parent: type)
+        klass = Dry::Core::ClassBuilder
+          .new(name: "#{Dry::Core::Inflector.classify(type)}[:#{name}]", parent: type)
           .call
 
         if block
@@ -113,7 +114,7 @@ module ROM
       #
       # @api private
       def default_name
-        Inflector.underscore(Inflector.demodulize(name)).to_sym
+        Dry::Core::Inflector.underscore(Dry::Core::Inflector.demodulize(name)).to_sym
       end
 
       # Return default options based on class macros

--- a/lib/rom/commands/composite.rb
+++ b/lib/rom/commands/composite.rb
@@ -1,5 +1,4 @@
 require 'rom/pipeline'
-require 'rom/support/constants'
 
 module ROM
   module Commands

--- a/lib/rom/configuration_dsl.rb
+++ b/lib/rom/configuration_dsl.rb
@@ -1,5 +1,3 @@
-require 'rom/support/constants'
-
 require 'rom/configuration_dsl/relation'
 require 'rom/configuration_dsl/mapper_dsl'
 require 'rom/configuration_dsl/command_dsl'

--- a/lib/rom/configuration_dsl/command.rb
+++ b/lib/rom/configuration_dsl/command.rb
@@ -1,7 +1,5 @@
-require 'rom/support/constants'
-
-require 'rom/support/inflector'
-require 'rom/support/class_builder'
+require 'dry/core/inflector'
+require 'dry/core/class_builder'
 
 module ROM
   module ConfigurationDSL
@@ -16,12 +14,12 @@ module ROM
       # @api private
       def self.build_class(name, relation, options = EMPTY_HASH, &block)
         type = options.fetch(:type) { name }
-        command_type = Inflector.classify(type)
+        command_type = Dry::Core::Inflector.classify(type)
         adapter = options.fetch(:adapter)
         parent = ROM::Command.adapter_namespace(adapter).const_get(command_type)
         class_name = generate_class_name(adapter, command_type, relation)
 
-        ClassBuilder.new(name: class_name, parent: parent).call do |klass|
+        Dry::Core::ClassBuilder.new(name: class_name, parent: parent).call do |klass|
           klass.register_as(name)
           klass.relation(relation)
           klass.class_eval(&block) if block
@@ -33,9 +31,9 @@ module ROM
       # @api private
       def self.generate_class_name(adapter, command_type, relation)
         pieces = ['ROM']
-        pieces << Inflector.classify(adapter)
+        pieces << Dry::Core::Inflector.classify(adapter)
         pieces << 'Commands'
-        pieces << "#{command_type}[#{Inflector.classify(relation)}s]"
+        pieces << "#{command_type}[#{Dry::Core::Inflector.classify(relation)}s]"
         pieces.join('::')
       end
     end

--- a/lib/rom/configuration_dsl/mapper.rb
+++ b/lib/rom/configuration_dsl/mapper.rb
@@ -1,5 +1,4 @@
-require 'rom/support/constants'
-require 'rom/support/class_builder'
+require 'dry/core/class_builder'
 
 module ROM
   module ConfigurationDSL
@@ -25,7 +24,7 @@ module ROM
             ROM::Mapper
           end
 
-        ClassBuilder.new(name: class_name, parent: parent_class).call do |klass|
+        Dry::Core::ClassBuilder.new(name: class_name, parent: parent_class).call do |klass|
           klass.relation(name)
           klass.inherit_header(inherit_header)
 

--- a/lib/rom/configuration_dsl/mapper_dsl.rb
+++ b/lib/rom/configuration_dsl/mapper_dsl.rb
@@ -1,4 +1,3 @@
-require 'rom/support/constants'
 require 'rom/configuration_dsl/mapper'
 
 module ROM

--- a/lib/rom/configuration_dsl/relation.rb
+++ b/lib/rom/configuration_dsl/relation.rb
@@ -1,5 +1,5 @@
-require 'rom/support/constants'
-require 'rom/support/class_builder'
+require 'dry/core/class_builder'
+require 'dry/core/inflector'
 
 module ROM
   module ConfigurationDSL
@@ -13,10 +13,10 @@ module ROM
       #
       # @api private
       def self.build_class(name, options = EMPTY_HASH)
-        class_name = "ROM::Relation[#{Inflector.camelize(name)}]"
+        class_name = "ROM::Relation[#{Dry::Core::Inflector.camelize(name)}]"
         adapter = options.fetch(:adapter)
 
-        ClassBuilder.new(name: class_name, parent: ROM::Relation[adapter]).call do |klass|
+        Dry::Core::ClassBuilder.new(name: class_name, parent: ROM::Relation[adapter]).call do |klass|
           klass.gateway(options.fetch(:gateway, :default))
           klass.dataset(name)
         end

--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -23,7 +23,7 @@ module ROM
   MissingAdapterIdentifierError = Class.new(StandardError)
 
   DuplicateConfigurationError = Class.new(StandardError)
-  DuplicateContainerError = Class.new(StandardError)  
+  DuplicateContainerError = Class.new(StandardError)
 
   InvalidOptionValueError = Class.new(StandardError)
   InvalidOptionKeyError = Class.new(StandardError)

--- a/lib/rom/global.rb
+++ b/lib/rom/global.rb
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 require 'rom/plugin_registry'
 require 'rom/global/plugin_dsl'
-require 'rom/support/deprecations'
 
 module ROM
   # Globally accessible public interface exposed via ROM module

--- a/lib/rom/global/plugin_dsl.rb
+++ b/lib/rom/global/plugin_dsl.rb
@@ -1,5 +1,3 @@
-require 'rom/support/constants'
-
 module ROM
   module Global
     # plugin registration DSL

--- a/lib/rom/plugins/configuration/configuration_dsl.rb
+++ b/lib/rom/plugins/configuration/configuration_dsl.rb
@@ -1,5 +1,5 @@
 require 'rom/configuration_dsl'
-require 'rom/support/deprecations'
+require 'dry/core/deprecations'
 
 module ROM
   module ConfigurationPlugins
@@ -10,7 +10,11 @@ module ROM
 
       # @api private
       def self.apply(configuration, options = {})
-        ROM::Deprecations.announce(:macros, "Calling `use(:macros)` is no longer necessary. Macros are enabled by default.")
+        Dry::Core::Deprecations.announce(
+          :macros,
+          "Calling `use(:macros)` is no longer necessary. Macros are enabled by default.",
+          tag: :rom
+        )
       end
     end
   end

--- a/lib/rom/plugins/relation/key_inference.rb
+++ b/lib/rom/plugins/relation/key_inference.rb
@@ -1,3 +1,5 @@
+require 'dry/core/inflector'
+
 module ROM
   module Plugins
     module Relation
@@ -24,7 +26,7 @@ module ROM
               relation.foreign_key
             end
           else
-            :"#{Inflector.singularize(name.dataset)}_id"
+            :"#{Dry::Core::Inflector.singularize(name.dataset)}_id"
           end
         end
 

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -1,5 +1,7 @@
 require 'set'
 
+require 'dry/core/inflector'
+require 'rom/support/class_macros'
 require 'rom/support/auto_curry'
 require 'rom/relation/curried'
 require 'rom/relation/name'
@@ -17,13 +19,13 @@ module ROM
       def inherited(klass)
         super
 
-        klass.extend ClassMacros
-        klass.defines :adapter
-
         if respond_to?(:adapter) && adapter.nil?
           raise MissingAdapterIdentifierError,
-            "relation class +#{self}+ is missing the adapter identifier"
+                "relation class +#{self}+ is missing the adapter identifier"
         end
+
+        klass.extend ClassMacros
+        klass.defines :adapter
 
         # Extend with functionality required by adapters *only* if this is a direct
         # descendant of an adapter-specific relation subclass
@@ -67,7 +69,7 @@ module ROM
           # @param [Symbol] value The name of the dataset
           #
           # @api public
-          def self.dataset(value = Undefined, &block)
+          def self.dataset(value = ClassMacros::UndefinedValue, &block)
             dataset_proc(block) if block
             super
           end
@@ -79,8 +81,8 @@ module ROM
           # @return [Symbol]
           #
           # @api public
-          def self.register_as(value = Undefined)
-            if value == Undefined
+          def self.register_as(value = ClassMacros::UndefinedValue)
+            if value == ClassMacros::UndefinedValue
               return @register_as if defined?(@register_as)
 
               super_val = super()
@@ -203,7 +205,7 @@ module ROM
       # @api private
       def default_name
         return unless name
-        Inflector.underscore(name).tr('/', '_').to_sym
+        Dry::Core::Inflector.underscore(name).tr('/', '_').to_sym
       end
 
       # @api private

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -1,6 +1,5 @@
 require 'dry-equalizer'
 
-require 'rom/support/constants'
 require 'rom/schema/dsl'
 require 'rom/association_set'
 

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -1,7 +1,6 @@
 require 'pathname'
 
-require 'rom/support/constants'
-require 'rom/support/inflector'
+require 'dry/core/inflector'
 require 'rom/support/options'
 
 require 'rom/setup/auto_registration_strategies/no_namespace'
@@ -62,7 +61,7 @@ module ROM
               file: file, directory: directory, entity: component_dirs.fetch(entity)
             ).call
           end
-        Inflector.constantize(klass_name)
+        Dry::Core::Inflector.constantize(klass_name)
       end
     end
   end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'rom/support/inflector'
+require 'dry/core/inflector'
 require 'rom/setup/auto_registration_strategies/base'
 
 module ROM
@@ -9,7 +9,7 @@ module ROM
       option :namespace, reader: true, type: String
 
       def call
-        "#{namespace}::#{Inflector.camelize(filename)}"
+        "#{namespace}::#{Dry::Core::Inflector.camelize(filename)}"
       end
 
       private

--- a/lib/rom/setup/auto_registration_strategies/no_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/no_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'rom/support/inflector'
+require 'dry/core/inflector'
 require 'rom/setup/auto_registration_strategies/base'
 
 module ROM
@@ -10,7 +10,7 @@ module ROM
       option :entity, reader: true, type: Symbol
 
       def call
-        Inflector.camelize(
+        Dry::Core::Inflector.camelize(
           file.sub(/^#{directory}\/#{entity}\//, '').sub(EXTENSION_REGEX, '')
         )
       end

--- a/lib/rom/setup/auto_registration_strategies/with_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/with_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'rom/support/inflector'
+require 'dry/core/inflector'
 require 'rom/setup/auto_registration_strategies/base'
 
 module ROM
@@ -9,7 +9,7 @@ module ROM
       option :directory, reader: true, type: Pathname
 
       def call
-        Inflector.camelize(
+        Dry::Core::Inflector.camelize(
           file.sub(/^#{directory.dirname}\//, '').sub(EXTENSION_REGEX, '')
         )
       end

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   gem.add_runtime_dependency 'dry-types', '~> 0.8'
+  gem.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.1'
   gem.add_runtime_dependency 'rom-support', '~> 2.0'
   gem.add_runtime_dependency 'rom-mapper', '~> 0.4.0'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,8 @@ end
 
 SPEC_ROOT = root = Pathname(__FILE__).dirname
 
-require 'rom/support/deprecations'
-ROM::Deprecations.set_logger!(SPEC_ROOT.join('../log/deprecations.log'))
+require 'dry/core/deprecations'
+Dry::Core::Deprecations.set_logger!(SPEC_ROOT.join('../log/deprecations.log'))
 
 require 'rom'
 


### PR DESCRIPTION
As a part of [leaving rom-support behind](https://github.com/dry-rb/dry-types/pull/132) I added dry-core to rom's dependencies and started to use its modules where possible.