### PR TITLE
Refactor setup/finalize to use notifications

### DIFF
--- a/core/lib/rom/create_container.rb
+++ b/core/lib/rom/create_container.rb
@@ -27,6 +27,7 @@ module ROM
         command_classes: setup.command_classes,
         mappers: setup.mapper_classes,
         plugins: setup.plugins,
+        notifications: setup.notifications,
         config: environment.config.dup.freeze
       )
 

--- a/core/lib/rom/gateway.rb
+++ b/core/lib/rom/gateway.rb
@@ -1,6 +1,7 @@
 require 'dry/core/class_attributes'
 
 require 'rom/transaction'
+require 'rom/support/notifications'
 
 module ROM
   # Abstract gateway class
@@ -13,6 +14,7 @@ module ROM
   # @api public
   class Gateway
     extend Dry::Core::ClassAttributes
+    extend Notifications::Listener
 
     defines :adapter
 
@@ -140,20 +142,6 @@ module ROM
     # @api public
     def logger
       # noop
-    end
-
-    # Extension hook for adding gateway-specific behavior to a command class
-    #
-    # This simply returns back the class by default
-    #
-    # @param [Class] klass The command class
-    # @param [Object] _dataset The dataset that will be used with this command class
-    #
-    # @return [Class]
-    #
-    # @api public
-    def extend_command_class(klass, _dataset)
-      klass
     end
 
     # Schema inference hook

--- a/core/lib/rom/setup.rb
+++ b/core/lib/rom/setup.rb
@@ -21,11 +21,15 @@ module ROM
     attr_reader :plugins
 
     # @api private
-    def initialize
+    attr_reader :notifications
+
+    # @api private
+    def initialize(notifications)
       @relation_classes = []
       @command_classes = []
       @mapper_classes = []
       @plugins = []
+      @notifications = notifications
     end
 
     # Relation sub-classes are being registered with this method during setup

--- a/core/lib/rom/setup/finalize.rb
+++ b/core/lib/rom/setup/finalize.rb
@@ -22,7 +22,7 @@ module ROM
   class Finalize
     attr_reader :gateways, :repo_adapter,
                 :relation_classes, :mapper_classes, :mapper_objects,
-                :command_classes, :plugins, :config
+                :command_classes, :plugins, :config, :notifications
 
     # @api private
     def initialize(options)
@@ -36,6 +36,7 @@ module ROM
       @mapper_objects = (mappers - @mapper_classes).reduce(:merge) || {}
 
       @config = options.fetch(:config)
+      @notifications = options.fetch(:notifications)
 
       @plugins = options.fetch(:plugins)
     end
@@ -80,7 +81,8 @@ module ROM
         gateways,
         relation_classes,
         mappers: mappers,
-        plugins: global_plugins
+        plugins: global_plugins,
+        notifications: notifications
       ).run!
     end
 
@@ -95,7 +97,7 @@ module ROM
     #
     # @api private
     def load_commands(relations)
-      FinalizeCommands.new(relations, gateways, command_classes).run!
+      FinalizeCommands.new(relations, gateways, command_classes, notifications).run!
     end
   end
 end

--- a/core/lib/rom/support/notifications.rb
+++ b/core/lib/rom/support/notifications.rb
@@ -1,0 +1,103 @@
+require 'dry/equalizer'
+
+require 'rom/constants'
+
+module ROM
+  module Notifications
+    LISTENERS_HASH = Hash.new { |h, k| h[k] = [] }
+
+    module Publisher
+      # @api public
+      def subscribe(event_id, query = EMPTY_HASH, &block)
+        listeners[event_id] << [block, query]
+        self
+      end
+
+      # @api public
+      def trigger(event_id, payload = EMPTY_HASH)
+        event = events[event_id]
+
+        listeners[event.id].each do |(listener, query)|
+          event.payload(payload).trigger(listener, query)
+        end
+      end
+    end
+
+    class Event
+      include Dry::Equalizer(:id, :payload)
+
+      attr_reader :id
+
+      def initialize(id, payload = EMPTY_HASH)
+        @id = id
+        @payload = payload
+      end
+
+      def [](name)
+        @payload.fetch(name)
+      end
+
+      def payload(data = nil)
+        if data
+          self.class.new(id, @payload.merge(data))
+        else
+          @payload
+        end
+      end
+
+      def trigger(listener, query = EMPTY_HASH)
+        listener.(self) if trigger?(query)
+      end
+
+      def trigger?(query)
+        query.empty? || query.all? { |key, value| @payload[key] == value }
+      end
+    end
+
+    extend Publisher
+
+    # @api public
+    def register_event(id, info = EMPTY_HASH)
+      Notifications.events[id] = Event.new(id, info)
+    end
+
+    # @api private
+    def self.events
+      @__events__ ||= {}
+    end
+
+    # @api private
+    def self.listeners
+      @__listeners__ ||= LISTENERS_HASH.dup
+    end
+
+    # @api public
+    def self.event_bus(id)
+      EventBus.new(id, events: events.dup, listeners: listeners.dup)
+    end
+
+    # @api public
+    module Listener
+      # @api public
+      def subscribe(event_id, query = EMPTY_HASH, &block)
+        Notifications.listeners[event_id] << [block, query]
+      end
+    end
+
+    # @api public
+    class EventBus
+      include Publisher
+
+      attr_reader :id
+      attr_reader :events
+      attr_reader :listeners
+
+      # @api public
+      def initialize(id, events: EMPTY_HASH, listeners: LISTENERS_HASH.dup)
+        @id = id
+        @listeners = listeners
+        @events = events
+      end
+    end
+  end
+end

--- a/core/spec/integration/commands_spec.rb
+++ b/core/spec/integration/commands_spec.rb
@@ -36,14 +36,11 @@ RSpec.describe 'Commands' do
 
   describe 'extending command with a db-specific behavior' do
     before do
-      gateway.instance_exec do
-        def extend_command_class(klass, _)
-          klass.class_eval do
-            def super_command?
-              true
-            end
+      configuration.notifications.subscribe('configuration.commands.class.before_build') do |event|
+        event[:command].class_eval do
+          def super_command?
+            true
           end
-          klass
         end
       end
     end

--- a/core/spec/unit/rom/gateway_spec.rb
+++ b/core/spec/unit/rom/gateway_spec.rb
@@ -107,14 +107,6 @@ RSpec.describe ROM::Gateway do
     end
   end
 
-  describe '#extend_command_class' do
-    it 'returns the class sent as 1st parameter' do
-      klass = Class.new.freeze
-
-      expect(gateway.extend_command_class(klass, "foo")).to eq(klass)
-    end
-  end
-
   describe '.adapter' do
     let(:gateway_class) { Class.new(ROM::Gateway) }
 

--- a/core/spec/unit/rom/relation/view_spec.rb
+++ b/core/spec/unit/rom/relation/view_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe ROM::Relation, '.view' do
   context 'with an explicit schema' do
     before do
       # this is normally called automatically during setup
-      relation_class.finalize(registry, relation)
+      ROM::Notifications.trigger(
+        'configuration.relations.object.registered', relation: relation, registry: registry
+      )
     end
 
     include_context 'relation with views' do
@@ -110,7 +112,10 @@ RSpec.describe ROM::Relation, '.view' do
       # this is normally called automatically during setup
       schema = relation_class.schema_proc.call.finalize_attributes!
       relation_class.set_schema!(schema)
-      relation_class.finalize(registry, relation)
+
+      ROM::Notifications.trigger(
+        'configuration.relations.object.registered', relation: relation, registry: registry
+      )
     end
 
     include_context 'relation with views' do

--- a/core/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/core/spec/unit/rom/setup/auto_registration_spec.rb
@@ -1,7 +1,10 @@
 require 'rom/setup'
+require 'rom/support/notifications'
 
 RSpec.describe ROM::Setup, '#auto_registration' do
-  subject(:setup) { ROM::Setup.new }
+  subject(:setup) { ROM::Setup.new(notifications) }
+
+  let(:notifications) { instance_double(ROM::Notifications::EventBus) }
 
   context 'with default component_dirs' do
     context 'with namespace turned on' do


### PR DESCRIPTION
This adds an event bus for configuration/finalization events. This way we can decouple core setup/config/finalization code from extensions and provide a robust API for hooking into rom-rb booting process.

This is divided into 3 parts:

- `ROM::Notifications` extension which can be used by anything to register events
- `ROM::Notifications::Listener` extension which can be used by anything to register event listeners
- `ROM::Notifications::EventBus` which is **instantiated** for every configuration, which means we don't use global listeners

Now, `ROM::Configuration` is now a publisher which registers a bunch of configuration events, it passes its notifications instance down to setup/finalize objects, and they trigger various events in correct moments.

We already have a couple of listeners:

- `ROM::Relation` core class listens to `configuration.relations.object.registered` in order to finalize relation view schemas (needed by simple adapters where schemas for views can't be automatically maintained at run-time)
- `ROM::Schema` listens to `configuration.relations.schema.allocated` which triggers attribute finalization and `configuration.relations.registry.created` which triggers association finalization

Cool part: listeners can provide a query hash which will be used to filter out events that should not be triggered based on this query, ie: `subscribe('some.event', adapter: :sql) { .. }` will only be triggered for sql adapter.