### PR TITLE
Generic JSON read/write type

### DIFF
--- a/core/lib/rom/types.rb
+++ b/core/lib/rom/types.rb
@@ -47,7 +47,7 @@ module ROM
       end
 
       def JSON(symbol_keys: false)
-        self.JsonWrite.meta(read: self.JsonRead(symbol_keys))
+        self.HashJson.meta(read: self.JsonHash(symbol_keys))
       end
     end
   end

--- a/core/lib/rom/types.rb
+++ b/core/lib/rom/types.rb
@@ -27,7 +27,7 @@ module ROM
     end
 
     module CoercibleMethods
-      def JsonRead(symbol_keys = false, type = Types::Hash)
+      def JsonHash(symbol_keys = false, type = Types::Hash)
         Types.Constructor(type) do |value|
           next Hash[value] if value.respond_to?(:to_hash)
 
@@ -39,7 +39,7 @@ module ROM
         end
       end
 
-      def JsonWrite(type = Types::String)
+      def HashJson(type = Types::String)
         Types.Constructor(type) do |value|
           next value unless value.respond_to?(:to_hash)
           ::JSON.dump(value)

--- a/core/lib/rom/types.rb
+++ b/core/lib/rom/types.rb
@@ -29,8 +29,6 @@ module ROM
     module CoercibleMethods
       def JsonHash(symbol_keys = false, type = Types::Hash)
         Types.Constructor(type) do |value|
-          next Hash[value] if value.respond_to?(:to_hash)
-
           begin
             ::JSON.parse(value.to_s, symbolize_names: symbol_keys)
           rescue ::JSON::ParserError
@@ -40,10 +38,7 @@ module ROM
       end
 
       def HashJson(type = Types::String)
-        Types.Constructor(type) do |value|
-          next value unless value.respond_to?(:to_hash)
-          ::JSON.dump(value)
-        end
+        Types.Constructor(type) { |value| ::JSON.dump(value) }
       end
 
       def JSON(symbol_keys: false)

--- a/core/lib/rom/types.rb
+++ b/core/lib/rom/types.rb
@@ -1,5 +1,5 @@
-require 'json'
 require 'dry-types'
+require 'json'
 
 module ROM
   module Types

--- a/core/spec/unit/rom/relation/schema_spec.rb
+++ b/core/spec/unit/rom/relation/schema_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe ROM::Relation, '.schema' do
     expect(schema.foreign_key(:users)).to be(schema[:author_id])
   end
 
+  it 'allows json read/write coersion' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::JSON
+      end
+    end
+
+    schema = Test::Posts.schema_proc.call
+    json_payload = '{"foo":"bar"}'
+    hash_payload = { "foo" => "bar" }
+
+    expect(schema[:payload][hash_payload]).to eq(json_payload)
+    expect(schema[:payload].meta[:read][json_payload]).to eq(hash_payload)
+  end
+
+  it 'allows json read/write coersion using symbols' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::JSON(symbol_keys: true)
+      end
+    end
+
+    schema = Test::Posts.schema_proc.call
+    json_payload = '{"foo":"bar"}'
+    hash_payload = { foo: "bar" }
+
+    expect(schema[:payload][hash_payload]).to eq(json_payload)
+    expect(schema[:payload].meta[:read][json_payload]).to eq(hash_payload)
+  end
+
   it 'sets register_as and dataset' do
     class Test::Users < ROM::Relation[:memory]
       schema(:users) do


### PR DESCRIPTION
Hi, following suggestion on Gitter, https://gitter.im/rom-rb/chat?at=597fb669210ac269204184f4
I would like to propose a generic json read/write type: `Coercible::Json` together with:

- `Coercible::Json()`
- `Coercible::JsonHash()`
- `Coercible::HashJson()`