### PR TITLE
Enable cross-gateway associations

### DIFF
--- a/core/lib/rom/associations/abstract.rb
+++ b/core/lib/rom/associations/abstract.rb
@@ -61,6 +61,11 @@ module ROM
         definition.result
       end
 
+      # @api public
+      def override?
+        definition.view
+      end
+
       # @api protected
       def apply_view(schema, relation)
         view_rel = relation.public_send(view)
@@ -96,7 +101,11 @@ module ROM
 
       # @api private
       def prepare(target)
-        call(target: target)
+        if override?
+          target.public_send(view)
+        else
+          call(target: target)
+        end
       end
 
       # @api private

--- a/core/lib/rom/associations/definitions/abstract.rb
+++ b/core/lib/rom/associations/definitions/abstract.rb
@@ -47,6 +47,10 @@ module ROM
         #   @return [Symbol] An optional view that should be used to extend assoc relation
         option :view, optional: true
 
+        # @!attribute [r] override
+        #   @return [TrueClass,FalseClass] Whether custom view should override default one or not
+        option :override, optional: true, default: -> { false }
+
         alias_method :name, :as
 
         # @api public
@@ -56,6 +60,11 @@ module ROM
             Name[options[:relation] || target, target, options[:as] || target],
             options
           )
+        end
+
+        # @api public
+        def override?
+          options[:override].equal?(true)
         end
 
         # @api public

--- a/core/lib/rom/memory/associations.rb
+++ b/core/lib/rom/memory/associations.rb
@@ -1,0 +1,4 @@
+require 'rom/memory/associations/many_to_many'
+require 'rom/memory/associations/many_to_one'
+require 'rom/memory/associations/one_to_many'
+require 'rom/memory/associations/one_to_one'

--- a/core/lib/rom/memory/associations/many_to_many.rb
+++ b/core/lib/rom/memory/associations/many_to_many.rb
@@ -1,0 +1,10 @@
+require 'rom/associations/many_to_many'
+
+module ROM
+  module Memory
+    module Associations
+      class ManyToMany < ROM::Associations::ManyToMany
+      end
+    end
+  end
+end

--- a/core/lib/rom/memory/associations/many_to_one.rb
+++ b/core/lib/rom/memory/associations/many_to_one.rb
@@ -1,0 +1,10 @@
+require 'rom/associations/many_to_one'
+
+module ROM
+  module Memory
+    module Associations
+      class ManyToOne < ROM::Associations::ManyToOne
+      end
+    end
+  end
+end

--- a/core/lib/rom/memory/associations/one_to_many.rb
+++ b/core/lib/rom/memory/associations/one_to_many.rb
@@ -1,0 +1,10 @@
+require 'rom/associations/one_to_many'
+
+module ROM
+  module Memory
+    module Associations
+      class OneToMany < ROM::Associations::OneToMany
+      end
+    end
+  end
+end

--- a/core/lib/rom/memory/associations/one_to_one.rb
+++ b/core/lib/rom/memory/associations/one_to_one.rb
@@ -1,0 +1,10 @@
+require 'rom/memory/associations/one_to_many'
+
+module ROM
+  module Memory
+    module Associations
+      class OneToOne < OneToMany
+      end
+    end
+  end
+end

--- a/core/lib/rom/memory/schema.rb
+++ b/core/lib/rom/memory/schema.rb
@@ -1,4 +1,5 @@
 require 'rom/schema'
+require 'rom/memory/associations'
 
 module ROM
   module Memory
@@ -7,6 +8,15 @@ module ROM
       # @api public
       def call(relation)
         relation.new(relation.dataset.project(*map(&:name)), schema: self)
+      end
+
+      # @api private
+      def finalize_associations!(relations:)
+        super do
+          associations.map do |definition|
+            Memory::Associations.const_get(definition.type).new(definition, relations)
+          end
+        end
       end
     end
   end

--- a/core/lib/rom/relation.rb
+++ b/core/lib/rom/relation.rb
@@ -195,7 +195,13 @@ module ROM
 
     # @api public
     def eager_load(assoc)
-      assoc.prepare(self).preload_assoc(assoc)
+      relation = assoc.prepare(self)
+
+      if assoc.override?
+        relation.(assoc)
+      else
+        relation.preload_assoc(assoc)
+      end
     end
 
     # @api private


### PR DESCRIPTION
This adds a new feature which was required to make cross-adapter
associations work, which is `override` option in association DSL. If
it's set to `true` then a given association will not produce its own
relation and will use provided `:view` instead. This way we are
completely free to define association views however we want. These views
will receive both association object and loaded relation, which should
make it more flexible.