### PR TITLE
Update dry-types dependency to 0.9

### DIFF
--- a/rom.gemspec
+++ b/rom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  gem.add_runtime_dependency 'dry-types', '~> 0.8'
+  gem.add_runtime_dependency 'dry-types', '~> 0.9'
   gem.add_runtime_dependency 'rom-support', '~> 2.0'
   gem.add_runtime_dependency 'rom-mapper', '~> 0.4.0'
 


### PR DESCRIPTION
This should make it possible to work with rom-sql 0.9, which also depends on dry-types 0.9.