### PR TITLE
Instrumentation plugin

### DIFF
--- a/lib/rom.rb
+++ b/lib/rom.rb
@@ -30,6 +30,7 @@ require 'rom/create_container'
 # register core plugins
 require 'rom/plugins/configuration/configuration_dsl'
 require 'rom/plugins/relation/registry_reader'
+require 'rom/plugins/relation/instrumentation'
 require 'rom/plugins/command/schema'
 
 module ROM
@@ -38,6 +39,7 @@ module ROM
   plugins do
     register :macros, ROM::ConfigurationPlugins::ConfigurationDSL, type: :configuration
     register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
+    register :instrumentation, ROM::Plugins::Relation::Instrumentation, type: :relation
     register :schema, ROM::Plugins::Command::Schema, type: :command
   end
 end

--- a/lib/rom/configuration.rb
+++ b/lib/rom/configuration.rb
@@ -13,7 +13,7 @@ module ROM
 
     attr_reader :environment, :setup
 
-    def_delegators :@setup, :register_relation, :register_command, :register_mapper,
+    def_delegators :@setup, :register_relation, :register_command, :register_mapper, :register_plugin,
                             :relation_classes, :command_classes, :mapper_classes,
                             :auto_registration
 

--- a/lib/rom/configuration_dsl.rb
+++ b/lib/rom/configuration_dsl.rb
@@ -70,5 +70,17 @@ module ROM
     def commands(name, &block)
       register_command(*CommandDSL.new(name, default_adapter, &block).command_classes)
     end
+
+    # @api public
+    def plugin(adapter, spec, &block)
+      type, name = spec.flatten(1)
+      plugin = plugin_registry.send(type).adapter(adapter).fetch(name) { plugin_registry.send(type).fetch(name) }
+      register_plugin(plugin.configure(&block))
+    end
+
+    # @api private
+    def plugin_registry
+      ROM.plugin_registry
+    end
   end
 end

--- a/lib/rom/create_container.rb
+++ b/lib/rom/create_container.rb
@@ -27,6 +27,7 @@ module ROM
         relation_classes: setup.relation_classes,
         command_classes: setup.command_classes,
         mappers: setup.mapper_classes,
+        plugins: setup.plugins,
         config: environment.config.dup.freeze
       )
 

--- a/lib/rom/plugin.rb
+++ b/lib/rom/plugin.rb
@@ -1,10 +1,13 @@
 require 'rom/plugin_base'
+require 'rom/support/configurable'
 
 module ROM
   # Plugin is a simple object used to store plugin configurations
   #
   # @private
   class Plugin < PluginBase
+    include Configurable
+
     # Apply this plugin to the provided class
     #
     # @param [Class] klass

--- a/lib/rom/plugin_base.rb
+++ b/lib/rom/plugin_base.rb
@@ -14,9 +14,18 @@ module ROM
     attr_reader :options
 
     # @api private
+    attr_reader :type
+
+    # @api private
     def initialize(mod, options)
       @mod      = mod
       @options  = options
+      @type = options.fetch(:type)
+    end
+
+    # @api private
+    def relation?
+      type == :relation
     end
 
     # Apply this plugin to the provided class

--- a/lib/rom/plugins/relation/instrumentation.rb
+++ b/lib/rom/plugins/relation/instrumentation.rb
@@ -1,39 +1,40 @@
 module ROM
   module Plugins
     module Relation
+      # Experimental plugin for configuring relations with an external
+      # instrumentation system like dry-monitor or ActiveSupport::Notifications
+      #
+      # @api public
       module Instrumentation
         # This hooks sets up a relation class with injectible notifications object
         #
         # @api private
         def self.included(klass)
           super
-
-          klass.class_eval do
-            defines :notifications
-
-            option :notifications, reader: true, default: -> relation {
-              relation.class.notifications.()
-            }
-          end
+          klass.option :notifications, reader: true
+          klass.extend(ClassInterface)
+          klass.instrument(:to_a)
         end
 
-        # Experimental plugin for configuring relations with an external
-        # instrumentation system like dry-monitor or ActiveSupport::Notifications
-        #
-        # @api public
-        def to_a
-          instrument { super }
+        module ClassInterface
+          def instrument(*methods)
+            methods.each do |meth|
+              define_method(meth) do
+                instrument { super }
+              end
+            end
+          end
         end
 
         # @api public
         def instrument(&block)
-          notifications.instrument(self.class.adapter, { name: name.relation }.merge(notification_payload), &block)
+          notifications.instrument(self.class.adapter, { name: name.relation }.merge(notification_payload(self)), &block)
         end
 
         private
 
         # @api private
-        def notification_payload
+        def notification_payload(relation)
           EMPTY_HASH
         end
       end

--- a/lib/rom/plugins/relation/instrumentation.rb
+++ b/lib/rom/plugins/relation/instrumentation.rb
@@ -1,0 +1,42 @@
+module ROM
+  module Plugins
+    module Relation
+      module Instrumentation
+        # This hooks sets up a relation class with injectible notifications object
+        #
+        # @api private
+        def self.included(klass)
+          super
+
+          klass.class_eval do
+            defines :notifications
+
+            option :notifications, reader: true, default: -> relation {
+              relation.class.notifications.()
+            }
+          end
+        end
+
+        # Experimental plugin for configuring relations with an external
+        # instrumentation system like dry-monitor or ActiveSupport::Notifications
+        #
+        # @api public
+        def to_a
+          instrument { super }
+        end
+
+        # @api public
+        def instrument(&block)
+          notifications.instrument(self.class.adapter, { name: name.relation }.merge(notification_payload), &block)
+        end
+
+        private
+
+        # @api private
+        def notification_payload
+          EMPTY_HASH
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -17,11 +17,16 @@ module ROM
     # @api private
     attr_reader :command_classes
 
+
+    # @api private
+    attr_reader :plugins
+
     # @api private
     def initialize
       @relation_classes = []
       @command_classes = []
       @mapper_classes = []
+      @plugins = []
     end
 
     # Relation sub-classes are being registered with this method during setup
@@ -43,6 +48,11 @@ module ROM
     # @api private
     def register_command(*klasses)
       klasses.reduce(@command_classes, :<<)
+    end
+
+    # @api private
+    def register_plugin(plugin)
+      plugins << plugin
     end
 
     def auto_registration(directory, options = {})

--- a/lib/rom/setup/finalize.rb
+++ b/lib/rom/setup/finalize.rb
@@ -21,7 +21,7 @@ module ROM
   # @private
   class Finalize
     attr_reader :gateways, :repo_adapter, :datasets, :gateway_map,
-      :relation_classes, :mapper_classes, :mapper_objects, :command_classes, :config
+      :relation_classes, :mapper_classes, :mapper_objects, :command_classes, :plugins, :config
 
     # @api private
     def initialize(options)
@@ -36,6 +36,8 @@ module ROM
       @mapper_objects = (mappers - @mapper_classes).reduce(:merge) || {}
 
       @config = options.fetch(:config)
+
+      @plugins = options.fetch(:plugins)
 
       initialize_datasets
     end
@@ -90,7 +92,7 @@ module ROM
     #
     # @api private
     def load_relations
-      FinalizeRelations.new(gateways, relation_classes).run!
+      FinalizeRelations.new(gateways, relation_classes, plugins.select(&:relation?)).run!
     end
 
     # @api private

--- a/lib/rom/support/configurable.rb
+++ b/lib/rom/support/configurable.rb
@@ -21,6 +21,10 @@ module ROM
         settings.key?(name)
       end
 
+      def to_hash
+        settings
+      end
+
       # @api private
       def freeze
         settings.each_value(&:freeze)
@@ -31,13 +35,13 @@ module ROM
       def respond_to_missing?(_name, _include_private = false)
         true
       end
-      
+
       def dup
         self.class.new(dup_settings(settings))
       end
-        
+
       private
-      
+
       def dup_settings(settings)
         settings.each_with_object({}) do |(key, value), new_settings|
           if value.is_a?(self.class)
@@ -75,6 +79,7 @@ module ROM
     # @api public
     def configure
       yield(config)
+      self
     end
   end
 end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -163,4 +163,22 @@ RSpec.describe 'Configuring ROM' do
       ROM.container(:memory) { |c| c.register_relation(Test::UserRelation) }
     end
   end
+
+  describe 'instrumentation setup' do
+    it 'allows setting instrumentation for relations' do
+      Test::Notifications = double(:notifications)
+
+      configuration = ROM::Configuration.new(:memory)
+
+      configuration.plugin(:memory, relations: :instrumentation) do |p|
+        p.notifications = Test::Notifications
+      end
+
+      configuration.relation(:users)
+
+      container = ROM.container(configuration)
+
+      expect(container.relations[:users].notifications).to be(Test::Notifications)
+    end
+  end
 end

--- a/spec/unit/rom/plugins/relation/instrumentation_spec.rb
+++ b/spec/unit/rom/plugins/relation/instrumentation_spec.rb
@@ -1,0 +1,35 @@
+require 'rom'
+require 'rom/memory'
+
+RSpec.describe ROM::Plugins::Relation::Instrumentation do
+  subject(:relation) do
+    relation_class.new(dataset)
+  end
+
+  let(:dataset) do
+    double(:dataset)
+  end
+
+  let(:relation_class) do
+    Class.new(ROM::Memory::Relation) do
+      schema(:users) do
+        attribute :name, ROM::Types::String
+      end
+
+      use :instrumentation
+
+      notifications -> { Test::Notifications }
+    end
+  end
+
+  before do
+    Test.const_set(:Notifications, spy(:notifications))
+  end
+
+  it 'uses notifications API when materializing a relation' do
+    relation.to_a
+
+    expect(Test::Notifications).
+      to have_received(:instrument).with(:memory, name: :users)
+  end
+end

--- a/spec/unit/rom/plugins/relation/instrumentation_spec.rb
+++ b/spec/unit/rom/plugins/relation/instrumentation_spec.rb
@@ -3,7 +3,7 @@ require 'rom/memory'
 
 RSpec.describe ROM::Plugins::Relation::Instrumentation do
   subject(:relation) do
-    relation_class.new(dataset)
+    relation_class.new(dataset, notifications: notifications)
   end
 
   let(:dataset) do
@@ -17,19 +17,14 @@ RSpec.describe ROM::Plugins::Relation::Instrumentation do
       end
 
       use :instrumentation
-
-      notifications -> { Test::Notifications }
     end
   end
 
-  before do
-    Test.const_set(:Notifications, spy(:notifications))
-  end
+  let(:notifications) { spy(:notifications) }
 
   it 'uses notifications API when materializing a relation' do
     relation.to_a
 
-    expect(Test::Notifications).
-      to have_received(:instrument).with(:memory, name: :users)
+    expect(notifications).to have_received(:instrument).with(:memory, name: :users)
   end
 end


### PR DESCRIPTION
This adds a new configuration dsl for setting up plugins with their config and a new relation plugin called `:instrumentation` which provides basic infrastructure for setting up instrumentation in adapters. This will be used in rom-sql to provide SQL logging.