### PR TITLE
Expand AutoRegistrationStrategies::CustomNamespace

### DIFF
--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -29,7 +29,7 @@ module ROM
     option :globs, default: -> {
       Hash[
         component_dirs.map { |component, path|
-          [component, directory.join("#{ path }/**/*.rb")]
+          [component, directory.join("#{path}/**/*.rb")]
         }
       ]
     }

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -66,6 +66,7 @@ module ROM
               file: file, directory: directory, entity: component_dirs.fetch(entity)
             ).call
           end
+
         Dry::Core::Inflector.constantize(klass_name)
       end
     end

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -55,7 +55,7 @@ module ROM
           case namespace
           when String
             AutoRegistrationStrategies::CustomNamespace.new(
-              namespace: namespace, file: file
+              namespace: namespace, file: file, directory: directory
             ).call
           when TrueClass
             AutoRegistrationStrategies::WithNamespace.new(

--- a/lib/rom/setup/auto_registration_strategies/base.rb
+++ b/lib/rom/setup/auto_registration_strategies/base.rb
@@ -10,7 +10,7 @@ module ROM
 
       option :file, type: Types::Strict::String
 
-      EXTENSION_REGEX = /\.rb\z/.freeze
+      EXTENSION_REGEX = /\.rb\z/
     end
   end
 end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -11,24 +11,48 @@ module ROM
       option :namespace, type: Types::Strict::String
 
       def call
-        potential_child = []
+        potential = []
+        attempted = []
 
         path_arr.reverse.each do |dir|
-          fragment = Dry::Core::Inflector.camelize(dir)
-          const = potential_child.unshift(fragment).join("::")
+          const_fragment = potential.unshift(
+            Dry::Core::Inflector.camelize(dir)
+          ).join("::")
 
-          break "#{namespace}::#{const}" if ns_const.const_defined?(const)
+          constant = "#{namespace}::#{const_fragment}"
+
+          return constant if ns_const.const_defined?(const_fragment)
+
+          attempted << constant
         end
+
+        # If we have reached this point, its means constant is not defined and
+        # NameError will be thrown if we attempt to camelize something like:
+        # `"#{namespace}::#{Dry::Core::Inflector.camelize(filename)}"`
+        # so we can assume naming convention was not respected in required
+        # file.
+
+        raise NameError, name_error_message(attempted)
       end
 
       private
+
+      def name_error_message(attempted)
+        "required file does not define expected constant name; either " \
+        "register your constant explicitly of try following the path" \
+        "naming convention like:\n\n\t- #{attempted.join("\n\t- ")}\n"
+      end
+
+      def filename
+        Pathname(file).basename('.rb')
+      end
 
       def ns_const
         @namespace_constant ||= Dry::Core::Inflector.constantize(namespace)
       end
 
       def path_arr
-        file_path << File.basename(file, ".rb")
+        file_path << filename
       end
 
       def file_path

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -27,8 +27,11 @@ module ROM
       end
 
       def path_arr
-        dir, filename = File.split(file)
-        dir.split("/")[1..-1] << File.basename(filename, ".rb")
+        file_path << File.basename(file, ".rb")
+      end
+
+      def file_path
+        File.dirname(file).split("/") - File.expand_path(".").split("/")
       end
     end
   end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -7,6 +7,7 @@ require 'rom/setup/auto_registration_strategies/base'
 module ROM
   module AutoRegistrationStrategies
     class CustomNamespace < Base
+      option :directory, type: PathnameType
       option :namespace, type: Types::Strict::String
 
       def call
@@ -31,7 +32,7 @@ module ROM
       end
 
       def file_path
-        File.dirname(file).split("/") - Dir.pwd.split("/")
+        File.dirname(file).split("/") - directory.to_s.split("/")
       end
     end
   end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -10,13 +10,25 @@ module ROM
       option :namespace, type: Types::Strict::String
 
       def call
-        "#{namespace}::#{Dry::Core::Inflector.camelize(filename)}"
+        potential_child = []
+
+        path_arr.reverse.each do |dir|
+          fragment = Dry::Core::Inflector.camelize(dir)
+          const = potential_child.unshift(fragment).join("::")
+
+          break "#{namespace}::#{const}" if ns_const.const_defined?(const)
+        end
       end
 
       private
 
-      def filename
-        Pathname(file).basename('.rb')
+      def ns_const
+        @namespace_constant ||= Dry::Core::Inflector.constantize(namespace)
+      end
+
+      def path_arr
+        dir, filename = File.split(file)
+        dir.split("/")[1..-1] << File.basename(filename, ".rb")
       end
     end
   end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -31,7 +31,7 @@ module ROM
       end
 
       def file_path
-        File.dirname(file).split("/") - File.expand_path(".").split("/")
+        File.dirname(file).split("/") - Dir.pwd.split("/")
       end
     end
   end

--- a/spec/fixtures/custom_namespace/commands/create_customer.rb
+++ b/spec/fixtures/custom_namespace/commands/create_customer.rb
@@ -1,0 +1,8 @@
+module My
+  module Namespace
+    module Commands
+      class CreateCustomer
+      end
+    end
+  end
+end

--- a/spec/fixtures/custom_namespace/mappers/customer_list.rb
+++ b/spec/fixtures/custom_namespace/mappers/customer_list.rb
@@ -1,0 +1,8 @@
+module My
+  module Namespace
+    module Mappers
+      class CustomerList
+      end
+    end
+  end
+end

--- a/spec/fixtures/custom_namespace/relations/customers.rb
+++ b/spec/fixtures/custom_namespace/relations/customers.rb
@@ -1,0 +1,8 @@
+module My
+  module Namespace
+    module Relations
+      class Customers
+      end
+    end
+  end
+end

--- a/spec/fixtures/wrong/commands/create_customer.rb
+++ b/spec/fixtures/wrong/commands/create_customer.rb
@@ -1,0 +1,8 @@
+module My
+  module NewNamespace
+    module Foo
+      class CreateCustomer
+      end
+    end
+  end
+end

--- a/spec/fixtures/wrong/mappers/customer_list.rb
+++ b/spec/fixtures/wrong/mappers/customer_list.rb
@@ -1,0 +1,8 @@
+module My
+  module NewNamespace
+    module Foo
+      class CustomerList
+      end
+    end
+  end
+end

--- a/spec/fixtures/wrong/relations/customers.rb
+++ b/spec/fixtures/wrong/relations/customers.rb
@@ -1,0 +1,8 @@
+module My
+  module NewNamespace
+    module Foo
+      class Customers
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
   require 'yaml'
   rubies = YAML.load(File.read(File.join(__dir__, '..', '.travis.yml')))['rvm']

--- a/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/spec/unit/rom/setup/auto_registration_spec.rb
@@ -150,6 +150,34 @@ RSpec.describe ROM::Setup, '#auto_registration' do
         end
       end
 
+      context 'when namespace has wrong subnamespace' do
+         subject do
+          -> do
+            setup.auto_registration(
+              SPEC_ROOT.join('fixtures/wrong'),
+              component_dirs: {
+                relations: :relations,
+                mappers: :mappers,
+                commands: :commands
+              },
+              namespace: 'My::NewNamespace'
+            )
+          end
+        end
+
+        describe '#relations' do
+          it { is_expected.to raise_exception NameError }
+        end
+
+        describe '#commands' do
+          it { is_expected.to raise_exception NameError }
+        end
+
+        describe '#mappers' do
+          it { is_expected.to raise_exception NameError }
+        end
+      end
+
       context 'when namespace does not implement subnamespace' do
         before do
           setup.auto_registration(

--- a/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/spec/unit/rom/setup/auto_registration_spec.rb
@@ -117,34 +117,68 @@ RSpec.describe ROM::Setup, '#auto_registration' do
       end
     end
 
-    context 'with custom namespace' do
-      before do
-        setup.auto_registration(
-          SPEC_ROOT.join('fixtures/custom'),
-          component_dirs: {
-            relations: :relations,
-            mappers: :mappers,
-            commands: :commands
-          },
-          namespace: 'My::Namespace'
-        )
-      end
+    describe 'custom namespace' do
+      context 'when namespace has subnamespace' do
+         before do
+          setup.auto_registration(
+            SPEC_ROOT.join('fixtures/custom_namespace'),
+            component_dirs: {
+              relations: :relations,
+              mappers: :mappers,
+              commands: :commands
+            },
+            namespace: 'My::Namespace'
+          )
+        end
 
-      describe '#relations' do
-        it 'loads files and returns constants' do
-          expect(setup.relation_classes).to eql([My::Namespace::Users])
+        describe '#relations' do
+          it 'loads files and returns constants' do
+            expect(setup.relation_classes).to eql([My::Namespace::Relations::Customers])
+          end
+        end
+
+        describe '#commands' do
+          it 'loads files and returns constants' do
+            expect(setup.command_classes).to eql([My::Namespace::Commands::CreateCustomer])
+          end
+        end
+
+        describe '#mappers' do
+          it 'loads files and returns constants' do
+            expect(setup.mapper_classes).to eql([My::Namespace::Mappers::CustomerList])
+          end
         end
       end
 
-      describe '#commands' do
-        it 'loads files and returns constants' do
-          expect(setup.command_classes).to eql([My::Namespace::CreateUser])
+      context 'when namespace does not implement subnamespace' do
+        before do
+          setup.auto_registration(
+            SPEC_ROOT.join('fixtures/custom'),
+            component_dirs: {
+              relations: :relations,
+              mappers: :mappers,
+              commands: :commands
+            },
+            namespace: 'My::Namespace'
+          )
         end
-      end
 
-      describe '#mappers' do
-        it 'loads files and returns constants' do
-          expect(setup.mapper_classes).to eql([My::Namespace::UserList])
+        describe '#relations' do
+          it 'loads files and returns constants' do
+            expect(setup.relation_classes).to eql([My::Namespace::Users])
+          end
+        end
+
+        describe '#commands' do
+          it 'loads files and returns constants' do
+            expect(setup.command_classes).to eql([My::Namespace::CreateUser])
+          end
+        end
+
+        describe '#mappers' do
+          it 'loads files and returns constants' do
+            expect(setup.mapper_classes).to eql([My::Namespace::UserList])
+          end
         end
       end
     end


### PR DESCRIPTION
Hello ROM people.

Some time ago I wanted to autoload some namespaced `ROM::Relation` I have had defined in my project and while everything looked fine and according to namespace path, I was surprised when this did not quite work out.

After some searching and asking on the gitter, I decided to take a look at the code (duh) and figured out autoloader takes only `File.basename(file, ".rb")` as constant name. So, in order to have everything working properly, I could not use `autoload(namespace: "Persistance")` with:

```ruby
# ./lib/persistence/relation/user.rb
module Persistance
  module Relation
    module Users < ROM::Relation[:sql]
      # stuff...
    end
  end
end
```

... as this would attempt to load `Persistence::Users` instead of `Persistence::Relation::Users` and that, of course, would fail. Now, after I figured this out, I modified my code so it would work as expected.

The end!


Well, maybe. Since this was a bit confusing for me, I imagine it might as well be for other people, so I would like to offer a PR which might remedy the situation.