### PR TITLE
Add before/after command hooks

### DIFF
--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -155,6 +155,16 @@ module ROM
       self.class.build(new_relation, options.merge(source: relation))
     end
 
+    # @api public
+    def before(*hooks)
+      self.class.new(relation, options.merge(before: hooks))
+    end
+
+    # @api public
+    def after(*hooks)
+      self.class.new(relation, options.merge(after: hooks))
+    end
+
     private
 
     # @api private

--- a/lib/rom/commands/class_interface.rb
+++ b/lib/rom/commands/class_interface.rb
@@ -123,7 +123,7 @@ module ROM
       #
       # @api private
       def options
-        { input: input, result: result }
+        { input: input, result: result, before: before, after: after }
       end
 
       # @api private

--- a/lib/rom/commands/lazy/create.rb
+++ b/lib/rom/commands/lazy/create.rb
@@ -10,11 +10,11 @@ module ROM
           if size > 1 && last.is_a?(Array)
             last.map.with_index do |parent, index|
               children = evaluator.call(first, index)
-              command_proc[command, parent, children].call(children, parent)
+              command_proc[command, parent, children].with(children).(parent)
             end.reduce(:concat)
           else
             input = evaluator.call(first)
-            command.call(input, *args[1..size-1])
+            command.with(input).(*args[1..size-1])
           end
         end
       end

--- a/lib/rom/commands/lazy/update.rb
+++ b/lib/rom/commands/lazy/update.rb
@@ -12,7 +12,7 @@ module ROM
               children = evaluator.call(first, index)
 
               children.map do |child|
-                command_proc[command, parent, child].call(child, parent)
+                command_proc[command, parent, child].with(child).(parent)
               end
             end.reduce(:concat)
           else
@@ -20,11 +20,11 @@ module ROM
 
             if input.is_a?(Array)
               input.map.with_index do |item, index|
-                command_proc[command, last, item].call(item, *args[1..size-1])
+                command_proc[command, last, item].with(item).(*args[1..size-1])
               end
             else
               command_proc[command, *(size > 1 ? [last, input] : [input])]
-                .call(input, *args[1..size-1])
+                .with(input).(*args[1..size-1])
             end
           end
         end

--- a/spec/integration/commands/create_spec.rb
+++ b/spec/integration/commands/create_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe 'Commands / Create' do
       relation :tasks
       register_as :create
       result :one
+      before :associate
 
-      def execute(task, user)
-        super(task.merge(name: user.to_h[:name]))
+      def associate(task, user)
+        task.merge(name: user.to_h[:name])
       end
     end
 

--- a/spec/integration/commands/graph_spec.rb
+++ b/spec/integration/commands/graph_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe 'Building up a command graph for nested input' do
     configuration.commands(:tasks) do
       define(:create) do
         result :one
+        before :associate
 
-        def execute(tuple, user)
-          super(tuple.merge(user: user.fetch(:name)))
+        def associate(tuple, user)
+          tuple.merge(user: user.fetch(:name))
         end
       end
     end
@@ -66,8 +67,10 @@ RSpec.describe 'Building up a command graph for nested input' do
   it 'creates a command graph for nested input with :many results as root' do
     configuration.commands(:tasks) do
       define(:create) do
-        def execute(tuples, user)
-          super(tuples.map { |t| t.merge(user: user.fetch(:name)) })
+        before :associate
+
+        def associate(tuples, user)
+          tuples.map { |t| t.merge(user: user.fetch(:name)) }
         end
       end
     end
@@ -120,16 +123,19 @@ RSpec.describe 'Building up a command graph for nested input' do
   it 'updates graph elements cleanly' do
     configuration.commands(:tasks) do
       define(:create) do
-        def execute(tuples, user)
-          super(tuples.map { |t| t.merge(user: user.fetch(:name)) })
+        before :associate
+
+        def associate(tuples, user)
+          tuples.map { |t| t.merge(user: user.fetch(:name)) }
         end
       end
 
       define(:update) do
         result :one
+        before :associate
 
-        def execute(tuple, user)
-          super(tuple.merge(user: user.fetch(:name)))
+        def associate(tuple, user)
+          tuple.merge(user: user.fetch(:name))
         end
       end
 
@@ -186,9 +192,7 @@ RSpec.describe 'Building up a command graph for nested input' do
 
     create.call(initial)
 
-    container.command(:tasks).create.call(
-      [{ title: 'Task One'}], { name: 'Jane' }
-    )
+    container.command(:tasks).create.with([{ title: 'Task One'}]).(name: 'Jane')
 
     expect(container.relation(:tasks)).to match_array([
       { title: 'Change Name', user: 'Johnny' },
@@ -233,8 +237,10 @@ RSpec.describe 'Building up a command graph for nested input' do
 
     configuration.commands(:tasks) do
       define(:create) do
-        def execute(tuples, user)
-          super(tuples.map { |t| t.merge(user: user.fetch(:name)) })
+        before :associate
+
+        def associate(tuples, user)
+          tuples.map { |t| t.merge(user: user.fetch(:name)) }
         end
       end
     end

--- a/spec/shared/command_graph.rb
+++ b/spec/shared/command_graph.rb
@@ -33,16 +33,20 @@ shared_context 'command graph' do
 
     configuration.commands(:books) do
       define(:create) do
-        def execute(tuples, user)
-          super(tuples.map { |t| t.merge(user: user.fetch(:name)) })
+        before :associate
+
+        def associate(tuples, user)
+          tuples.map { |t| t.merge(user: user.fetch(:name)) }
         end
       end
     end
 
     configuration.commands(:tags) do
       define(:create) do
-        def execute(tuples, task)
-          super(tuples.map { |t| t.merge(task: task.fetch(:title)) })
+        before :associate
+
+        def associate(tuples, task)
+          tuples.map { |t| t.merge(task: task.fetch(:title)) }
         end
       end
     end

--- a/spec/unit/rom/commands/graph_spec.rb
+++ b/spec/unit/rom/commands/graph_spec.rb
@@ -75,17 +75,19 @@ RSpec.describe ROM::Commands::Graph do
     configuration.commands(:tasks) do
       define(:create) do
         result :one
+        before :associate
 
-        def execute(task, user)
-          super(task.merge(user: user[:name]))
+        def associate(task, user)
+          task.merge(user: user[:name])
         end
       end
 
       define(:create) do
         register_as :create_many
+        before :associate
 
-        def execute(tasks, user)
-          super(tasks.map { |t| t.merge(user: user[:name]) })
+        def associate(tasks, user)
+          tasks.map { |t| t.merge(user: user[:name]) }
         end
       end
     end
@@ -93,13 +95,12 @@ RSpec.describe ROM::Commands::Graph do
     configuration.commands(:tags) do
       define(:create) do
         register_as :create_many
+        before :associate
 
-        def execute(tags, tasks)
-          super(
-            Array([tasks]).flatten.map { |task|
-              tags.map { |tag| tag.merge(task: task[:title]) }
-            }.flatten
-          )
+        def associate(tags, tasks)
+          Array([tasks]).flatten.map { |task|
+            tags.map { |tag| tag.merge(task: task[:title]) }
+          }.flatten
         end
       end
     end

--- a/spec/unit/rom/commands/lazy_spec.rb
+++ b/spec/unit/rom/commands/lazy_spec.rb
@@ -56,16 +56,19 @@ RSpec.describe ROM::Commands::Lazy do
       end
 
       define(:create_many, type: :create) do
-        def execute(tuples, user)
-          super(tuples.map { |tuple| tuple.merge(user: user[:name]) })
+        before :associate
+
+        def associate(tuples, user)
+          tuples.map { |tuple| tuple.merge(user: user[:name]) }
         end
       end
 
       define(:update) do
         result :one
+        before :associate
 
-        def execute(tuple, user)
-          super(tuple.merge(user: user[:name]))
+        def associate(tuple, user)
+          tuple.merge(user: user[:name])
         end
       end
     end

--- a/spec/unit/rom/commands/pre_and_post_processors_spec.rb
+++ b/spec/unit/rom/commands/pre_and_post_processors_spec.rb
@@ -1,7 +1,37 @@
 require 'rom/command'
 
 RSpec.describe ROM::Command, 'before/after hooks' do
-  context 'without extra args' do
+  let(:relation) do
+    spy(:relation)
+  end
+
+  describe '#before' do
+    subject(:command) do
+      Class.new(ROM::Command) do
+        def prepare(*)
+        end
+      end.build(relation)
+    end
+
+    it 'returns a new command with configured before hooks' do
+      expect(command.before(:prepare).before_hooks).to include(:prepare)
+    end
+  end
+
+  describe '#after' do
+    subject(:command) do
+      Class.new(ROM::Command) do
+        def prepare(*)
+        end
+      end.build(relation)
+    end
+
+    it 'returns a new command with configured after hooks' do
+      expect(command.after(:prepare).after_hooks).to include(:prepare)
+    end
+  end
+
+  context 'without curried args' do
     subject(:command) do
       Class.new(ROM::Command) do
         result :many
@@ -26,10 +56,6 @@ RSpec.describe ROM::Command, 'before/after hooks' do
 
     let(:tuples) do
       [{ name: 'Jane' }, { name: 'Joe' }]
-    end
-
-    let(:relation) do
-      spy(:relation)
     end
 
     it 'applies before/after hooks' do

--- a/spec/unit/rom/commands/pre_and_post_processors_spec.rb
+++ b/spec/unit/rom/commands/pre_and_post_processors_spec.rb
@@ -1,0 +1,99 @@
+require 'rom/command'
+
+RSpec.describe ROM::Command, 'before/after hooks' do
+  context 'without extra args' do
+    subject(:command) do
+      Class.new(ROM::Command) do
+        result :many
+        before :prepare
+        after :finalize
+
+        def execute(tuples)
+          input = tuples.map.with_index { |tuple, idx| tuple.merge(id: idx + 1) }
+          relation.insert(input)
+          input
+        end
+
+        def prepare(tuples)
+          tuples.map { |tuple| tuple.merge(prepared: true) }
+        end
+
+        def finalize(tuples)
+          tuples.map { |tuple| tuple.merge(finalized: true) }
+        end
+      end.build(relation)
+    end
+
+    let(:tuples) do
+      [{ name: 'Jane' }, { name: 'Joe' }]
+    end
+
+    let(:relation) do
+      spy(:relation)
+    end
+
+    it 'applies before/after hooks' do
+      insert_tuples = [
+        { id: 1, name: 'Jane', prepared: true },
+        { id: 2, name: 'Joe', prepared: true }
+      ]
+
+      result = [
+        { id: 1, name: 'Jane', prepared: true, finalized: true },
+        { id: 2, name: 'Joe', prepared: true, finalized: true }
+      ]
+
+      expect(command.call(tuples)).to eql(result)
+
+      expect(relation).to have_received(:insert).with(insert_tuples)
+    end
+  end
+
+  context 'with extra args' do
+    subject(:command) do
+      Class.new(ROM::Command) do
+        result :many
+        before :prepare
+        after :finalize
+
+        def execute(tuples)
+          input = tuples.map.with_index { |tuple, idx| tuple.merge(id: idx + 1) }
+          relation.insert(input)
+          input
+        end
+
+        def prepare(tuples, name)
+          tuples.map.with_index { |tuple, idx| tuple.merge(name: "#{name} #{idx + 1}") }
+        end
+
+        def finalize(tuples)
+          tuples.map { |tuple| tuple.merge(finalized: true) }
+        end
+      end.build(relation)
+    end
+
+    let(:tuples) do
+      [{ email: 'user-1@test.com' }, { email: 'user-2@test.com' }]
+    end
+
+    let(:relation) do
+      spy(:relation)
+    end
+
+    it 'applies before/after hooks' do
+      insert_tuples = [
+        { id: 1, email: 'user-1@test.com', name: 'User 1' },
+        { id: 2, email: 'user-2@test.com', name: 'User 2' }
+      ]
+
+      result = [
+        { id: 1, email: 'user-1@test.com', name: 'User 1', finalized: true },
+        { id: 2, email: 'user-2@test.com', name: 'User 2', finalized: true }
+      ]
+
+      expect(command.with(tuples).call('User')).to eql(result)
+
+      expect(relation).to have_received(:insert).with(insert_tuples)
+    end
+  end
+end

--- a/spec/unit/rom/commands_spec.rb
+++ b/spec/unit/rom/commands_spec.rb
@@ -99,8 +99,14 @@ RSpec.describe 'Commands' do
       }.build(users)
 
       create_task = Class.new(ROM::Commands::Create) {
-        def execute(task_input, user_tuple)
-          relation.insert(task_input.merge(user_id: user_tuple[:user_id]))
+        before :associate
+
+        def associate(task_input, user_tuple)
+          task_input.merge(user_id: user_tuple[:user_id])
+        end
+
+        def execute(task_input)
+          relation.insert(task_input)
         end
       }.build(tasks)
 


### PR DESCRIPTION
## Overview

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️  **BREAKING CHANGE** ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️

This makes it impossible to override `execute` to pre/post process input tuples, and makes `execute` a true implementation detail in adapters. This approach turned out to be problematic as we had to create additional command classes, configuring them was awkward, and it was inflexible. Instead of overidding `execute` this PR introduces a new concept of before/after hooks that are applied with correct arguments and in correct order.

This addition means two things:

- there's no longer any need to override `execute` (which was private anyway) in order to pre- or post-process input or result tuples
- hooks are based on class-level pre-configured options, or instance-level options that can be used at run-time
- initially we're going to support hooks as a list of command method names, and additional arguments can be provided for things like associations (explicit assoc name, or join keys etc.)

This feature is mostly for rom-sql, as its `associates` plugin has been difficult to use as it requires creating special command classes with overridden `execute`, which was an overkill; however, I'm pretty sure many other adapters can benefit from this.

### Hook types

- `before` is executed using curried args and call args, this allows us to prepare curried tuples based on additional args, the result of applying this hook is passed directly to `execute` method
- `after` is applied to the result of `execute` method, and whatever is returned becomes the actual command result, either a single tuple or an array with 1 or more tuples

### New API

``` ruby
# you can preconfigure a command class to always apply hooks
class CreateTask < ROM::Commands::Create[:memory]
  result :one
  relation :users
  before :associate_user

  def associate_user(task, user)
    task.merge(user_id: user[:id])
  end
end

# call with curried task and a user
create_task.with(title: "Task 1").call(id: 1, name: "Jane")
```

The actual cool part, and one of the most important reasons why this feature was created, is to be able to ask for a command with hooks dynamically at run-time. This will allow us to prepare all types of commands with additional tuple processing in places like repositories, without having to create special command *classes*:

``` ruby
# this is the same as the above, but at runtime
class CreateTask < ROM::Commands::Create[:memory]
  result :one
  relation :users

  def associate_user(task, user)
    task.merge(user_id: user[:id])
  end
end

# call with curried task and a user
create_task.before(:associate_user).with(title: "Task 1").call(id: 1, name: "Jane")
```

### TODO

- [x] add `before` and `after` command hooks
- [x] update graph to use hook-based command calls
- [x] add ability to provide additional args for hooks, ie `before(associate: :user)` where `:user` is an association name
- [x] add `Command#before` and `Command#after`
- [x] port `associates` rom-sql plugin to use this new API to make sure it does the job