### PR TITLE
feature: schemas in view definitions

### DIFF
--- a/lib/rom/plugins/relation/view.rb
+++ b/lib/rom/plugins/relation/view.rb
@@ -16,6 +16,13 @@ module ROM
             def self.attributes
               @__attributes__ ||= {}
             end
+
+            def self.schema_defined!
+              super
+              view(:base, schema.map { |t| t.meta[:name] }) do
+                self
+              end
+            end
           end
         end
 

--- a/lib/rom/plugins/relation/view.rb
+++ b/lib/rom/plugins/relation/view.rb
@@ -42,7 +42,7 @@ module ROM
               .fetch(view_name, self.class.attributes.fetch(:base))
 
             if header.is_a?(Proc)
-              instance_exec(&header)
+              Array(instance_exec(&header))
             else
               header
             end

--- a/lib/rom/plugins/relation/view.rb
+++ b/lib/rom/plugins/relation/view.rb
@@ -104,14 +104,16 @@ module ROM
                 auto_curry(name) { with(view: name) }
               end
             else
-              define_method(name) do
-                relation = instance_exec(&relation_block)
-
-                if new_schema_fn
-                  self.class.attributes[name].project_relation(relation)
-                else
-                  relation
-                end.with(view: name)
+              if new_schema_fn
+                define_method(name) do
+                  relation = instance_exec(&relation_block)
+                  self.class.attributes[name].project_relation(relation).with(view: name)
+                end
+              else
+                define_method(name) do
+                  relation = instance_exec(&relation_block)
+                  relation.with(view: name)
+                end
               end
             end
           end

--- a/lib/rom/plugins/relation/view.rb
+++ b/lib/rom/plugins/relation/view.rb
@@ -35,9 +35,7 @@ module ROM
               .fetch(view_name, self.class.attributes.fetch(:base))
 
             if header.is_a?(Proc)
-              evaled_header = instance_exec(&header)
-              self.class.attributes[view_name] = evaled_header
-              Array(evaled_header)
+              Array(instance_exec(&header))
             else
               Array(header)
             end
@@ -101,7 +99,16 @@ module ROM
             if relation_block.arity > 0
               auto_curry_guard do
                 define_method(name, &relation_block)
-                auto_curry(name) { with(view: name) }
+
+                if new_schema_fn
+                  auto_curry(name) do
+                    self.class.attributes[name].project_relation(self).with(view: name) 
+                  end
+                else
+                  auto_curry(name) do
+                    with(view: name) 
+                  end
+                end
               end
             else
               if new_schema_fn

--- a/lib/rom/plugins/relation/view/dsl.rb
+++ b/lib/rom/plugins/relation/view/dsl.rb
@@ -5,7 +5,7 @@ module ROM
         class DSL
           attr_reader :name
 
-          attr_reader :attributes
+          attr_reader :header
 
           attr_reader :relation_block
 
@@ -15,17 +15,17 @@ module ROM
             @name = name
             @schema = schema
             @new_schema = nil
-            @attributes = nil
+            @header = nil
             @relation_block = nil
             instance_eval(&block)
           end
 
           def schema(&block)
-            @new_schema = @schema.instance_exec(&block)
+            @new_schema = -> { @schema.instance_exec(&block) }
           end
 
           def header(*args, &block)
-            @attributes = args.size > 0 ? args.first : block
+            @header = args.size > 0 ? args.first : block
           end
 
           def relation(&block)
@@ -33,7 +33,7 @@ module ROM
           end
 
           def call
-            [name, attributes, relation_block, new_schema]
+            [name, header, relation_block, new_schema]
           end
         end
       end

--- a/lib/rom/plugins/relation/view/dsl.rb
+++ b/lib/rom/plugins/relation/view/dsl.rb
@@ -9,9 +9,19 @@ module ROM
 
           attr_reader :relation_block
 
-          def initialize(name, &block)
+          attr_reader :new_schema
+
+          def initialize(name, schema = nil, &block)
             @name = name
+            @schema = schema
+            @new_schema = nil
+            @attributes = nil
+            @relation_block = nil
             instance_eval(&block)
+          end
+
+          def schema(&block)
+            @new_schema = @schema.instance_exec(&block)
           end
 
           def header(*args, &block)
@@ -23,7 +33,7 @@ module ROM
           end
 
           def call
-            [name, attributes, relation_block]
+            [name, attributes, relation_block, new_schema]
           end
         end
       end

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -168,6 +168,13 @@ module ROM
         end
       end
 
+      # A hook which is called when a schema was defined for a relation
+      #
+      # @api private
+      def schema_defined!
+        # no-op
+      end
+
       # Dynamically define a method that will forward to the dataset and wrap
       # response in the relation itself
       #

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -77,7 +77,7 @@ module ROM
     #
     # @api public
     def project(*names)
-      self.class.new(name, attributes.select { |key, _| names.include?(key) })
+      self.class.new(name, attributes: attributes.select { |key, _| names.include?(key) })
     end
 
     # Return FK attribute for a given relation name

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -57,11 +57,27 @@ module ROM
       attributes.size == 0
     end
 
+    # @api public
+    def to_ary
+      map { |attribute| attribute.meta[:name] }
+    end
+
     # Return attribute
     #
     # @api public
     def [](name)
       attributes.fetch(name)
+    end
+
+    # Project a schema to include only specified attributes
+    #
+    # @param [*Array] names The name of the attributes
+    #
+    # @return [Schema]
+    #
+    # @api public
+    def project(*names)
+      self.class.new(name, attributes.select { |key, _| names.include?(key) })
     end
 
     # Return FK attribute for a given relation name

--- a/lib/rom/setup/finalize/finalize_relations.rb
+++ b/lib/rom/setup/finalize/finalize_relations.rb
@@ -50,7 +50,11 @@ module ROM
         gateway = @gateways.fetch(klass.gateway)
         ds_proc = klass.dataset_proc || -> _ { self }
 
-        klass.schema.finalize!(gateway) if klass.schema
+        if klass.schema
+          klass.schema.finalize!(gateway)
+          klass.schema_defined!
+        end
+
         dataset = gateway.dataset(klass.dataset).instance_exec(klass, &ds_proc)
 
         klass.new(dataset, __registry__: registry)

--- a/spec/unit/rom/plugins/relation/view_spec.rb
+++ b/spec/unit/rom/plugins/relation/view_spec.rb
@@ -52,24 +52,48 @@ RSpec.describe ROM::Plugins::Relation::View do
   end
 
   context 'with a schema' do
-    let(:relation_class) do
-      Class.new(ROM::Memory::Relation) do
-        use :view
-
-        schema do
-          attribute :id, ROM::Types::Int
-          attribute :name, ROM::Types::String
-        end
-      end
-    end
-
     before do
       # this is normally called automatically during setup
       relation_class.schema_defined!
     end
 
-    it 'infers base view from the schema' do
-      expect(relation.attributes).to eql(%i[id name])
+    describe 'base view attributes' do
+      let(:relation_class) do
+        Class.new(ROM::Memory::Relation) do
+          use :view
+
+          schema do
+            attribute :id, ROM::Types::Int
+            attribute :name, ROM::Types::String
+          end
+        end
+      end
+
+      it 'infers base view from the schema' do
+        expect(relation.attributes).to eql(%i[id name])
+      end
+    end
+
+    describe 're-using schema in a view definition' do
+      let(:relation_class) do
+        Class.new(ROM::Memory::Relation) do
+          use :view
+
+          schema do
+            attribute :id, ROM::Types::Int
+            attribute :name, ROM::Types::String
+          end
+
+          view(:names) do
+            header { schema.project(:name) }
+            relation { project(:name) }
+          end
+        end
+      end
+
+      it 'uses projected schema for view attributes' do
+        expect(relation.attributes(:names)).to eql(%i[name])
+      end
     end
   end
 end

--- a/spec/unit/rom/plugins/relation/view_spec.rb
+++ b/spec/unit/rom/plugins/relation/view_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ROM::Plugins::Relation::View do
     end
   end
 
-  context 'with a schema' do
+  context 'with an explicit schema' do
     before do
       # this is normally called automatically during setup
       relation_class.schema_defined!
@@ -86,11 +86,11 @@ RSpec.describe ROM::Plugins::Relation::View do
 
           view(:names) do
             schema do
-              project(:name) 
+              project(:name)
             end
 
             relation do
-              self 
+              self
             end
           end
         end
@@ -112,6 +112,30 @@ RSpec.describe ROM::Plugins::Relation::View do
           .to receive(:project_relation).with(relation).and_return(new_rel)
 
         expect(relation.names).to eql(new_rel)
+      end
+    end
+
+    context 'with an inferred schema' do
+      before do
+        # this is normally called automatically during setup
+        relation_class.schema.finalize!
+        relation_class.schema_defined!
+      end
+
+      let(:relation_class) do
+        Class.new(ROM::Memory::Relation) do
+          use :view
+
+          schema_inferrer -> dataset, gateway {
+            { id: ROM::Types::Int, name: ROM::Types::String }
+          }
+
+          schema(infer: true)
+        end
+      end
+
+      it 'infers base view from the schema' do
+        expect(relation.attributes).to eql(%i[id name])
       end
     end
   end

--- a/spec/unit/rom/plugins/relation/view_spec.rb
+++ b/spec/unit/rom/plugins/relation/view_spec.rb
@@ -50,4 +50,26 @@ RSpec.describe ROM::Plugins::Relation::View do
       end
     end
   end
+
+  context 'with a schema' do
+    let(:relation_class) do
+      Class.new(ROM::Memory::Relation) do
+        use :view
+
+        schema do
+          attribute :id, ROM::Types::Int
+          attribute :name, ROM::Types::String
+        end
+      end
+    end
+
+    before do
+      # this is normally called automatically during setup
+      relation_class.schema_defined!
+    end
+
+    it 'infers base view from the schema' do
+      expect(relation.attributes).to eql(%i[id name])
+    end
+  end
 end

--- a/spec/unit/rom/plugins/relation/view_spec.rb
+++ b/spec/unit/rom/plugins/relation/view_spec.rb
@@ -5,47 +5,49 @@ require 'rom/plugins/relation/view'
 RSpec.describe ROM::Plugins::Relation::View do
   subject(:relation) { relation_class.new([]) }
 
-  let(:relation_class) do
-    Class.new(ROM::Memory::Relation) do
-      use :view
+  context 'without a schema' do
+    let(:relation_class) do
+      Class.new(ROM::Memory::Relation) do
+        use :view
 
-      view(:base, [:id, :name]) do
-        self
+        view(:base, [:id, :name]) do
+          self
+        end
+
+        view(:ids, [:id]) do
+          self
+        end
+
+        view(:names, [:name]) do |id|
+          self
+        end
+      end
+    end
+
+    describe '#attributes' do
+      it 'returns base view attributes by default' do
+        expect(relation.attributes).to eql([:id, :name])
       end
 
-      view(:ids, [:id]) do
-        self
+      it 'returns attributes for a view' do
+        expect(relation.ids.attributes).to eql([:id])
       end
 
-      view(:names, [:name]) do |id|
-        self
+      it 'returns attributes for a view with args' do
+        expect(relation.names(1).attributes).to eql([:name])
       end
-    end
-  end
 
-  describe '#attributes' do
-    it 'returns base view attributes by default' do
-      expect(relation.attributes).to eql([:id, :name])
-    end
+      it 'returns attributes for a curried view' do
+        expect(relation.names.attributes).to eql([:name])
+      end
 
-    it 'returns attributes for a view' do
-      expect(relation.ids.attributes).to eql([:id])
-    end
+      it 'returns correct arity for a curried view' do
+        expect(relation.names.arity).to be(1)
+      end
 
-    it 'returns attributes for a view with args' do
-      expect(relation.names(1).attributes).to eql([:name])
-    end
-
-    it 'returns attributes for a curried view' do
-      expect(relation.names.attributes).to eql([:name])
-    end
-
-    it 'returns correct arity for a curried view' do
-      expect(relation.names.arity).to be(1)
-    end
-
-    it 'returns explicitly set attributes' do
-      expect(relation.with(attributes: [:foo, :bar]).attributes).to eql([:foo, :bar])
+      it 'returns explicitly set attributes' do
+        expect(relation.with(attributes: [:foo, :bar]).attributes).to eql([:foo, :bar])
+      end
     end
   end
 end

--- a/spec/unit/rom/plugins/relation/view_spec.rb
+++ b/spec/unit/rom/plugins/relation/view_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe ROM::Plugins::Relation::View do
       expect(names_schema).to receive(:project_relation).with(relation).and_return(new_rel)
       expect(relation.names).to eql(new_rel)
     end
+
+    it 'auto-projects a restricted relation via schema' do
+      new_rel = relation_class.new([{ id: 2 }])
+      ids_schema = relation_class.attributes[:ids_for_names]
+
+      expect(ids_schema).to receive(:project_relation).with(relation.restrict(name: ['Jane'])).and_return(new_rel)
+      expect(relation.ids_for_names(['Jane'])).to eql(new_rel)
+    end
   end
 
   context 'with an explicit schema' do
@@ -97,6 +105,16 @@ RSpec.describe ROM::Plugins::Relation::View do
 
             relation do
               self
+            end
+          end
+
+          view(:ids_for_names) do
+            schema do
+              project(:id)
+            end
+
+            relation do |names|
+              restrict(name: names)
             end
           end
         end
@@ -131,6 +149,16 @@ RSpec.describe ROM::Plugins::Relation::View do
 
             relation do
               self
+            end
+          end
+
+          view(:ids_for_names) do
+            schema do
+              project(:id)
+            end
+
+            relation do |names|
+              restrict(name: names)
             end
           end
         end


### PR DESCRIPTION
This will add a couple of sweet new features:

- [x] infer base views automatically based on schemas
- [x] allow using schemas in view definitions to DRY things up
- [x] extend views so that they can delegate column selection to a schema *automatically* (this will be awesome OMG)
- [x] extend view attributes info with **types** so that we can infer dry-structs and do other cool things
- [x] make it possible to use inferred schemas with views
