### PR TITLE
Provide adapter to schema DSL instance

### DIFF
--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -105,6 +105,7 @@ module ROM
           @schema_proc = proc do |*args, &inner_block|
             schema_dsl.new(
               relation_name,
+              adapter: adapter,
               schema_class: schema_class,
               attr_class: schema_attr_class,
               inferrer: schema_inferrer.with(enabled: infer),


### PR DESCRIPTION
Fixes ":plugin doesn't exist in ROM::AdapterPluginRegistry registry"
when using adapter-specific plugins.