### PR TITLE
Fix ROM::Schema.define method

### DIFF
--- a/core/lib/rom/schema.rb
+++ b/core/lib/rom/schema.rb
@@ -116,6 +116,7 @@ module ROM
     def self.define(name, attributes: EMPTY_ARRAY, attr_class: Attribute, **options)
       new(
         name,
+        attr_class: attr_class,
         attributes: attributes(attributes, attr_class),
         **options
       ) { |schema| yield(schema) if block_given? }

--- a/core/spec/unit/rom/relation_spec.rb
+++ b/core/spec/unit/rom/relation_spec.rb
@@ -222,6 +222,25 @@ RSpec.describe ROM::Relation do
       expect(relation.schema.name).to eql(ROM::Relation::Name[:test_some_relation])
       expect(relation.schema?).to be(false)
     end
+
+    context 'when relation has custom attribute class' do
+      before do
+        module Test
+          class Attribute < ROM::Attribute; end
+          class Relation < ROM::Relation
+            schema_attr_class Test::Attribute
+          end
+        end
+      end
+
+      it 'define schema with attribute class' do
+        relation = Class.new(Test::Relation) do
+          schema(:test_some_relation) {}
+        end.new([])
+
+        expect(relation.schema.attr_class).to eq Test::Attribute
+      end
+    end
   end
 
   describe '#input_schema' do


### PR DESCRIPTION
I think `Schema.definition` already worked correctly before, until we lost `attr_class` agrument for schema initilazer [here](https://github.com/rom-rb/rom/commit/c7518fc28#diff-3ac454f9c196d0f7c33922c20f51583cL117).
It also is reason of #460 