### PR TITLE
WIP: Add interface to pass config options from relation to dataset

### DIFF
--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -299,6 +299,15 @@ module ROM
         relation_class.schema || relation_class.schema_class.define(relation_class.default_name)
       end
 
+      # Returns options that will override dataset config
+      #
+      # @return [Hash]
+      #
+      # @api public
+      def dataset_options
+        EMPTY_HASH
+      end
+
       # Hook to finalize a relation after its instance was created
       #
       # @api private

--- a/lib/rom/setup/finalize/finalize_relations.rb
+++ b/lib/rom/setup/finalize/finalize_relations.rb
@@ -53,7 +53,7 @@ module ROM
         klass.schema(infer: true) unless klass.schema
         klass.schema.finalize!(gateway: gateway, relations: registry)
 
-        dataset = gateway.dataset(klass.dataset).instance_exec(klass, &ds_proc)
+        dataset = gateway.dataset(klass.dataset, klass.dataset_options).instance_exec(klass, &ds_proc)
 
         klass.new(dataset, __registry__: registry)
       end


### PR DESCRIPTION
**Why?**
This change required for `rom-http` adapter

**This PR**
Adds interface `Relation.dataset_options` that
will be passed to related dataset