### PR TITLE
Use dry-inflector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ COMPONENTS.each do |component|
 end
 
 gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct.git', branch: 'master'
+gem 'dry-inflector', git: 'https://github.com/dry-rb/dry-inflector.git', branch: 'backward-compat'
+gem 'dry-core', git: 'https://github.com/dry-rb/dry-core.git', branch: 'master'
 
 group :sql do
   gem 'sequel', '~> 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ COMPONENTS.each do |component|
 end
 
 gem 'dry-struct', git: 'https://github.com/dry-rb/dry-struct.git', branch: 'master'
-gem 'dry-inflector', git: 'https://github.com/dry-rb/dry-inflector.git', branch: 'backward-compat'
+gem 'dry-inflector', git: 'https://github.com/dry-rb/dry-inflector.git', branch: 'master'
 gem 'dry-core', git: 'https://github.com/dry-rb/dry-core.git', branch: 'master'
 
 group :sql do
@@ -26,7 +26,6 @@ end
 
 group :test do
   gem 'rspec', '~> 3.6'
-  gem 'inflecto'
   gem 'simplecov', platforms: :mri
 end
 

--- a/core/lib/rom/associations/definitions/abstract.rb
+++ b/core/lib/rom/associations/definitions/abstract.rb
@@ -124,7 +124,7 @@ module ROM
         #
         # @api public
         def type
-          Dry::Core::Inflector.demodulize(self.class.name).to_sym
+          Inflector.demodulize(self.class.name).to_sym
         end
       end
     end

--- a/core/lib/rom/associations/through_identifier.rb
+++ b/core/lib/rom/associations/through_identifier.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module ROM
   module Associations
@@ -20,7 +20,7 @@ module ROM
 
       # @api private
       def self.default_assoc_name(relation)
-        Dry::Core::Inflector.singularize(relation).to_sym
+        Inflector.singularize(relation).to_sym
       end
 
       # @api private

--- a/core/lib/rom/command_compiler.rb
+++ b/core/lib/rom/command_compiler.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 require 'rom/initializer'
 require 'rom/commands'
@@ -107,7 +107,7 @@ module ROM
 
     # @api private
     def type
-      @_type ||= Commands.const_get(Dry::Core::Inflector.classify(id))[adapter]
+      @_type ||= Commands.const_get(Inflector.classify(id))[adapter]
     rescue NameError
       nil
     end
@@ -132,7 +132,7 @@ module ROM
           if meta[:combine_type] == :many
             name
           else
-            { Dry::Core::Inflector.singularize(name).to_sym => name }
+            { Inflector.singularize(name).to_sym => name }
           end
 
         mapping =
@@ -227,7 +227,7 @@ module ROM
         if relation.associations.key?(parent_relation)
           parent_relation
         else
-          singular_name = Dry::Core::Inflector.singularize(parent_relation).to_sym
+          singular_name = Inflector.singularize(parent_relation).to_sym
           singular_name if relation.associations.key?(singular_name)
         end
 

--- a/core/lib/rom/command_proxy.rb
+++ b/core/lib/rom/command_proxy.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module ROM
   # TODO: look into making command graphs work without the root key in the input
@@ -9,7 +9,7 @@ module ROM
     attr_reader :command, :root
 
     # @api private
-    def initialize(command, root = Dry::Core::Inflector.singularize(command.name.relation).to_sym)
+    def initialize(command, root = Inflector.singularize(command.name.relation).to_sym)
       @command = command
       @root = root
     end

--- a/core/lib/rom/commands/class_interface.rb
+++ b/core/lib/rom/commands/class_interface.rb
@@ -1,5 +1,5 @@
 require 'dry/core/class_builder'
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module ROM
   # Base command class with factory class-level interface and setup-related logic
@@ -39,7 +39,7 @@ module ROM
       #
       # @api public
       def [](adapter)
-        adapter_namespace(adapter).const_get(Dry::Core::Inflector.demodulize(name))
+        adapter_namespace(adapter).const_get(Inflector.demodulize(name))
       end
 
       # Return namespaces that contains command subclasses of a specific adapter
@@ -85,7 +85,7 @@ module ROM
       # @api public
       def create_class(name, type, &block)
         klass = Dry::Core::ClassBuilder
-          .new(name: "#{Dry::Core::Inflector.classify(type)}[:#{name}]", parent: type)
+          .new(name: "#{Inflector.classify(type)}[:#{name}]", parent: type)
           .call
 
         if block
@@ -235,7 +235,7 @@ module ROM
       #
       # @api private
       def default_name
-        Dry::Core::Inflector.underscore(Dry::Core::Inflector.demodulize(name)).to_sym
+        Inflector.underscore(Inflector.demodulize(name)).to_sym
       end
 
       # Return default options based on class macros

--- a/core/lib/rom/configuration_dsl/command.rb
+++ b/core/lib/rom/configuration_dsl/command.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 require 'dry/core/class_builder'
 
 module ROM
@@ -14,7 +14,7 @@ module ROM
       # @api private
       def self.build_class(name, relation, options = EMPTY_HASH, &block)
         type = options.fetch(:type) { name }
-        command_type = Dry::Core::Inflector.classify(type)
+        command_type = Inflector.classify(type)
         adapter = options.fetch(:adapter)
         parent = ROM::Command.adapter_namespace(adapter).const_get(command_type)
         class_name = generate_class_name(adapter, command_type, relation)
@@ -31,9 +31,9 @@ module ROM
       # @api private
       def self.generate_class_name(adapter, command_type, relation)
         pieces = ['ROM']
-        pieces << Dry::Core::Inflector.classify(adapter)
+        pieces << Inflector.classify(adapter)
         pieces << 'Commands'
-        pieces << "#{command_type}[#{Dry::Core::Inflector.classify(relation)}s]"
+        pieces << "#{command_type}[#{Inflector.classify(relation)}s]"
         pieces.join('::')
       end
     end

--- a/core/lib/rom/configuration_dsl/relation.rb
+++ b/core/lib/rom/configuration_dsl/relation.rb
@@ -1,5 +1,5 @@
 require 'dry/core/class_builder'
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module ROM
   module ConfigurationDSL
@@ -13,7 +13,7 @@ module ROM
       #
       # @api private
       def self.build_class(name, options = EMPTY_HASH)
-        class_name = "ROM::Relation[#{Dry::Core::Inflector.camelize(name)}]"
+        class_name = "ROM::Relation[#{Inflector.camelize(name)}]"
         adapter = options.fetch(:adapter)
 
         Dry::Core::ClassBuilder.new(name: class_name, parent: ROM::Relation[adapter]).call do |klass|

--- a/core/lib/rom/gateway.rb
+++ b/core/lib/rom/gateway.rb
@@ -32,6 +32,22 @@ module ROM
     #    @param [Symbol] adapter The adapter identifier
     defines :adapter
 
+    # @!method self.mapper_compiler
+    #  Get or set gateway-specific mapper compiler class
+    #
+    #  @overload mapper_compiler
+    #    Return mapper compiler class
+    #    @return [Class]
+    #
+    #  @overload mapper_compiler(klass)
+    #    @example
+    #      class MyGateway < ROM::Gateway
+    #        mapper_compiler MyMapperCompiler
+    #      end
+    #
+    #    @param [Class] klass The mapper compiler class
+    defines :mapper_compiler
+
     # @!attribute [r] connection
     #   @return [Object] The gateway's connection object (type varies across adapters)
     attr_reader :connection
@@ -176,6 +192,15 @@ module ROM
     # @api public
     def transaction(opts = EMPTY_HASH, &block)
       transaction_runner(opts).run(opts, &block)
+    end
+
+    # Return configured mapper compiler class
+    #
+    # @return [Class]
+    #
+    # @api private
+    def mapper_compiler
+      self.class.mapper_compiler
     end
 
     private

--- a/core/lib/rom/relation.rb
+++ b/core/lib/rom/relation.rb
@@ -602,7 +602,7 @@ module ROM
       if attr
         attr.name
       else
-        :"#{Dry::Core::Inflector.singularize(name.dataset)}_id"
+        :"#{Inflector.singularize(name.dataset)}_id"
       end
     end
 

--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -1,6 +1,6 @@
 require 'set'
 
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 require 'rom/constants'
 require 'rom/relation/name'
@@ -292,7 +292,7 @@ module ROM
       #
       # @api private
       def default_name
-        Name[Dry::Core::Inflector.underscore(name).tr('/', '_').to_sym]
+        Name[Inflector.underscore(name).tr('/', '_').to_sym]
       end
 
       # @api private

--- a/core/lib/rom/schema/associations_dsl.rb
+++ b/core/lib/rom/schema/associations_dsl.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 require 'rom/associations/definitions'
 
@@ -197,7 +197,7 @@ module ROM
 
       # @api private
       def dataset_name(name)
-        ::Dry::Core::Inflector.pluralize(name).to_sym
+        Inflector.pluralize(name).to_sym
       end
     end
   end

--- a/core/lib/rom/setup/auto_registration.rb
+++ b/core/lib/rom/setup/auto_registration.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 require 'rom/types'
 require 'rom/initializer'
@@ -94,7 +94,7 @@ module ROM
             ).call
           end
 
-        Dry::Core::Inflector.constantize(klass_name)
+        Inflector.constantize(klass_name)
       end
     end
   end

--- a/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 require 'rom/types'
 require 'rom/setup/auto_registration_strategies/base'
 
@@ -28,7 +28,7 @@ module ROM
 
         path_arr.reverse.each do |dir|
           const_fragment = potential.unshift(
-            Dry::Core::Inflector.camelize(dir)
+            Inflector.camelize(dir)
           ).join("::")
 
           constant = "#{namespace}::#{const_fragment}"
@@ -40,7 +40,7 @@ module ROM
 
         # If we have reached this point, its means constant is not defined and
         # NameError will be thrown if we attempt to camelize something like:
-        # `"#{namespace}::#{Dry::Core::Inflector.camelize(filename)}"`
+        # `"#{namespace}::#{Inflector.camelize(filename)}"`
         # so we can assume naming convention was not respected in required
         # file.
 
@@ -63,7 +63,7 @@ module ROM
 
       # @api private
       def ns_const
-        @namespace_constant ||= Dry::Core::Inflector.constantize(namespace)
+        @namespace_constant ||= Inflector.constantize(namespace)
       end
 
       # @api private

--- a/core/lib/rom/setup/auto_registration_strategies/no_namespace.rb
+++ b/core/lib/rom/setup/auto_registration_strategies/no_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 require 'rom/types'
 require 'rom/setup/auto_registration_strategies/base'
 
@@ -22,7 +22,7 @@ module ROM
       #
       # @api private
       def call
-        Dry::Core::Inflector.camelize(
+        Inflector.camelize(
           file.sub(/^#{directory}\/#{entity}\//, '').sub(EXTENSION_REGEX, '')
         )
       end

--- a/core/lib/rom/setup/auto_registration_strategies/with_namespace.rb
+++ b/core/lib/rom/setup/auto_registration_strategies/with_namespace.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 require 'rom/setup/auto_registration_strategies/base'
 
 module ROM
@@ -18,7 +18,7 @@ module ROM
       #
       # @api private
       def call
-        Dry::Core::Inflector.camelize(
+        Inflector.camelize(
           file.sub(/^#{directory.dirname}\//, '').sub(EXTENSION_REGEX, '')
         )
       end

--- a/core/lib/rom/support/inflector.rb
+++ b/core/lib/rom/support/inflector.rb
@@ -1,0 +1,20 @@
+require 'dry/inflector'
+
+module ROM
+  DOUBLE_COLON = '::'.freeze
+
+  Inflector = Dry::Inflector.new
+
+  def Inflector.constantize(input)
+    names = input.split(DOUBLE_COLON)
+    names.shift if names.first.empty?
+
+    names.inject(Object) do |constant, name|
+      if constant.const_defined?(name, false)
+        constant.const_get(name)
+      else
+        constant.const_missing(name)
+      end
+    end
+  end
+end

--- a/core/lib/rom/support/inflector.rb
+++ b/core/lib/rom/support/inflector.rb
@@ -3,18 +3,7 @@ require 'dry/inflector'
 module ROM
   DOUBLE_COLON = '::'.freeze
 
-  Inflector = Dry::Inflector.new
-
-  def Inflector.constantize(input)
-    names = input.split(DOUBLE_COLON)
-    names.shift if names.first.empty?
-
-    names.inject(Object) do |constant, name|
-      if constant.const_defined?(name, false)
-        constant.const_get(name)
-      else
-        constant.const_missing(name)
-      end
-    end
+  Inflector = Dry::Inflector.new do |i|
+    i.plural(/people\z/i, 'people')
   end
 end

--- a/core/spec/support/schema.rb
+++ b/core/spec/support/schema.rb
@@ -1,5 +1,5 @@
 require 'dry/types'
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module SchemaHelpers
   def define_schema(source, attrs)
@@ -18,7 +18,7 @@ module SchemaHelpers
   end
 
   def build_assoc(type, *args)
-    klass = Dry::Core::Inflector.classify(type)
+    klass = ROM::Inflector.classify(type)
     definition = ROM::Associations::Definitions.const_get(klass).new(*args)
     ROM::Memory::Associations.const_get(definition.type).new(definition, relations)
   end

--- a/mapper/lib/rom/model_builder.rb
+++ b/mapper/lib/rom/model_builder.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 
 module ROM
   # Model builders can be used to build model classes for mappers
@@ -54,7 +54,7 @@ module ROM
 
         @namespace =
           if parts.any?
-            Dry::Core::Inflector.constantize(parts.join('::'))
+            Inflector.constantize(parts.join('::'))
           else
             Object
           end

--- a/mapper/lib/rom/struct_compiler.rb
+++ b/mapper/lib/rom/struct_compiler.rb
@@ -1,4 +1,4 @@
-require 'dry/core/inflector'
+require 'rom/support/inflector'
 require 'dry/core/class_builder'
 require 'dry/types/compiler'
 
@@ -104,7 +104,7 @@ module ROM
 
     # @api private
     def class_name(name)
-      Dry::Core::Inflector.classify(Dry::Core::Inflector.singularize(name))
+      Inflector.classify(Inflector.singularize(name))
     end
   end
 end


### PR DESCRIPTION
We're switching to dry-inflector as THE inflection backend in rom-rb. Usage of `Dry::Core::Inflector` is removed.