### PR TITLE
Make timestamp plugin work with changesets

### DIFF
--- a/changeset/spec/integration/changeset_spec.rb
+++ b/changeset/spec/integration/changeset_spec.rb
@@ -36,6 +36,25 @@ RSpec.describe 'Using changesets' do
       expect(delete).to be_kind_of(ROM::Changeset::Delete)
     end
 
+    it 'works with command plugins' do
+      configuration.commands(:books) do
+        define(:create) do
+          use :timestamps
+          timestamp :created_at, :updated_at
+          result :one
+        end
+      end
+
+      changeset = books.changeset(:create, title: "rom-rb is awesome")
+
+      result = changeset.commit
+
+      expect(result.id).to_not be(nil)
+      expect(result.title).to eql("rom-rb is awesome")
+      expect(result.created_at).to be_instance_of(Time)
+      expect(result.updated_at).to be_instance_of(Time)
+    end
+
     it 'can be passed to a command' do
       changeset = users.changeset(:create, name: "Jane Doe")
       command = users.command(:create)
@@ -122,6 +141,28 @@ RSpec.describe 'Using changesets' do
       expect(result.title).to eql('rom-rb is awesome for real')
       expect(result.updated_at).to be_instance_of(Time)
     end
+
+
+    it 'works with command plugins' do
+      configuration.commands(:books) do
+        define(:update) do
+          use :timestamps
+          timestamp :updated_at
+          result :one
+        end
+      end
+
+      book = books.command(:create).call(title: 'rom-rb is awesome')
+
+      changeset = books.by_pk(book.id).changeset(:update, title: "rom-rb is awesome for real")
+
+      result = changeset.commit
+
+      expect(result.id).to_not be(nil)
+      expect(result.title).to eql("rom-rb is awesome for real")
+      expect(result.updated_at).to be_instance_of(Time)
+    end
+
 
     it 'skips update execution with no diff' do
       book = books.command(:create).call(title: 'rom-rb is awesome')

--- a/core/lib/rom/command.rb
+++ b/core/lib/rom/command.rb
@@ -441,6 +441,19 @@ module ROM
       self.class.restrictable.equal?(true)
     end
 
+    # Yields tuples for insertion or return an enumerator
+    #
+    # @api private
+    def map_input_tuples(tuples, &mapper)
+      return enum_for(:with_input_tuples, tuples) unless mapper
+
+      if tuples.respond_to? :merge
+        mapper[tuples]
+      else
+        tuples.map(&mapper)
+      end
+    end
+
     private
 
     # Hook called by Pipeline to get composite class for commands

--- a/core/lib/rom/plugins/command/timestamps.rb
+++ b/core/lib/rom/plugins/command/timestamps.rb
@@ -70,12 +70,7 @@ module ROM
           def set_timestamps(tuples, *)
             timestamps = build_timestamps
 
-            case tuples
-            when Hash
-              timestamps.merge(tuples)
-            when Array
-              tuples.map { |t| timestamps.merge(t) }
-            end
+            map_input_tuples(tuples) { |t| timestamps.merge(t) }
           end
 
           private


### PR DESCRIPTION
Changesets pass themselves as an argument to command pipelines, rather
than the raw tuple.  Because the timestamp plugin was using Hash/Array
to determine the method to use for blending new data, it was triggering
a failure when the changeset fell through the case statement here.

We should probably keep an eye out for any similar patterns in command
hooks as the resulting error message was an utterly unclear:
      ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # /home/flip/.gem/ruby/2.4.2/gems/rom-sql-2.3.0/lib/rom/sql/commands/create.rb:22:in `execute'

fixes #475