### PR TITLE
Add default schema inferrer

### DIFF
--- a/changeset/Gemfile
+++ b/changeset/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'rom-core', path: '../core'
   gem 'rom-mapper', path: '../mapper'
   gem 'rom-repository', path: '../repository'
-  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'master'
+  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'add-indexes-to-schema'
   gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git', branch: 'master'
   gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct.git', branch: 'master'
   gem 'rspec'

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -25,7 +25,7 @@ group :test do
 end
 
 group :sql do
-  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'master'
+  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'add-indexes-to-schema'
   gem 'sequel'
   gem 'jdbc-sqlite3', platforms: :jruby
   gem 'jdbc-postgres', platforms: :jruby

--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -90,19 +90,18 @@ module ROM
         if defined?(@schema) && !block && !infer
           @schema
         elsif block || infer
+          raise MissingSchemaClassError.new(self) unless schema_class
+
           ds_name = dataset || schema_opts.fetch(:dataset, default_name.dataset)
           relation = as || schema_opts.fetch(:relation, ds_name)
 
           @relation_name = Name[relation, ds_name]
-          inferrer = infer ? schema_inferrer : Schema::DEFAULT_INFERRER
-
-          unless schema_class
-            raise MissingSchemaClassError.new(self)
-          end
 
           dsl = schema_dsl.new(
             relation_name,
-            schema_class: schema_class, attr_class: schema_attr_class, inferrer: inferrer,
+            schema_class: schema_class,
+            attr_class: schema_attr_class,
+            inferrer: schema_inferrer.with(enabled: infer),
             &block
           )
 

--- a/core/lib/rom/schema/inferrer.rb
+++ b/core/lib/rom/schema/inferrer.rb
@@ -1,0 +1,71 @@
+require 'dry/core/class_attributes'
+
+module ROM
+  class Schema
+    # @api private
+    class Inferrer
+      extend Dry::Core::ClassAttributes
+      extend Initializer
+
+      defines :attributes_inferrer, :attr_class
+
+      MissingAttributesError = Class.new(StandardError) do
+        def initialize(name, attributes)
+          super("missing attributes in #{name.inspect} schema: #{attributes.map(&:inspect).join(', ')}")
+        end
+      end
+
+      DEFAULT_ATTRIBUTES = [EMPTY_ARRAY, EMPTY_ARRAY].freeze
+
+      attributes_inferrer -> * { DEFAULT_ATTRIBUTES }
+
+      attr_class Attribute
+
+      include Dry::Equalizer(:options)
+
+      option :attr_class, default: -> { self.class.attr_class }
+
+      option :enabled, default: -> { true }
+
+      alias_method :enabled?, :enabled
+
+      option :attributes_inferrer, default: -> { self.class.attributes_inferrer }
+
+      # @api private
+      def call(schema, gateway)
+        if enabled?
+          inferred, missing = attributes_inferrer.(schema, gateway, options)
+        else
+          inferred, missing = DEFAULT_ATTRIBUTES
+        end
+
+        attributes = merge_attributes(schema.attributes, inferred)
+
+        check_all_attributes_defined(schema, attributes, missing)
+
+        { attributes: attributes }
+      end
+
+      # @api private
+      def check_all_attributes_defined(schema, all_known, not_inferred)
+        not_defined = not_inferred - all_known.map(&:name)
+
+        if not_defined.size > 0
+          raise MissingAttributesError.new(schema.name, not_defined)
+        end
+      end
+
+      # @api private
+      def merge_attributes(defined, inferred)
+        defined_names = defined.map(&:name)
+
+        defined + inferred.reject { |attr| defined_names.include?(attr.name) }
+      end
+
+      # @api private
+      def with(new_options)
+        self.class.new(options.merge(new_options))
+      end
+    end
+  end
+end

--- a/core/spec/support/schema.rb
+++ b/core/spec/support/schema.rb
@@ -13,6 +13,10 @@ module SchemaHelpers
     ROM::Types.const_get(id).meta(name: name, **opts)
   end
 
+  def define_attribute(*args)
+    ROM::Schema::Attribute.new(define_type(*args))
+  end
+
   def build_assoc(type, *args)
     klass = Dry::Core::Inflector.classify(type)
     definition = ROM::Associations::Definitions.const_get(klass).new(*args)

--- a/core/spec/unit/rom/relation/view_spec.rb
+++ b/core/spec/unit/rom/relation/view_spec.rb
@@ -120,11 +120,13 @@ RSpec.describe ROM::Relation, '.view' do
 
     include_context 'relation with views' do
       let(:relation_class) do
+        attributes_inferrer = proc {
+          [[define_attribute(:users, :Int, name: :id), define_attribute(:users, :String, name: :name)],
+           []]
+        }
+
         Class.new(ROM::Memory::Relation) do
-          schema_inferrer -> dataset, gateway {
-            [[ROM::Types::Int.meta(name: :id, source: :users),
-             ROM::Types::String.meta(name: :name, source: :users)], []]
-          }
+          schema_inferrer ROM::Schema::DEFAULT_INFERRER.with(attributes_inferrer: attributes_inferrer)
 
           schema(:users, infer: true)
 

--- a/core/spec/unit/rom/relation_spec.rb
+++ b/core/spec/unit/rom/relation_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe ROM::Relation do
       }.new([])
 
       expect(relation.schema).to be_empty
-      expect(relation.schema.inferrer).to be(ROM::Schema::DEFAULT_INFERRER)
+      expect(relation.schema.inferrer).to eql(ROM::Schema::DEFAULT_INFERRER)
       expect(relation.schema.name).to eql(ROM::Relation::Name[:test_some_relation])
       expect(relation.schema?).to be(false)
     end

--- a/core/spec/unit/rom/schema/finalize_spec.rb
+++ b/core/spec/unit/rom/schema/finalize_spec.rb
@@ -19,11 +19,18 @@ RSpec.describe ROM::Schema, '#finalize!' do
 
   context 'with inferrer' do
     subject(:schema) do
-      ROM::Schema.define(:users, attributes: attributes, inferrer: inferrer)
+      ROM::Schema.define(
+        :users,
+        attributes: attributes,
+        inferrer: ROM::Schema::DEFAULT_INFERRER.with(
+          attributes_inferrer: attributes_inferrer,
+          enabled: true
+        )
+      )
     end
 
-    let(:inferrer) do
-      proc { [[define_type(:name, :String)], [:id, :age]]}
+    let(:attributes_inferrer) do
+      proc { [ [define_attribute(:name, :String)], %i(id age) ] }
     end
 
     context 'when all required attributes are present' do
@@ -56,7 +63,10 @@ RSpec.describe ROM::Schema, '#finalize!' do
 
       it 'raises error' do
         expect { schema.finalize_attributes!.finalize! }.
-          to raise_error(ROM::Schema::MissingAttributesError, /missing attributes in :users schema: :id, :age/)
+          to raise_error(
+               ROM::Schema::Inferrer::MissingAttributesError,
+               /missing attributes in :users schema: :id, :age/
+             )
       end
     end
   end

--- a/repository/Gemfile
+++ b/repository/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'rom-core', path: '../core'
   gem 'rom-mapper', path: '../mapper'
   gem 'rom-changeset', path: '../changeset'
-  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'master'
+  gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'add-indexes-to-schema'
   gem 'rspec'
   gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct', branch: 'master'
   gem 'byebug', platforms: :mri

--- a/repository/spec/spec_helper.rb
+++ b/repository/spec/spec_helper.rb
@@ -25,14 +25,8 @@ LOGGER = Logger.new(File.open('./log/test.log', 'a'))
 require 'dry/core/deprecations'
 Dry::Core::Deprecations.set_logger!(SPEC_ROOT.join('../log/deprecations.log'))
 
-require 'rom/sql/schema/inferrer'
-
-# Make inference errors quiet
-class ROM::SQL::Schema::Inferrer
-  def self.on_error(*args)
-    # shush
-  end
-end
+# quiet in specs
+ROM::SQL::Relation.tap { |r| r.schema_inferrer(r.schema_inferrer.suppress_errors) }
 
 # Namespace holding all objects created during specs
 module Test


### PR DESCRIPTION
This add ability to infer more than just attributes. In rom-sql we need this for indexes and foreign at least. In theory, we might infer some storage options as well, such as tablespaces and page fillfactor (or give an API for doing this).