### PR TITLE
Add support for defining schema types for reading data

### DIFF
--- a/lib/rom/plugins/command/schema.rb
+++ b/lib/rom/plugins/command/schema.rb
@@ -20,9 +20,9 @@ module ROM
 
               input_handler =
                 if default_input != Hash && relation.schema?
-                  -> tuple { relation.schema_hash[input[tuple]] }
+                  -> tuple { relation.input_schema[input[tuple]] }
                 elsif relation.schema?
-                  relation.schema_hash
+                  relation.input_schema
                 else
                   default_input
                 end

--- a/lib/rom/schema.rb
+++ b/lib/rom/schema.rb
@@ -256,6 +256,20 @@ module ROM
       freeze
     end
 
+    # @api private
+    def to_output_hash
+      Types::Coercible::Hash.schema(
+        map { |attr| [attr.name, attr.to_read_type] }.to_h
+      )
+    end
+
+    # @api private
+    def to_input_hash
+      Types::Coercible::Hash.schema(
+        map { |attr| [attr.name, attr] }.to_h
+      )
+    end
+
     private
 
     # @api private

--- a/lib/rom/schema/dsl.rb
+++ b/lib/rom/schema/dsl.rb
@@ -32,9 +32,15 @@ module ROM
       # @see Relation.schema
       #
       # @api public
-      def attribute(name, type)
+      def attribute(name, type, options = EMPTY_HASH)
         @attributes ||= {}
-        @attributes[name] = type.meta(name: name, source: relation)
+
+        @attributes[name] =
+          if options[:read]
+            type.meta(name: name, source: relation, read: options[:read])
+          else
+            type.meta(name: name, source: relation)
+          end
       end
 
       # Specify which key(s) should be the primary key

--- a/lib/rom/schema/type.rb
+++ b/lib/rom/schema/type.rb
@@ -13,6 +13,20 @@ module ROM
         @type = type
       end
 
+      # @api private
+      def [](input)
+        type[input]
+      end
+
+      # @api private
+      def read?
+        ! meta[:read].nil?
+      end
+
+      def to_read_type
+        read? ? meta[:read] : type
+      end
+
       # @api public
       def primary_key?
         meta[:primary_key].equal?(true)

--- a/spec/unit/rom/plugins/command/schema_spec.rb
+++ b/spec/unit/rom/plugins/command/schema_spec.rb
@@ -38,17 +38,17 @@ RSpec.describe ROM::Plugins::Command::Schema do
 
     context 'when relation has a schema' do
       let(:relation) do
-        instance_double(ROM::Relation, schema?: true, schema_hash: schema_hash)
+        instance_double(ROM::Relation, schema?: true, input_schema: input_schema)
       end
 
-      let(:schema_hash) do
-        double(:schema_hash)
+      let(:input_schema) do
+        double(:input_schema)
       end
 
       it 'sets schema hash as input handler' do
         command = Class.new(command_class).build(relation)
 
-        expect(command.input).to be(schema_hash)
+        expect(command.input).to be(input_schema)
       end
 
       it 'sets a composed input handler with schema hash and a custom one' do
@@ -57,7 +57,7 @@ RSpec.describe ROM::Plugins::Command::Schema do
         command = Class.new(command_class) { input my_handler }.build(relation)
 
         expect(my_handler).to receive(:[]).with('some value').and_return('my handler')
-        expect(schema_hash).to receive(:[]).with('my handler').and_return('a tuple')
+        expect(input_schema).to receive(:[]).with('my handler').and_return('a tuple')
 
         expect(command.input['some value']).to eql('a tuple')
       end

--- a/spec/unit/rom/relation/call_spec.rb
+++ b/spec/unit/rom/relation/call_spec.rb
@@ -1,0 +1,51 @@
+require 'rom/relation'
+
+RSpec.describe ROM::Relation, '#call' do
+  subject(:relation) do
+    relation_class.new(data)
+  end
+
+  context 'without read types in schema' do
+    let(:relation_class) do
+      Class.new(ROM::Relation[:memory]) do
+        schema do
+          attribute :id, ROM::Types::Int
+          attribute :name, ROM::Types::String
+        end
+      end
+    end
+
+    let(:data) do
+      [{ id: '1', name: 'Jane' }, { id: '2', name: 'John'} ]
+    end
+
+    it 'has noop output_schema' do
+      expect(relation.output_schema).to be(ROM::Relation::NOOP_OUTPUT_SCHEMA)
+    end
+
+    it 'returns loaded relation with data' do
+      expect(relation.call.collection).
+        to eql(data)
+    end
+  end
+
+  context 'with read types in schema' do
+    let(:relation_class) do
+      Class.new(ROM::Relation[:memory]) do
+        schema do
+          attribute :id, ROM::Types::String, read: ROM::Types::Coercible::Int
+          attribute :name, ROM::Types::String
+        end
+      end
+    end
+
+    let(:data) do
+      [{ id: '1', name: 'Jane' }, { id: '2', name: 'John'} ]
+    end
+
+    it 'returns loaded relation with coerced data' do
+      expect(relation.call.collection).
+        to eql([{ id: 1, name: 'Jane' }, { id: 2, name: 'John'} ])
+    end
+  end
+end

--- a/spec/unit/rom/relation/schema_spec.rb
+++ b/spec/unit/rom/relation/schema_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe ROM::Relation, '.schema' do
     expect(Test::Users.schema).to eql(schema)
   end
 
+  it 'allows defining types for reading tuples' do
+    module Test
+      module Types
+        CoercibleDate = ROM::Types::Date.constructor(Date.method(:parse))
+      end
+    end
+
+    class Test::Users < ROM::Relation[:memory]
+      schema do
+        attribute :id, Types::Int
+        attribute :date, Types::Coercible::String, read: Test::Types::CoercibleDate
+      end
+    end
+
+    schema = Test::Users.schema
+
+    expect(schema.to_output_hash).
+      to eql(ROM::Types::Coercible::Hash.schema(id: schema[:id].type, date: schema[:date].meta[:read]))
+  end
+
   it 'allows setting composite primary key' do
     class Test::Users < ROM::Relation[:memory]
       schema do

--- a/spec/unit/rom/relation_spec.rb
+++ b/spec/unit/rom/relation_spec.rb
@@ -232,13 +232,13 @@ RSpec.describe ROM::Relation do
     end
   end
 
-  describe '#schema_hash' do
+  describe '#input_schema' do
     it 'returns a schema hash type' do
       relation = Class.new(ROM::Relation[:memory]) do
         schema { attribute :id, ROM::Types::Coercible::Int }
       end.new([])
 
-      expect(relation.schema_hash[id: '1']).to eql(id: 1)
+      expect(relation.input_schema[id: '1']).to eql(id: 1)
     end
 
     it 'returns a plain Hash coercer when there is no schema' do
@@ -246,7 +246,7 @@ RSpec.describe ROM::Relation do
 
       tuple = [[:id, '1']]
 
-      expect(relation.schema_hash[tuple]).to eql(id: '1')
+      expect(relation.input_schema[tuple]).to eql(id: '1')
     end
   end
 end


### PR DESCRIPTION
This extends schema DSL with the ability to define "read" type that will
be used when a relation loads its tuples. By default we set this to a
noop passthrough-proc but if there are any attributes with a special
"read" type then we use relation's schema "relation hash" which is built
from schema attributes including "read" types.

This is a last-moment addition but it turned out we can't support
various custom DB types without this feature, and it was planned already
for rom 3.1.0 anyway.

Here's extended schema API:

``` ruby
class Users < ROM::Relation[:yaml]
  schema do
    # this means that the canonical db type is a string but we want an int
    # in resulting relation tuples
    attribute :id, Types::String, read: Types::Coercible::Int
    attribute :name, Types::String
  end
end
```

/cc @flash-gordon @AMHOL 