### PR TITLE
Introduce Relation::Wrap

### DIFF
--- a/core/lib/rom/relation/wrap_methods.rb
+++ b/core/lib/rom/relation/wrap_methods.rb
@@ -1,0 +1,72 @@
+require 'rom/relation/wrap'
+
+module ROM
+  class Relation
+    # Provides convenient methods for producing wrapped relations
+    #
+    # @api public
+    module WrapMethods
+      # Wrap other relations
+      #
+      # @example
+      #   tasks.wrap(owner: [users, user_id: :id])
+      #
+      # @param [Hash] options
+      #
+      # @return [RelationProxy]
+      #
+      # @api public
+      def wrap(*names, **options)
+        wrap_class.new(self, wraps_from_names(names) + wraps_from_options(options))
+      end
+
+      # Shortcut to wrap parents
+      #
+      # @example
+      #   tasks.wrap_parent(owner: users)
+      #
+      # @return [RelationProxy]
+      #
+      # @api public
+      def wrap_parent(options)
+        wrap(
+          options.each_with_object({}) { |(name, parent), h|
+            keys = combine_keys(parent, self, :children)
+            h[name] = [parent, keys]
+          }
+        )
+      end
+
+      # Return a wrapped representation of a relation
+      #
+      # This will carry meta info used to produce a correct AST from a relation
+      # so that correct mapper can be generated
+      #
+      # @return [RelationProxy]
+      #
+      # @api private
+      def wrapped(new_name, keys, wrap_from_assoc = false)
+        with(
+          name: name.as(new_name),
+          schema: schema.wrap,
+          meta: {
+            keys: keys, wrap_from_assoc: wrap_from_assoc, wrap: true, combine_name: new_name
+          }
+        )
+      end
+
+      # @api private
+      def wraps_from_options(options)
+        options.map { |(name, (relation, keys))| relation.wrapped(name, keys) }
+      end
+
+      # @api private
+      def wraps_from_names(names)
+        names.map { |name|
+          assoc = associations[name]
+          __registry__[assoc.target.relation].wrapped(name, assoc.combine_keys(__registry__), true)
+        }
+      end
+    end
+  end
+end

--- a/repository/spec/unit/relation_proxy_spec.rb
+++ b/repository/spec/unit/relation_proxy_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe 'loading proxy' do
     it 'returns valid ast for a wrapped relation' do
       relation = tags_relation.wrap_parent(task: tasks_relation)
 
-      tags_schema = tags_relation.schema.qualified
+      tags_schema = tags_relation.schema
       tasks_schema = tasks_relation.schema.wrap
 
       expect(relation.to_ast).to eql(


### PR DESCRIPTION
This adds an explicit representation of a relation which embeds data from other relation(s). It's similar to `Relation::Graph` except that it's materialization logic may differ across adapters. There's a `remove-auto-wrap` branch in rom-sql where this was already integrated.