### PR TITLE
Add tests demonstrating issue with overriding struct attribute methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ COMPONENTS.each do |component|
 end
 
 gem 'dry-types', git: 'https://github.com/dry-rb/dry-types', branch: 'master'
+gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct', branch: 'skip-overridding-attr-readers'
 
 group :sql do
   gem 'sequel', '~> 4.45'

--- a/core/spec/unit/rom/relation/struct_namespace_spec.rb
+++ b/core/spec/unit/rom/relation/struct_namespace_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ROM::Relation, '#struct_namespace' do
       end
 
       it 'gives access to non-attribute methods defined in the struct superclass' do
-        expect(admins.first.shared_user?).to be_true
+        expect(admins.first).to be_shared_user
       end
 
       it 'gives access to overridden attribute methods idefined n the struct superclass' do


### PR DESCRIPTION
In working through a real app with the rom 4 betas, I noticed an issue with the way auto-generated structs in struct namespaces work.

There are 2 (related) aspects to this:

1. It's not possible to define overriding attribute methods on structs and refer to the original attribute value
2. Which also means when a struct class inherits from _another_ struct class, the superclass' overriding attribute method is not accessible

I _think_ the problem starts with these lines in `struct_compiler.rb`:

```ruby
          build_class(name, ROM::Struct, ns) do |klass|
            attributes.each do |(attr_name, type)|
              klass.attribute(attr_name, type)
            end
          end
```

This is going to define dry-struct attributes on the class that it builds.

Then if we go over to dry-struct's source and look at at this part of `class_interface.rb`:

```ruby
      def attributes(new_schema)
        check_schema_duplication(new_schema)

        schema schema.merge(new_schema)
        input Types['coercible.hash'].public_send(constructor_type, schema)

        attr_reader(*new_schema.keys)
```

When attributes are defined on a dry-struct, an `attr_reader` is _always_ created for each attribute.

The problem in this case here in rom is that the classes that are defined for auto-structs in a namespace all _inherit_ from the user's own custom struct classes. Since these `attr_readers` are defined in the subclass, the overridden attribute methods in the parent class are no longer reachable.

That's the class inheritance side of the problem (point 2 in my list above).

The other side of the problem is about accessing the original value when defining this overriding attribute methods in the first place. It makes a lot of sense to me that the original value should be accessible as `super` in these methods, but I don't think dry-struct actually lets us work like that. Since it defines `attr_reader` methods directly on the class, and not in some included module, we end up having to refer to the original values as `@attribute_name`, which I think is not ideal.

