### PR TITLE
Raise exception for invalid relation name

### DIFF
--- a/core/lib/rom/constants.rb
+++ b/core/lib/rom/constants.rb
@@ -27,6 +27,12 @@ module ROM
   UnsupportedRelationError = Class.new(StandardError)
   MissingAdapterIdentifierError = Class.new(StandardError)
 
+  class InvalidRelationName < StandardError
+    def initialize(relation)
+      super("Relation name: #{relation} is a protected word, please use another relation name")
+    end
+  end
+
   class ElementNotFoundError < KeyError
     def initialize(key, registry)
       super(set_message(key, registry))

--- a/core/lib/rom/constants.rb
+++ b/core/lib/rom/constants.rb
@@ -19,6 +19,7 @@ module ROM
   RelationAlreadyDefinedError = Class.new(StandardError)
   MapperAlreadyDefinedError = Class.new(StandardError)
   NoRelationError = Class.new(StandardError)
+  InvalidRelationName = Class.new(StandardError)
   CommandError = Class.new(StandardError)
   KeyMissing = Class.new(ROM::CommandError)
   TupleCountMismatchError = Class.new(CommandError)

--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -96,9 +96,7 @@ module ROM
           ds_name = dataset || schema_opts.fetch(:dataset, default_name.dataset)
           relation = as || schema_opts.fetch(:relation, ds_name)
 
-          if INVALID_RELATIONS_NAMES.include?(relation.to_sym)
-            raise InvalidRelationName.new(invalid_relation_msg(relation))
-          end
+          raise InvalidRelationName.new(relation) if invalid_relation_name?(relation)
 
           @relation_name = Name[relation, ds_name]
 
@@ -287,8 +285,8 @@ module ROM
 
       private
 
-      def invalid_relation_msg(relation)
-        "Relation name: #{relation} is a protected word, please use another relation name"
+      def invalid_relation_name?(relation)
+        INVALID_RELATIONS_NAMES.include?(relation.to_sym)
       end
     end
   end

--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -27,6 +27,9 @@ module ROM
       end
 
       DEFAULT_DATASET_PROC = -> * { self }.freeze
+      INVALID_RELATIONS_NAMES = [
+        :relations
+      ].freeze
 
       # Return adapter-specific relation subclass
       #
@@ -92,6 +95,10 @@ module ROM
 
           ds_name = dataset || schema_opts.fetch(:dataset, default_name.dataset)
           relation = as || schema_opts.fetch(:relation, ds_name)
+
+          if INVALID_RELATIONS_NAMES.include?(relation.to_sym)
+            raise InvalidRelationName.new(invalid_relation_msg(relation))
+          end
 
           @relation_name = Name[relation, ds_name]
 
@@ -276,6 +283,12 @@ module ROM
 
       def name
         super || superclass.name
+      end
+
+      private
+
+      def invalid_relation_msg(relation)
+        "Relation name: #{relation} is a protected word, please use another relation name"
       end
     end
   end

--- a/core/spec/unit/rom/relation_spec.rb
+++ b/core/spec/unit/rom/relation_spec.rb
@@ -112,6 +112,36 @@ RSpec.describe ROM::Relation do
         expect(relation.name).to eql(ROM::Relation::Name[:foo_bar])
       end
     end
+
+    context 'invalid names' do
+      let(:relation_name_symbol) do
+        module Test
+          class Relations < ROM::Relation[:memory]
+            schema(:relations) { }
+          end
+        end
+      end
+
+      let(:relation_name_string) do
+        module Test
+          class Relations < ROM::Relation[:memory]
+            schema('relations') { }
+          end
+        end
+      end
+
+      it 'raises an exception when is symbol' do
+        expect {
+          relation_name_symbol
+        }.to raise_error(ROM::InvalidRelationName)
+      end
+
+      it 'raises an exception when is string' do
+        expect {
+          relation_name_string
+        }.to raise_error(ROM::InvalidRelationName)
+      end
+    end
   end
 
   describe "#each" do


### PR DESCRIPTION
Solves #434 

@solnic after playing with the code I found this to be a good place for raising the error 😄 

Although the test infers the name from the `schema` macro I would have liked to test creating a `Relations` class but not under the namespace of `Test` but the `ConstantLiker` wouldn't allow me.

Hope this helps.