### PR TITLE
Avoid splat arguments if they are coercible to array in repository commands macro

### DIFF
--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -113,7 +113,13 @@ module ROM
             if changeset.respond_to?(:commit)
               changeset.commit
             else
-              root.command(type, **opts).public_send(view_name, *view_args).call(*input)
+              #   in case of view_args been coercible to an array we do not want to splat it
+              #   example: Date and Time objects
+              if view_args.respond_to?(:to_a)
+                root.command(type, **opts).public_send(view_name, view_args).call(*input)
+              else
+                root.command(type, **opts).public_send(view_name, *view_args).call(*input)
+              end
             end
           end
         end

--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -113,13 +113,8 @@ module ROM
             if changeset.respond_to?(:commit)
               changeset.commit
             else
-              #   in case of view_args been coercible to an array we do not want to splat it
-              #   example: Date and Time objects
-              if view_args.respond_to?(:to_a)
-                root.command(type, **opts).public_send(view_name, view_args).call(*input)
-              else
-                root.command(type, **opts).public_send(view_name, *view_args).call(*input)
-              end
+              view_args = [view_args] unless view_args.respond_to?(:to_ary)
+              root.command(type, **opts).public_send(view_name, *view_args).call(*input)
             end
           end
         end

--- a/repository/spec/integration/command_macros_spec.rb
+++ b/repository/spec/integration/command_macros_spec.rb
@@ -191,5 +191,17 @@ RSpec.describe ROM::Repository, '.command' do
       deleted_name = repo.delete(1)
       expect(deleted_name).to eql('Jane Doe')
     end
+
+    it 'allows to set update macro with Date objects and not splat them' do
+      repo = Class.new(ROM::Repository[:books]) do
+        commands delete: [:by_pk, :expired]
+      end.new(rom)
+
+      repo.books.insert(title: 'John Doe', created_at: Time.now - 3600)
+
+      repo.delete_expired(Time.now)
+
+      expect(repo.books.count).to be_zero
+    end
   end
 end

--- a/repository/spec/shared/relations.rb
+++ b/repository/spec/shared/relations.rb
@@ -19,6 +19,10 @@ RSpec.shared_context 'relations' do
           belongs_to :users, as: :author, relation: :authors, foreign_key: :author_id
         end
       end
+
+      def expired(expiration_time=default_expiration_time)
+        where{ created_at < expiration_time }
+      end
     end
 
     configuration.relation(:users) do

--- a/repository/spec/shared/relations.rb
+++ b/repository/spec/shared/relations.rb
@@ -20,7 +20,7 @@ RSpec.shared_context 'relations' do
         end
       end
 
-      def expired(expiration_time=default_expiration_time)
+      def expired(expiration_time=Time.now)
         where{ created_at < expiration_time }
       end
     end


### PR DESCRIPTION
Solves #435 

To avoid splatting the arguments if they are coercible into Array.