### PR TITLE
Core associations

### DIFF
--- a/core/lib/rom/associations/abstract.rb
+++ b/core/lib/rom/associations/abstract.rb
@@ -1,0 +1,91 @@
+require 'dry/core/constants'
+require 'dry/core/class_attributes'
+
+require 'rom/types'
+require 'rom/initializer'
+
+module ROM
+  module Associations
+    # Abstract association class
+    #
+    # @api public
+    class Abstract
+      extend Initializer
+
+      include Dry::Core::Constants
+      include Dry::Equalizer(:definition, :source, :target)
+
+      # @!attribute [r] definition
+      #   @return [ROM::Associations::Definition] Association configuration object
+      param :definition
+
+      # @!attribute [r] relations
+      #   @return [ROM::RelationRegistry] Relation registry
+      option :relations, reader: true
+
+      # @!attribute [r] source
+      #   @return [ROM::SQL::Relation] the source relation
+      option :source, reader: true
+
+      # @!attribute [r] target
+      #   @return [ROM::SQL::Relation::Name] the target relation
+      option :target, reader: true
+
+      # @api public
+      def self.new(definition, relations)
+        super(
+          definition,
+          relations: relations,
+          source: relations[definition.source.relation],
+          target: relations[definition.target.relation]
+        )
+      end
+
+      # @api public
+      def view
+        definition.view
+      end
+
+      # @api public
+      def name
+        definition.name
+      end
+
+      # @api public
+      def foreign_key
+        definition.foreign_key
+      end
+
+      # @api public
+      def result
+        definition.result
+      end
+
+      # @api public
+      def join(type, source = self.source, target = self.target)
+        source.__send__(type, target.name.dataset, join_keys).qualified
+      end
+
+      # @api protected
+      def apply_view(schema, relation)
+        view_rel = relation.public_send(view)
+        schema.merge(view_rel.schema.qualified).uniq(&:to_sql_name).(view_rel)
+      end
+
+      # @api public
+      def combine_keys
+        Hash[*with_keys]
+      end
+
+      # @api private
+      def join_key_map
+        join_keys.to_a.flatten.map(&:key)
+      end
+
+      # @api private
+      def self_ref?
+        source.name.dataset == target.name.dataset
+      end
+    end
+  end
+end

--- a/core/lib/rom/associations/many_to_many.rb
+++ b/core/lib/rom/associations/many_to_many.rb
@@ -1,0 +1,68 @@
+require 'rom/types'
+require 'rom/associations/abstract'
+
+module ROM
+  module Associations
+    class ManyToMany < Abstract
+      attr_reader :join_relation
+
+      # @api private
+      def initialize(*)
+        super
+        @join_relation = relations[through]
+      end
+
+      # @api public
+      def call(target_rel = nil)
+        raise NotImplementedError
+      end
+
+      # @api public
+      def foreign_key
+        definition.foreign_key || join_relation.foreign_key(source.name)
+      end
+
+      # @api public
+      def through
+        definition.through
+      end
+
+      # @api private
+      def parent_combine_keys
+        target.associations[source.name].combine_keys.to_a.flatten(1)
+      end
+
+      # @api private
+      def associate(children, parent)
+        ((spk, sfk), (tfk, tpk)) = join_key_map
+
+        case parent
+        when Array
+          parent.map { |p| associate(children, p) }.flatten(1)
+        else
+          children.map { |tuple|
+            { sfk => tuple.fetch(spk), tfk => parent.fetch(tpk) }
+          }
+        end
+      end
+
+      protected
+
+      # @api private
+      def with_keys(&block)
+        source_key = source.primary_key
+        target_key = foreign_key || join_relation.foreign_key(source.name)
+        return [source_key, target_key] unless block
+        yield(source_key, target_key)
+      end
+
+      # @api private
+      def join_key_map
+        left = super
+        right = join_relation.associations[target.name].join_key_map
+
+        [left, right]
+      end
+    end
+  end
+end

--- a/core/lib/rom/associations/many_to_one.rb
+++ b/core/lib/rom/associations/many_to_one.rb
@@ -1,0 +1,28 @@
+require 'rom/associations/abstract'
+
+module ROM
+  module Associations
+    class ManyToOne < Abstract
+      # @api public
+      def call(left = self.target)
+        raise NotImplementedError
+      end
+
+      # @api private
+      def associate(child, parent)
+        fk, pk = join_key_map
+        child.merge(fk => parent.fetch(pk))
+      end
+
+      protected
+
+      # @api private
+      def with_keys(&block)
+        source_key = foreign_key || source.foreign_key(target.name.dataset)
+        target_key = target.schema.primary_key_name
+        return [source_key, target_key] unless block
+        yield(source_key, target_key)
+      end
+    end
+  end
+end

--- a/core/lib/rom/associations/one_to_many.rb
+++ b/core/lib/rom/associations/one_to_many.rb
@@ -1,0 +1,35 @@
+require 'rom/associations/abstract'
+
+module ROM
+  module Associations
+    class OneToMany < Abstract
+      # @api public
+      def call(right = self.target)
+        raise NotImplementedError
+      end
+
+      # @api public
+      def join_keys
+        with_keys { |source_key, target_key|
+          { source[source_key].qualified(source_alias) => target[target_key].qualified }
+        }
+      end
+
+      # @api private
+      def associate(child, parent)
+        pk, fk = join_key_map
+        child.merge(fk => parent.fetch(pk))
+      end
+
+      protected
+
+      # @api private
+      def with_keys(&block)
+        source_key = source.schema.primary_key_name
+        target_key = foreign_key || target.foreign_key(source.name)
+        return [source_key, target_key] unless block
+        yield(source_key, target_key)
+      end
+    end
+  end
+end

--- a/core/lib/rom/associations/one_to_one.rb
+++ b/core/lib/rom/associations/one_to_one.rb
@@ -1,0 +1,8 @@
+require 'rom/associations/one_to_many'
+
+module ROM
+  module Associations
+    class OneToOne < OneToMany
+    end
+  end
+end

--- a/core/lib/rom/associations/one_to_one_through.rb
+++ b/core/lib/rom/associations/one_to_one_through.rb
@@ -1,0 +1,8 @@
+require 'rom/associations/many_to_many'
+
+module ROM
+  module Associations
+    class OneToOneThrough < ManyToMany
+    end
+  end
+end

--- a/core/lib/rom/relation.rb
+++ b/core/lib/rom/relation.rb
@@ -51,9 +51,10 @@ module ROM
     include Relation::Commands
 
     extend Dry::Core::ClassAttributes
-    defines :schema_class, :schema_inferrer, :schema_dsl, :wrap_class
+    defines :schema_class, :schema_attr_class, :schema_inferrer, :schema_dsl, :wrap_class
 
     schema_dsl Schema::DSL
+    schema_attr_class Schema::Attribute
     schema_class Schema
     schema_inferrer Schema::DEFAULT_INFERRER
     wrap_class Relation::Wrap

--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -173,7 +173,11 @@ module ROM
             raise MissingSchemaClassError.new(self)
           end
 
-          dsl = schema_dsl.new(name, schema_class: schema_class, inferrer: inferrer, &block)
+          dsl = schema_dsl.new(
+            name,
+            schema_class: schema_class, attr_class: schema_attr_class, inferrer: inferrer,
+            &block
+          )
 
           @schema = dsl.call
         end

--- a/core/lib/rom/schema.rb
+++ b/core/lib/rom/schema.rb
@@ -38,6 +38,14 @@ module ROM
       end
     end
 
+    AttributeAlreadyDefinedError = Class.new(StandardError)
+
+    include Dry::Equalizer(:name, :attributes)
+    include Enumerable
+
+    attr_reader :name, :attributes, :inferrer, :associations_dsl
+
+
     include Dry::Equalizer(:name, :attributes, :associations)
     include Enumerable
 

--- a/core/lib/rom/schema/associations_dsl.rb
+++ b/core/lib/rom/schema/associations_dsl.rb
@@ -1,0 +1,186 @@
+require 'dry/core/inflector'
+
+require 'rom/associations/definitions'
+
+module ROM
+  class Schema
+    # Additional schema DSL for definition SQL associations
+    #
+    # This DSL is exposed in `associations do .. end` blocks in schema defintions.
+    #
+    # @api public
+    class AssociationsDSL < BasicObject
+      # @!attribute [r] source
+      #   @return [Relation::Name] The source relation
+      attr_reader :source
+
+      # @!attribute [r] registry
+      #   @return [RelationRegistry] Relations registry from a rom container
+      attr_reader :registry
+
+      # @api private
+      def initialize(source, &block)
+        @source = source
+        @registry = {}
+        instance_exec(&block)
+      end
+
+      # Establish a one-to-many association
+      #
+      # @example using relation identifier
+      #   has_many :tasks
+      #
+      # @example with a :through option
+      #   # this establishes many-to-many association
+      #   has_many :tasks, through: :users_tasks
+      #
+      # @example using aliased association with a custom view
+      #   has_many :posts, as: :published_posts, view: :published
+      #
+      # @example using custom target relation
+      #   has_many :user_posts, relation: :posts
+      #
+      # @param [Symbol] target The target relation identifier
+      # @param [Hash] options A hash with additional options
+      #
+      # @return [Associations::OneToMany]
+      #
+      # @see #many_to_many
+      #
+      # @api public
+      def one_to_many(target, options = {})
+        if options[:through]
+          many_to_many(target, options)
+        else
+          add(::ROM::Associations::Definitions::OneToMany.new(source, target, options))
+        end
+      end
+      alias_method :has_many, :one_to_many
+
+      # Establish a one-to-one association
+      #
+      # @example using relation identifier
+      #   one_to_one :addresses, as: :address
+      #
+      # @example with an intermediate join relation
+      #   one_to_one :tasks, as: :priority_task, through: :assignments
+      #
+      # @param [Symbol] target The target relation identifier
+      # @param [Hash] options A hash with additional options
+      #
+      # @return [Associations::OneToOne]
+      #
+      # @see #belongs_to
+      #
+      # @api public
+      def one_to_one(target, options = {})
+        if options[:through]
+          one_to_one_through(target, options)
+        else
+          add(::ROM::Associations::Definitions::OneToOne.new(source, target, options))
+        end
+      end
+
+      # Establish a one-to-one association with a :through option
+      #
+      # @example
+      #   one_to_one_through :users, as: :author, through: :users_posts
+      #
+      # @return [Associations::OneToOneThrough]
+      #
+      # @api public
+      def one_to_one_through(target, options = {})
+        add(::ROM::Associations::Definitions::OneToOneThrough.new(source, target, options))
+      end
+
+      # Establish a many-to-many association
+      #
+      # @example using relation identifier
+      #   many_to_many :tasks, through: :users_tasks
+      #
+      # @param [Symbol] target The target relation identifier
+      # @param [Hash] options A hash with additional options
+      #
+      # @return [Associations::OneToOne]
+      #
+      # @see #one_to_many
+      #
+      # @api public
+      def many_to_many(target, options = {})
+        add(::ROM::Associations::Definitions::ManyToMany.new(source, target, options))
+      end
+
+      # Establish a many-to-one association
+      #
+      # @example using relation identifier
+      #   many_to_one :users, as: :author
+      #
+      # @param [Symbol] target The target relation identifier
+      # @param [Hash] options A hash with additional options
+      #
+      # @return [Associations::OneToOne]
+      #
+      # @see #one_to_many
+      #
+      # @api public
+      def many_to_one(target, options = {})
+        add(::ROM::Associations::Definitions::ManyToOne.new(source, target, options))
+      end
+
+      # Shortcut for many_to_one which sets alias automatically
+      #
+      # @example with an alias (relation identifier is inferred via pluralization)
+      #   belongs_to :user
+      #
+      # @example with an explicit alias
+      #   belongs_to :users, as: :author
+      #
+      # @see #many_to_one
+      #
+      # @return [Associations::ManyToOne]
+      #
+      # @api public
+      def belongs_to(name, options = {})
+        many_to_one(dataset_name(name), {as: name}.merge(options))
+      end
+
+      # Shortcut for one_to_one which sets alias automatically
+      #
+      # @example with an alias (relation identifier is inferred via pluralization)
+      #   one_to_one :address
+      #
+      # @example with an explicit alias and a custom view
+      #   one_to_one :posts, as: :priority_post, view: :prioritized
+      #
+      # @see #one_to_one
+      #
+      # @return [Associations::ManyToOne]
+      #
+      # @api public
+      def has_one(name, options = {})
+        one_to_one(dataset_name(name), {as: name}.merge(options))
+      end
+
+      # Return an association set for a schema
+      #
+      # @return [AssociationSet]
+      #
+      # @api private
+      def call
+        AssociationSet.new(registry)
+      end
+
+      private
+
+      # @api private
+      def add(association)
+        registry[association.name] = association
+      end
+
+      # @api private
+      def dataset_name(name)
+        ::Dry::Core::Inflector.pluralize(name).to_sym
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds core associations APIs, including:

- `Schema::AssociationDSL`
- `Schema::DSL#associations` known from rom-sql
- `Associations::*` classes imported from rom-sql with sql-specific methods removed
- Ability to configure `Relation.schema_attr_class` which defaults to `Schema::Attribute` (and ie rom-sql sets this to `SQL::Attribute`
- A generic `Schema::DSL#call` method so that adapters don't have to implement it

I'll import specs from rom-sql later on. I want to remove ad-hoc combines first because it will simplify code.