### PR TITLE
Build optional read types in SchemaDSL

### DIFF
--- a/core/lib/rom/schema/dsl.rb
+++ b/core/lib/rom/schema/dsl.rb
@@ -93,6 +93,8 @@ module ROM
       def build_type(name, type, options = EMPTY_HASH)
         if options[:read]
           type.meta(name: name, source: relation, read: options[:read])
+        elsif type.optional? && !type.meta[:read] && type.right.meta[:read]
+          type.meta(name: name, source: relation, read: type.right.meta[:read].optional)
         else
           type.meta(name: name, source: relation)
         end


### PR DESCRIPTION
rom-sql's inferrer already does it automatically, without it things aren't working smoothly enough, for instance `attribute :email, Types::PG::Array(:varchar).optional` doesn't get converted from Sequel::PGArray to a plain Array value even the source type Types::PG::Array has a read type inside. Now it's possible not to bother about this nuances, though we might change the DSL/behavior in future (to make it easier/transparent of course).