### PR TITLE
Types/coercible json naming change

### DIFF
--- a/lib/rom/types.rb
+++ b/lib/rom/types.rb
@@ -9,6 +9,8 @@ module ROM
       other.extend(Methods)
       other::Coercible.extend(CoercibleMethods)
       other::Coercible.const_set('JSON', other::Coercible.JSON)
+      other::Coercible.const_set('JSONHash', other::Coercible.JSONHash)
+      other::Coercible.const_set('HashJSON', other::Coercible.HashJSON)
       super
     end
 
@@ -27,7 +29,7 @@ module ROM
     end
 
     module CoercibleMethods
-      def JsonHash(symbol_keys = false, type = Types::Hash)
+      def JSONHash(symbol_keys: false, type: Types::Hash)
         Types.Constructor(type) do |value|
           next Hash[value] if value.respond_to?(:to_hash)
 
@@ -39,7 +41,7 @@ module ROM
         end
       end
 
-      def HashJson(type = Types::String)
+      def HashJSON(type: Types::String)
         Types.Constructor(type) do |value|
           next value unless value.respond_to?(:to_hash)
           ::JSON.dump(value)
@@ -47,7 +49,7 @@ module ROM
       end
 
       def JSON(symbol_keys: false)
-        self.HashJson.meta(read: self.JsonHash(symbol_keys))
+        self.HashJSON.meta(read: self.JSONHash(symbol_keys: symbol_keys))
       end
     end
   end

--- a/spec/unit/rom/relation/schema_spec.rb
+++ b/spec/unit/rom/relation/schema_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ROM::Relation, '.schema' do
     expect(schema.foreign_key(:users)).to be(schema[:author_id])
   end
 
-  it 'allows json read/write coersion' do
+  it 'allows JSON read/write coersion', aggregate_failures: true do
     class Test::Posts < ROM::Relation[:memory]
       schema do
         attribute :payload, Types::Coercible::JSON
@@ -96,7 +96,7 @@ RSpec.describe ROM::Relation, '.schema' do
     expect(schema[:payload].meta[:read][json_payload]).to eq(hash_payload)
   end
 
-  it 'allows json read/write coersion using symbols' do
+  it 'allows JSON/Hash read/write coersion using symbols as keys', aggregate_failures: true do
     class Test::Posts < ROM::Relation[:memory]
       schema do
         attribute :payload, Types::Coercible::JSON(symbol_keys: true)
@@ -109,6 +109,61 @@ RSpec.describe ROM::Relation, '.schema' do
 
     expect(schema[:payload][hash_payload]).to eq(json_payload)
     expect(schema[:payload].meta[:read][json_payload]).to eq(hash_payload)
+  end
+
+  it 'allows JSON to Hash coersion only' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::JSONHash
+      end
+    end
+
+    schema = Test::Posts.schema
+    json_payload = '{"foo":"bar"}'
+    hash_payload = { "foo" => "bar" }
+
+    expect(schema[:payload][json_payload]).to eq(hash_payload)
+  end
+
+  it 'returns original payload in JSON to Hash coersion when json is invalid' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::JSONHash
+      end
+    end
+
+    schema = Test::Posts.schema
+    json_payload = 'invalid: json'
+
+    expect(schema[:payload][json_payload]).to eq(json_payload)
+  end
+
+  it 'allows JSON to Hash coersion only using symbols as keys' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::JSONHash(symbol_keys: true)
+      end
+    end
+
+    schema = Test::Posts.schema
+    json_payload = '{"foo":"bar"}'
+    hash_payload = { foo: "bar" }
+
+    expect(schema[:payload][json_payload]).to eq(hash_payload)
+  end
+
+  it 'allows Hash to JSON coersion only' do
+    class Test::Posts < ROM::Relation[:memory]
+      schema do
+        attribute :payload, Types::Coercible::HashJSON
+      end
+    end
+
+    schema = Test::Posts.schema
+    json_payload = '{"foo":"bar"}'
+    hash_payload = { "foo" => "bar" }
+
+    expect(schema[:payload][hash_payload]).to eq(json_payload)
   end
 
   it 'sets register_as and dataset' do


### PR DESCRIPTION
**Addressing**: https://github.com/rom-rb/rom/pull/446#discussion_r133506000

Rename CoercibleMethods `HashJson -> HashJSON`, `JsonHash -> JSONHash`

Refactor attributes to keyword arguments.
- Add specs for usage of both individually.
- Add spec to cover case when Input JSON is invalid for `JSONHash`.

PR for 4.X will follow shortly.

@solnic I am also thinking about extending this a bit more by making it possible for JSON serializer to be plugged in. Any thoughts on idea? cc: @flash-gordon 