### PR TITLE
Use dry-types HEAD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :sql do
   gem 'pg', platforms: [:mri, :rbx]
   gem 'jdbc-postgres', platforms: :jruby
   gem 'rom-sql', git: 'https://github.com/rom-rb/rom-sql.git', branch: 'master'
+  gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git'
   gem 'dry-monitor'
 end
 


### PR DESCRIPTION
This is required since rom-rb/rom-sql@4746e546dee81895e9c88c6fad44f047316730ff increased the minimum required dry-types version for rom-sql to one that hasn't been released yet.