### PR TITLE
Include Enumerable in ROM::Relation::Materializable

### DIFF
--- a/core/lib/rom/relation/materializable.rb
+++ b/core/lib/rom/relation/materializable.rb
@@ -4,6 +4,8 @@ module ROM
     #
     # @api public
     module Materializable
+      include Enumerable
+
       # Coerce the relation to an array
       #
       # @return [Array]

--- a/core/lib/rom/relation/materializable.rb
+++ b/core/lib/rom/relation/materializable.rb
@@ -47,15 +47,6 @@ module ROM
       def one!
         call.one!
       end
-
-      # Return first tuple from a relation coerced to an array
-      #
-      # @return [Object]
-      #
-      # @api public
-      def first
-        to_a.first
-      end
     end
   end
 end

--- a/core/spec/shared/materializable.rb
+++ b/core/spec/shared/materializable.rb
@@ -16,6 +16,23 @@ shared_examples_for 'materializable relation' do
     end
   end
 
+  describe '#map' do
+    it 'yields objects' do
+      count = relation.to_a.size
+      result = []
+
+      relation.map do |object|
+        result << object
+      end
+
+      expect(result.count).to eql(count)
+    end
+
+    it 'returns enumerator when block is not provided' do
+      expect(relation.map.to_a).to eql(relation.to_a)
+    end
+  end
+
   describe '#one' do
     it 'returns one tuple' do
       expect(relation.one).to be_instance_of(Hash)

--- a/core/spec/unit/rom/relation/curried_spec.rb
+++ b/core/spec/unit/rom/relation/curried_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ROM::Relation::Curried do
     end
 
     it 'does not forward to the relation when method is auto-curried' do
-      expect { users_relation.by_name.find }.to raise_error(NoMethodError, /find/)
+      expect { users_relation.by_name.by_name }.to raise_error(NoMethodError, /by_name/)
     end
 
     it 'raises no method error when method is not defined' do


### PR DESCRIPTION
This means that `#each` doesn't work differently to other `Enumerable` methods like `#map`, which are currently forwarded to the relation.

The current behavior is very surprising: `#each` will yield model objects, while `#map` and other `Enumerable` methods will yield hashes.

Since `Enumerable` provides a `#find` method, a spec that relied on `Materializable` not having a `#find` had to be updated to use a different non-existent method.

Additionally, the definition for `ROM::Relation::Materializable#first` can be removed since `#first` is provided by `Enumerable`.