### PR TITLE
Fix RDoc example for #has_one

### DIFF
--- a/core/lib/rom/schema/associations_dsl.rb
+++ b/core/lib/rom/schema/associations_dsl.rb
@@ -156,10 +156,10 @@ module ROM
       # Shortcut for one_to_one which sets alias automatically
       #
       # @example with an alias (relation identifier is inferred via pluralization)
-      #   one_to_one :address
+      #   has_one :address
       #
       # @example with an explicit alias and a custom view
-      #   one_to_one :posts, as: :priority_post, view: :prioritized
+      #   has_one :posts, as: :priority_post, view: :prioritized
       #
       # @see #one_to_one
       #


### PR DESCRIPTION
The RDocs are for the method #has_one, but the examples are showing #one_to_one, so we fix that.