### PR TITLE
Look up the most nested constant first in the CustomNamespace strategy

### DIFF
--- a/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -23,13 +23,14 @@ module ROM
       #
       # @api private
       def call
-        potential = []
+        parts = path_arr.map { |part| Inflector.camelize(part) }
+        potential = parts.map.with_index { |arr, i|
+          parts[(i - parts.size)..parts.size]
+        }
         attempted = []
 
-        path_arr.reverse.each do |dir|
-          const_fragment = potential.unshift(
-            Inflector.camelize(dir)
-          ).join("::")
+        potential.map do |path|
+          const_fragment = path.join("::")
 
           constant = "#{namespace}::#{const_fragment}"
 

--- a/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/core/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -24,9 +24,9 @@ module ROM
       # @api private
       def call
         parts = path_arr.map { |part| Inflector.camelize(part) }
-        potential = parts.map.with_index { |arr, i|
+        potential = parts.map.with_index do |_, i|
           parts[(i - parts.size)..parts.size]
-        }
+        end
         attempted = []
 
         potential.map do |path|

--- a/core/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/core/spec/unit/rom/setup/auto_registration_spec.rb
@@ -151,6 +151,21 @@ RSpec.describe ROM::Setup, '#auto_registration' do
             expect(setup.mapper_classes).to eql([My::Namespace::Mappers::CustomerList])
           end
         end
+
+        context 'with possibly clashing namespace' do
+          before do
+            module My
+              module Namespace
+                module Customers
+                end
+              end
+            end
+          end
+
+          it 'starts with the deepest constant' do
+            expect(setup.relation_classes).to eql([My::Namespace::Relations::Customers])
+          end
+        end
       end
 
       context 'when namespace has wrong subnamespace' do

--- a/core/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/core/spec/unit/rom/setup/auto_registration_spec.rb
@@ -2,9 +2,19 @@ require 'rom/setup'
 require 'rom/support/notifications'
 
 RSpec.describe ROM::Setup, '#auto_registration' do
+  let!(:loaded_features) { $LOADED_FEATURES.dup }
+
   subject(:setup) { ROM::Setup.new(notifications) }
 
   let(:notifications) { instance_double(ROM::Notifications::EventBus) }
+
+  after do
+    %i(Persistence Users CreateUser UserList My).each do |const|
+      Object.send(:remove_const, const) if Object.const_defined?(const)
+    end
+
+    $LOADED_FEATURES.replace(loaded_features)
+  end
 
   context 'with default component_dirs' do
     context 'with namespace turned on' do


### PR DESCRIPTION
In my app, I have `App::Events` which is a module not related to the persistence layer and I also have `App::Relations::Events` which is a relations class. `CustomNamespace` wrongfully picks up `App::Events` rather than App::Relations::Events. This PR fixes the issue, now it starts with the longest constant name.