### PR TITLE
Allow options for command timestamps plugin

### DIFF
--- a/core/lib/rom/command_compiler.rb
+++ b/core/lib/rom/command_compiler.rb
@@ -52,6 +52,10 @@ module ROM
     #   @return [Array<Symbol>] a list of optional plugins that will be enabled for commands
     option :plugins, optional: true, default: -> { EMPTY_ARRAY }
 
+    # @!attribute [r] plugins_options
+    #   @return [Hash] a hash of options for the plugins
+    option :plugins_options, optional: true, default: -> { EMPTY_HASH }
+
     # @!attribute [r] meta
     #   @return [Array<Symbol>] Meta data for a command
     option :meta, optional: true
@@ -82,12 +86,13 @@ module ROM
     # @api private
     def call(*args)
       cache.fetch_or_store(args.hash) do
-        type, adapter, ast, plugins, meta = args
+        type, adapter, ast, plugins, plugins_options, meta = args
 
         compiler = with(
           id: type,
           adapter: adapter,
           plugins: Array(plugins),
+          plugins_options: plugins_options,
           meta: meta
         )
 
@@ -191,7 +196,8 @@ module ROM
         end
 
         plugins.each do |plugin|
-          klass.use(plugin)
+          plugin_options = plugins_options.fetch(plugin) { EMPTY_HASH }
+          klass.use(plugin, plugin_options)
         end
 
         gateway = gateways[relation.gateway]

--- a/core/lib/rom/commands/class_interface.rb
+++ b/core/lib/rom/commands/class_interface.rb
@@ -110,7 +110,7 @@ module ROM
       #
       # @api public
       def use(plugin, _options = EMPTY_HASH)
-        ROM.plugin_registry.commands.fetch(plugin, adapter).apply_to(self)
+        ROM.plugin_registry.commands.fetch(plugin, adapter).apply_to(self, _options)
       end
 
       # Extend a command class with relation view methods

--- a/core/lib/rom/commands/class_interface.rb
+++ b/core/lib/rom/commands/class_interface.rb
@@ -109,8 +109,8 @@ module ROM
       # @option _options [Symbol] :adapter (:default) first adapter to check for plugin
       #
       # @api public
-      def use(plugin, _options = EMPTY_HASH)
-        ROM.plugin_registry.commands.fetch(plugin, adapter).apply_to(self, _options)
+      def use(plugin, options = EMPTY_HASH)
+        ROM.plugin_registry.commands.fetch(plugin, adapter).apply_to(self, options)
       end
 
       # Extend a command class with relation view methods

--- a/core/lib/rom/core.rb
+++ b/core/lib/rom/core.rb
@@ -29,6 +29,7 @@ require 'rom/create_container'
 require 'rom/plugins/relation/registry_reader'
 require 'rom/plugins/relation/instrumentation'
 require 'rom/plugins/command/schema'
+require 'rom/plugins/command/timestamps'
 require 'rom/plugins/schema/timestamps'
 
 module ROM
@@ -40,5 +41,6 @@ module ROM
     register :registry_reader, ROM::Plugins::Relation::RegistryReader, type: :relation
     register :instrumentation, ROM::Plugins::Relation::Instrumentation, type: :relation
     register :schema, ROM::Plugins::Command::Schema, type: :command
+    register :timestamps, ROM::Plugins::Command::Timestamps, type: :command
   end
 end

--- a/core/lib/rom/plugin.rb
+++ b/core/lib/rom/plugin.rb
@@ -15,7 +15,7 @@ module ROM
     #
     # @api private
     def apply_to(klass, options = EMPTY_HASH)
-      if options.any?
+      if mod.respond_to?(:new)
         klass.send(:include, mod.new(options))
       else
         klass.send(:include, mod)

--- a/core/lib/rom/plugins/command/timestamps.rb
+++ b/core/lib/rom/plugins/command/timestamps.rb
@@ -44,16 +44,12 @@ module ROM
           klass.defines :timestamp_columns, :datestamp_columns
           klass.timestamp_columns Set.new
           klass.datestamp_columns Set.new
+          klass.before :set_timestamps
           klass.timestamp_columns klass.timestamp_columns.merge(timestamps) if timestamps.any?
           klass.datestamp_columns klass.datestamp_columns.merge(datestamps) if datestamps.any?
         end
 
         module InstanceMethods
-          # @api private
-          def self.included(base)
-            base.before :set_timestamps
-          end
-
           # @api private
           def timestamp_columns
             self.class.timestamp_columns

--- a/core/lib/rom/plugins/command/timestamps.rb
+++ b/core/lib/rom/plugins/command/timestamps.rb
@@ -1,0 +1,149 @@
+require 'set'
+
+module ROM
+  module Plugins
+    module Command
+      # A plugin for automatically adding timestamp values
+      # when executing a command
+      #
+      # Set up attributes to timestamp when the command is called
+      #
+      # @example
+      #   class CreateTask < ROM::Commands::Create[:sql]
+      #     result :one
+      #     use :timestamps, timestamps: %i(created_at, updated_at), datestamps: %i(:written)
+      #   end
+      #
+      #   create_user = rom.command(:user).create.curry(name: 'Jane')
+      #
+      #   result = create_user.call
+      #   result[:created_at]  #=> Time.now.utc
+      #
+      # @api public
+      class Timestamps < Module
+        attr_reader :timestamps, :datestamps
+        def initialize(timestamps: [], datestamps: [])
+          @timestamps = store_attributes(timestamps)
+          @datestamps = store_attributes(datestamps)
+        end
+
+        def store_attributes(attr)
+          attr.is_a?(Array) ? attr : Array[attr]
+        end
+
+        # @api private
+        def included(klass)
+          klass.defines :timestamp_columns, :datestamp_columns
+          klass.timestamp_columns Set.new
+          klass.datestamp_columns Set.new
+          klass.timestamp_columns klass.timestamp_columns.merge(timestamps) if timestamps.any?
+          klass.datestamp_columns klass.datestamp_columns.merge(datestamps) if datestamps.any?
+          klass.include(InstanceMethods)
+          klass.extend(ClassInterface)
+          super
+        end
+
+        module InstanceMethods
+          # @api private
+          def self.included(base)
+            base.before :set_timestamps
+          end
+
+          # @api private
+          def timestamp_columns
+            self.class.timestamp_columns
+          end
+
+          # @api private
+          def datestamp_columns
+            self.class.datestamp_columns
+          end
+
+          # Set the timestamp attributes on the given tuples
+          #
+          # @param [Array<Hash>, Hash] tuples the input tuple(s)
+          #
+          # @return [Array<Hash>, Hash]
+          #
+          # @api private
+          def set_timestamps(tuples, *)
+            timestamps = build_timestamps
+
+            case tuples
+            when Hash
+              timestamps.merge(tuples)
+            when Array
+              tuples.map { |t| timestamps.merge(t) }
+            end
+          end
+
+          private
+
+          # @api private
+          def build_timestamps
+            time        = Time.now.utc
+            date        = Date.today
+            timestamps  = {}
+
+            timestamp_columns.each do |column|
+              timestamps[column.to_sym] = time
+            end
+
+            datestamp_columns.each do |column|
+              timestamps[column.to_sym] = date
+            end
+
+            timestamps
+          end
+        end
+
+        module ClassInterface
+          # @api private
+          # Set up attributes to timestamp when the command is called
+          #
+          # @example
+          #   class CreateTask < ROM::Commands::Create[:sql]
+          #     result :one
+          #     use :timestamps
+          #     timestamps :created_at, :updated_at
+          #   end
+          #
+          #   create_user = rom.command(:user).create.curry(name: 'Jane')
+          #
+          #   result = create_user.call
+          #   result[:created_at]  #=> Time.now.utc
+          #
+          # @param [Array<Symbol>] names A list of attribute names
+          #
+          # @api public
+          def timestamps(*names)
+            timestamp_columns timestamp_columns.merge(names)
+          end
+          alias timestamp timestamps
+
+          # Set up attributes to datestamp when the command is called
+          #
+          # @example
+          #   class CreateTask < ROM::Commands::Create[:sql]
+          #     result :one
+          #     use :timestamps
+          #     datestamps :created_on, :updated_on
+          #   end
+          #
+          #   create_user = rom.command(:user).create.curry(name: 'Jane')
+          #
+          #   result = create_user.call
+          #   result[:created_at]  #=> Date.today
+          #
+          # @param [Array<Symbol>] names A list of attribute names
+          #
+          # @api public
+          def datestamps(*names)
+            datestamp_columns datestamp_columns.merge(names)
+          end
+          alias datestamp datestamps
+        end
+      end
+    end
+  end
+end

--- a/core/lib/rom/plugins/command/timestamps.rb
+++ b/core/lib/rom/plugins/command/timestamps.rb
@@ -27,20 +27,25 @@ module ROM
           @datestamps = store_attributes(datestamps)
         end
 
+        # @api private
         def store_attributes(attr)
           attr.is_a?(Array) ? attr : Array[attr]
         end
 
         # @api private
         def included(klass)
+          initialize_timestamp_attributes(klass)
+          klass.include(InstanceMethods)
+          klass.extend(ClassInterface)
+          super
+        end
+
+        def initialize_timestamp_attributes(klass)
           klass.defines :timestamp_columns, :datestamp_columns
           klass.timestamp_columns Set.new
           klass.datestamp_columns Set.new
           klass.timestamp_columns klass.timestamp_columns.merge(timestamps) if timestamps.any?
           klass.datestamp_columns klass.datestamp_columns.merge(datestamps) if datestamps.any?
-          klass.include(InstanceMethods)
-          klass.extend(ClassInterface)
-          super
         end
 
         module InstanceMethods

--- a/core/lib/rom/relation/commands.rb
+++ b/core/lib/rom/relation/commands.rb
@@ -35,8 +35,8 @@ module ROM
       # @return [ROM::Command]
       #
       # @api public
-      def command(type, mapper: nil, use: EMPTY_ARRAY, **opts)
-        base_command = commands.key?(type) ? commands[type] : commands[type, adapter, to_ast, use, opts]
+      def command(type, mapper: nil, use: EMPTY_ARRAY, plugins_options: EMPTY_HASH, **opts)
+        base_command = commands.key?(type) ? commands[type] : commands[type, adapter, to_ast, use, plugins_options, opts]
 
         command =
           if mapper

--- a/core/spec/unit/rom/command_compiler_spec.rb
+++ b/core/spec/unit/rom/command_compiler_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe 'ROM::CommandCompiler' do
     end
 
     it 'builds commands using ast' do
-      command = compiler[:create, :memory, [:relation, users_ast], [], {}]
+      command = compiler[:create, :memory, [:relation, users_ast], [], {}, {}]
       expect(command).to be_a(ROM::Memory::Commands::Create)
     end
 
     it "doesn't use a global cache" do
-      args = [:create, :memory, [:relation, users_ast], [], {}]
+      args = [:create, :memory, [:relation, users_ast], [], {}, {}]
       command = compiler[*args]
       second_command = second_compiler[*args]
 

--- a/core/spec/unit/rom/plugins/command/timestamps_spec.rb
+++ b/core/spec/unit/rom/plugins/command/timestamps_spec.rb
@@ -1,0 +1,168 @@
+require 'rom/command'
+require 'rom/plugins/command/timestamps'
+
+RSpec.describe ROM::Plugins::Command::Timestamps do
+  include_context 'container'
+
+  let(:users) { container.commands.users }
+  let(:tasks) { container.commands.tasks }
+  let(:time) { DateTime.now }
+
+  before do
+    configuration.relation :users do
+      def by_name(name)
+        restrict(name: name)
+      end
+    end
+
+    configuration.relation :tasks do
+      def by_priority(priority)
+        restrict(priority: priority)
+      end
+    end
+
+    configuration.commands(:users) do
+      define :create_with_timestamps_options, type: :create do
+        result :one
+        use :timestamps, timestamps: %i(created_at updated_at)
+      end
+
+      define :create_with_datestamps_options, type: :create do
+        result :one
+        use :timestamps, datestamps: :written
+      end
+
+      define :create_with_both_options, type: :create do
+        result :one
+        use :timestamps, timestamps: %i(created_at updated_at), datestamps: :written
+      end
+
+      define :create do
+        result :one
+        use :timestamps
+        timestamp :updated_at, :created_at
+        datestamp :written
+      end
+
+      define :create_many, type: :create do
+        result :many
+        use :timestamps
+        timestamp :updated_at, :created_at
+      end
+
+      define :update do
+        use :timestamps
+        timestamp :updated_at
+      end
+
+      define :create_with_task, type: :create do
+        result :one
+        use :timestamps
+        timestamp :updated_at, :created_at
+
+        before :assign_task
+        def assign_task(tuple, task)
+          tuple.merge(task_id: task[:id])
+        end
+      end
+    end
+
+    configuration.commands(:tasks) do
+      define :create do
+        result :one
+      end
+    end
+  end
+
+  shared_examples_for 'a command setting timestamps' do
+    let(:user_command)  { users.public_send(command)  }
+    let(:result) { user_command.call(name: 'Piotr', email: 'piotr@solnic.eu') }
+
+    it 'applies timestamps by default' do
+      created = DateTime.parse(result[:created_at].to_s)
+      updated = DateTime.parse(result[:updated_at].to_s)
+
+      expect(created).to be_within(1).of(time)
+      expect(updated).to eq created
+    end
+  end
+
+  shared_examples_for 'a command setting datestamp' do
+    let(:user_command)  { users.public_send(command)  }
+    let(:result) { user_command.call(name: 'Piotr', email: 'piotr@solnic.eu') }
+
+    it 'applies datestamps by default' do
+      expect(Date.parse(result[:written].to_s)).to eq Date.today
+    end
+  end
+
+  it_behaves_like 'a command setting timestamps' do
+    let(:command) { :create_with_timestamps_options }
+  end
+
+  it_behaves_like 'a command setting datestamp' do
+    let(:command) { :create_with_datestamps_options }
+  end
+
+  it_behaves_like 'a command setting timestamps' do
+    let(:command) { :create_with_both_options }
+  end
+
+  it_behaves_like 'a command setting datestamp' do
+    let(:command) { :create_with_both_options }
+  end
+
+  it_behaves_like 'a command setting timestamps' do
+    let(:command) { :create }
+  end
+
+  it_behaves_like 'a command setting datestamp' do
+    let(:command) { :create }
+  end
+
+  it "sets timestamps on multi-tuple inputs" do
+    input = [{text: "note one"}, {text: "note two"}]
+
+    results = users.create_many.call(input)
+
+    results.each do |result|
+      created = DateTime.parse(result[:created_at].to_s)
+
+      expect(created).to be_within(1).of(time)
+    end
+  end
+
+  it "only updates specified timestamps" do
+    initial = users.create.call(name: 'Piotr', email: 'piotr@solnic.eu')
+    initial_updated_at = initial[:updated_at]
+    sleep 1  # Unfortunate, but unless I start injecting clocks into the
+             # command, this is needed to make sure the time actually changes
+    updated = users.update.call(name: 'Piotr Updated').first
+    expect(updated[:created_at]).to eq initial[:created_at]
+    expect(updated[:updated_at]).not_to eq initial_updated_at
+  end
+
+  it "allows overriding timestamps" do |ex|
+    tomorrow = (Time.now + (60 * 60 * 24))
+
+    users.create.call(name: 'Piotr', email: 'piotr@solnic.eu')
+    updated = users.update.call(name: 'Piotr Updated', updated_at: tomorrow).first
+
+    expect(updated[:updated_at].iso8601).to eql(tomorrow.iso8601)
+  end
+
+  it "works with chained commands" do
+    create_user = tasks.create.curry(name: 'ROM-RB', title: 'Work on OSS', priority: 1)
+    create_note = users.create_with_task.curry(name: 'Piotr')
+
+    command = create_user >> create_note
+
+    result = command.call
+
+    created = DateTime.parse(result[:created_at].to_s)
+    updated = DateTime.parse(result[:updated_at].to_s)
+
+    expect(created).to be_within(1).of(time)
+    expect(updated).to eq created
+  end
+end

--- a/core/spec/unit/rom/plugins/command/timestamps_spec.rb
+++ b/core/spec/unit/rom/plugins/command/timestamps_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe ROM::Plugins::Command::Timestamps do
     expect(updated[:updated_at]).not_to eq initial_updated_at
   end
 
-  it "allows overriding timestamps" do |ex|
+  it "allows overriding timestamps" do
     tomorrow = (Time.now + (60 * 60 * 24))
 
     users.create.call(name: 'Piotr', email: 'piotr@solnic.eu')

--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -62,7 +62,7 @@ module ROM
       #
       #   # with custom command plugin
       #   class UserRepo < ROM::Repository[:users]
-      #     commands :create, plugin: :my_command_plugin
+      #     commands :create, use: :my_command_plugin
       #   end
       #
       #   # with custom mapper

--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -77,7 +77,7 @@ module ROM
       # @return [Array<Symbol>] A list of defined command names
       #
       # @api public
-      def commands(*names, mapper: nil, use: nil, **opts)
+      def commands(*names, mapper: nil, use: nil, plugins_options: EMPTY_HASH, **opts)
         if names.any? || opts.any?
           @commands = names + opts.to_a
 
@@ -85,9 +85,9 @@ module ROM
             type, *view = Array(spec).flatten
 
             if view.size > 0
-              define_restricted_command_method(type, view, mapper: mapper, use: use)
+              define_restricted_command_method(type, view, mapper: mapper, use: use, plugins_options: plugins_options)
             else
-              define_command_method(type, mapper: mapper, use: use)
+              define_command_method(type, mapper: mapper, use: use, plugins_options: plugins_options)
             end
           end
         else

--- a/repository/spec/integration/command_macros_spec.rb
+++ b/repository/spec/integration/command_macros_spec.rb
@@ -149,6 +149,15 @@ RSpec.describe ROM::Repository, '.command' do
       expect(updated_user.updated_at).to be > updated_user.created_at
     end
 
+    it 'allows to pass options to plugins' do
+      repo = Class.new(ROM::Repository[:users]) do
+        commands :create, update: :by_pk, use: %i(modify_name timestamps), plugins_options: { modify_name: { reverse: true } }
+      end.new(rom)
+
+      user = repo.create(name: 'Jane')
+      expect(user.name).to eq 'enaJ'
+    end
+
     it 'allows to use several plugins' do
       repo = Class.new(ROM::Repository[:users]) do
         commands :create, use: %i(upcase_name timestamps)

--- a/repository/spec/shared/plugins.rb
+++ b/repository/spec/shared/plugins.rb
@@ -54,12 +54,43 @@ RSpec.shared_context 'plugins' do
           klass.extend ClassInterface
         end
       end
+
+      class ModifyName < Module
+        attr_reader :opts
+        def initialize(opts = {})
+          @opts = opts
+        end
+
+        def included(klass)
+          super
+          klass.defines :reverse
+          klass.reverse opts[:reverse]
+          klass.before :modify_name
+          klass.include InstanceInterface
+        end
+
+        module InstanceInterface
+
+          def reverse?
+            self.class.reverse
+          end
+
+          def modify_name(tuples, *)
+            if reverse?
+              tuples.merge(name: tuples[:name].reverse)
+            else
+              tuples
+            end
+          end
+        end
+      end
     end
 
     ROM.plugins do
       adapter :sql do
         register :timestamps, Test::Timestamps, type: :command
         register :upcase_name, Test::UpcaseName, type: :command
+        register :modify_name, Test::ModifyName, type: :command
       end
     end
   end


### PR DESCRIPTION
Solves #467 

- Allow to pass options to command plugins
- Refactor Command Timestamp plugin to accept options
- Move Command Timestamp plugin to rom-core

After this changes the `timestamp` plugin will works as before and also accepts initial options to set timestamps.

```ruby
class CreateTask < ROM::Commands::Create[:sql]
  result :one
  use :timestamps, timestamps: %i(created_at, updated_at), datestamps: %i(:written)
end
```

Also in order to been able to set a fully working command from a `Relation` we need to allow passing options to the `commands` API, since we support setting multiple commands, I decided to go with the approach of having a new argument `plugins_options` been a hash where each key must be equal to the plugins name.

```ruby
class UserRepo < ROM::Repository[:users]
  commands :create, use: %i(schema timestamps), plugins_options: { timestamps: datestamps: %i(:written) }
end
```

### Missing 
- [x] Modify `Repository#commands` to accepts options for plugin
- [ ] Remove `Timestamp` from `rom-sql` https://github.com/rom-rb/rom-sql/pull/264