### PR TITLE
Build a separate schema for every container

### DIFF
--- a/core/lib/rom/relation.rb
+++ b/core/lib/rom/relation.rb
@@ -479,7 +479,7 @@ module ROM
     #   Map tuples to the provided custom model class
     #
     #   @example
-    #     users.as(MyUserModel)
+    #     users.map_with(MyUserModel)
     #
     #   @param [Class>] model Your custom model class
     #

--- a/core/spec/integration/multi_env_spec.rb
+++ b/core/spec/integration/multi_env_spec.rb
@@ -66,4 +66,45 @@ RSpec.describe 'Setting up ROM with multiple environments' do
       expect { configuration[:two].register_mapper(Test::UserMapper) }.to_not raise_error
     end
   end
+
+  context 'with associations' do
+    before do
+      module Test
+        class Users < ROM::Relation[:memory]
+          schema(:users) do
+            attribute :id, ROM::Types::Int
+            attribute :name, ROM::Types::String
+
+            associations do
+              has_many :tasks
+            end
+          end
+        end
+
+        class Tasks  < ROM::Relation[:memory]
+          schema(:tasks) do
+            attribute :id, ROM::Types::Int
+            attribute :title, ROM::Types::String
+            attribute :user_id, ROM::Types::Int
+
+            associations do
+              belongs_to :user
+            end
+          end
+        end
+      end
+    end
+
+    it 'separates associations between different configurations' do
+      configuration[:one].register_relation(Test::Users)
+      configuration[:one].register_relation(Test::Tasks)
+
+      configuration[:two].register_relation(Test::Users)
+      configuration[:two].register_relation(Test::Tasks)
+
+      expect(
+        container[:one].relations[:users].schema.associations
+      ).not_to be(container[:two].relations[:users].associations)
+    end
+  end
 end

--- a/core/spec/unit/rom/relation/name_spec.rb
+++ b/core/spec/unit/rom/relation/name_spec.rb
@@ -2,6 +2,8 @@ require 'rom/relation/name'
 
 RSpec.describe ROM::Relation::Name do
   describe '.[]' do
+    before { ROM::Relation::Name.cache.clear }
+
     it 'returns a new name from args' do
       expect(ROM::Relation::Name[:users]).to eql(
         ROM::Relation::Name.new(:users)


### PR DESCRIPTION
It turned out associations are now shares relations which is not as good as just sharing schemas. For instance, my app has two containers that use the same set of relations but different DB connections underneath, this leads to a situation where one relation tries to pull data through a different connection.