### PR TITLE
[core] set relation registry in schema upon finalization

### DIFF
--- a/core/lib/rom/schema.rb
+++ b/core/lib/rom/schema.rb
@@ -54,6 +54,7 @@ module ROM
 
       unless schema.frozen?
         schema.finalize_attributes!(gateway: gateway, relations: registry)
+        schema.set!(:relations, registry)
       end
     end
 
@@ -416,6 +417,12 @@ module ROM
       [:schema, [name, attributes.map(&:to_ast)]]
     end
 
+    # @api private
+    def set!(key, value)
+      instance_variable_set("@#{ key }", value)
+      options[key] = value
+    end
+
     private
 
     # @api private
@@ -447,12 +454,6 @@ module ROM
         @primary_key_name = primary_key[0].meta[:name]
         @primary_key_names = primary_key.map { |type| type.meta[:name] }
       end
-    end
-
-    # @api private
-    def set!(key, value)
-      instance_variable_set("@#{ key }", value)
-      options[key] = value
     end
 
     memoize :count_index, :name_index, :source_index, :to_ast, :to_input_hash, :to_output_hash

--- a/core/lib/rom/setup/finalize/finalize_relations.rb
+++ b/core/lib/rom/setup/finalize/finalize_relations.rb
@@ -90,7 +90,7 @@ module ROM
 
         notifications.trigger(
           'configuration.relations.schema.set',
-          schema: schema, relation: klass, adapter: klass.adapter
+          schema: schema, relation: klass, registry: registry, adapter: klass.adapter
         )
 
         rel_key = schema.name.to_sym

--- a/core/spec/integration/setup_spec.rb
+++ b/core/spec/integration/setup_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'Configuring ROM' do
       expect(tasks.users).to eql(users)
       expect(tasks.users.commands).to be_kind_of(ROM::CommandRegistry)
     end
+
+    it 'configures rom schema to store relations' do
+      users_schema = users_relation.schema
+      tasks_schema = tasks_relation.schema
+      expect(users_schema.relations[:users]).to eql(users_relation)
+      expect(tasks_schema.relations[:tasks]).to eql(tasks_relation)
+    end
   end
 
   context 'without schema' do


### PR DESCRIPTION
@solnic @flash-gordon 

I created this PR so we can discuss this https://github.com/rom-rb/rom-sql/issues/247. The finalize process still quite complex and I'm sure I'm missing something.

For what it looks like at this point when this message `configuration.relations.registry.created` is trigger the `RealtionRegistry` has been created. 

So I thought might be a simple solution to set the relations for each schema at this point.