### PR TITLE
Feature: schema projection api

### DIFF
--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -118,6 +118,17 @@ module ROM
       self.class.new(name, options.merge(attributes: names.map { |name| [name, self[name]] }.to_h))
     end
 
+    # Project a schema with renamed attributes
+    #
+    # @param [Hash] mapping The attribute mappings
+    #
+    # @return [Schema]
+    #
+    # @api public
+    def rename(mapping)
+      self.class.new(name, options.merge(attributes: mapping.map { |key, value| [value, self[key].aliased(value)] }.to_h))
+    end
+
     # Return FK attribute for a given relation name
     #
     # @return [Dry::Types::Definition]

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -115,7 +115,7 @@ module ROM
     #
     # @api public
     def project(*names)
-      self.class.new(name, options.merge(attributes: attributes.select { |key, _| names.include?(key) }))
+      self.class.new(name, options.merge(attributes: names.map { |name| [name, self[name]] }.to_h))
     end
 
     # Return FK attribute for a given relation name

--- a/lib/rom/schema/type.rb
+++ b/lib/rom/schema/type.rb
@@ -30,7 +30,12 @@ module ROM
 
       # @api public
       def name
-        meta[:name]
+        meta[:alias] || meta[:name]
+      end
+
+      # @api public
+      def aliased(name)
+        self.class.new(type.meta(alias: name))
       end
 
       # @api public

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,8 @@ def T(*args)
 end
 
 RSpec.configure do |config|
+  config.include(SchemaHelpers)
+
   config.after do
     Test.remove_constants
   end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,0 +1,10 @@
+require 'dry-types'
+
+module SchemaHelpers
+  def define_schema(name, attrs)
+    ROM::Schema.define(
+      name,
+      attributes: attrs.each_with_object({}) { |(k, v), h| h[k] = v.meta(name: k) }
+    )
+  end
+end

--- a/spec/unit/rom/schema/project_spec.rb
+++ b/spec/unit/rom/schema/project_spec.rb
@@ -2,13 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#project' do
   subject(:schema) do
-    ROM::Schema.define(
-      :users, attributes: {
-        id: ROM::Types::Int.meta(name: :id),
-        name: ROM::Types::String.meta(name: :name),
-        age: ROM::Types::Int.meta(name: :age)
-      }
-    )
+    define_schema(:users, id: ROM::Types::Int, name: ROM::Types::String, age: ROM::Types::Int)
   end
 
   it 'projects provided attribute names' do

--- a/spec/unit/rom/schema/project_spec.rb
+++ b/spec/unit/rom/schema/project_spec.rb
@@ -1,0 +1,17 @@
+require 'rom/schema'
+
+RSpec.describe ROM::Schema, '#project' do
+  subject(:schema) do
+    ROM::Schema.define(
+      :users, attributes: {
+        id: ROM::Types::Int.meta(name: :id),
+        name: ROM::Types::String.meta(name: :name),
+        age: ROM::Types::Int.meta(name: :age)
+      }
+    )
+  end
+
+  it 'projects provided attribute names' do
+    expect(schema.project(:name, :age).map(&:name)).to eql(%i[name age])
+  end
+end

--- a/spec/unit/rom/schema/rename_spec.rb
+++ b/spec/unit/rom/schema/rename_spec.rb
@@ -1,0 +1,16 @@
+require 'rom/schema'
+
+RSpec.describe ROM::Schema, '#rename' do
+  subject(:schema) do
+    define_schema(:users, user_id: ROM::Types::Int, user_name: ROM::Types::String)
+  end
+
+  let(:renamed) do
+    schema.rename(user_id: :id, user_name: :name)
+  end
+
+  it 'returns projected schema with renamed attributes' do
+    expect(renamed.map(&:name)).to eql(%i[id name])
+    expect(renamed.map { |attr| attr.meta[:name] }).to eql(%i[user_id user_name])
+  end
+end


### PR DESCRIPTION
This makes `Schema#project` first class and adds `Schema#rename`. We'll be able to replace `header` concept in rom-sql with this (header will be deprecated there).