### PR TITLE
Make error messages about missing attribute lazy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ COMPONENTS.each do |component|
   gem "rom-#{component}", path: Pathname(__dir__).join(component).realpath
 end
 
+gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct.git'
+
 group :sql do
   gem 'sequel', '~> 5.0'
   gem 'sqlite3', platforms: [:mri, :rbx]

--- a/mapper/lib/rom/struct.rb
+++ b/mapper/lib/rom/struct.rb
@@ -70,7 +70,16 @@ module ROM
   #
   # @api public
   class Struct < Dry::Struct
-    MissingAttribute = Class.new(NameError)
+    MissingAttribute = Class.new(NameError) do
+      def initialize(&block)
+        super
+        @message_proc = block
+      end
+
+      def message
+        @message_proc.call
+      end
+    end
 
     # Returns a short string representation
     #
@@ -90,16 +99,9 @@ module ROM
       __send__(name)
     end
 
-    if RUBY_VERSION < '2.3'
-      # @api private
-      def respond_to?(*)
-        super
-      end
-    else
-      # @api private
-      def respond_to_missing?(*)
-        super
-      end
+    # @api private
+    def respond_to_missing?(*)
+      super
     end
 
     private
@@ -107,7 +109,7 @@ module ROM
     def method_missing(*)
       super
     rescue NameError => error
-      raise MissingAttribute.new("#{ error.message } (not loaded attribute?)")
+      raise MissingAttribute.new { "#{ error.message } (attribute not loaded?)" }
     end
   end
 end

--- a/mapper/spec/unit/rom/struct_compiler_spec.rb
+++ b/mapper/spec/unit/rom/struct_compiler_spec.rb
@@ -119,13 +119,27 @@ RSpec.describe ROM::StructCompiler, '#call' do
 
       expect {
         user.upcased_middle_name
-      }.to raise_error(ROM::Struct::MissingAttribute, /not loaded attribute\?/)
+      }.to raise_error(ROM::Struct::MissingAttribute, /attribute not loaded\?/)
     end
 
     it 'works with implicit coercions' do
       user = struct.new(id: 1, name: 'Jane')
 
       expect([user].flatten).to eql([user])
+    end
+
+    it 'generates a proper error if with overridden getters and a missing method in them' do
+      class Test::Custom::User < ROM::Struct
+        def name
+          first_name
+        end
+      end
+
+      user = struct.new(id: 1, name: 'Jane')
+
+      expect {
+        user.name
+      }.to raise_error(ROM::Struct::MissingAttribute, /attribute not loaded\?/)
     end
   end
 end


### PR DESCRIPTION
Otherwise, it conflicts with the latest dry-struct and the did_you_mean gem in a really weird way.