### PR TITLE
Allow specifying timestamps manually when using mappers

### DIFF
--- a/changeset/lib/rom/changeset/pipe.rb
+++ b/changeset/lib/rom/changeset/pipe.rb
@@ -14,11 +14,11 @@ module ROM
 
       def self.add_timestamps(data)
         now = Time.now
-        data.merge(created_at: now, updated_at: now)
+        Hash(created_at: now, updated_at: now).merge(data)
       end
 
       def self.touch(data)
-        data.merge(updated_at: Time.now)
+        Hash(updated_at: Time.now).merge(data)
       end
     end
 

--- a/changeset/spec/unit/pipe_registry_spec.rb
+++ b/changeset/spec/unit/pipe_registry_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe ROM::Changeset::PipeRegistry do
+  describe '.add_timestamps' do
+    context 'input has no timestamps' do
+      let(:data) { Hash(name: 'John') }
+
+      it 'adds timestamps to hash' do
+        expect(described_class.add_timestamps(data)[:name]).to eq('John')
+
+        expect(described_class.add_timestamps(data)[:created_at]).to be_a(Time)
+        expect(described_class.add_timestamps(data)[:updated_at]).to be_a(Time)
+      end
+    end
+
+    context 'input has (some) timestamps' do
+      let(:data) { Hash(name: 'John', created_at: :timestamp) }
+
+      it 'preserves original values' do
+        expect(described_class.add_timestamps(data)[:name]).to eq('John')
+        expect(described_class.add_timestamps(data)[:created_at]).to eq(:timestamp)
+      end
+
+      it 'adds missing values' do
+        expect(described_class.add_timestamps(data)[:name]).to eq('John')
+        expect(described_class.add_timestamps(data)[:updated_at]).to be_a(Time)
+      end
+    end
+  end
+
+  describe '.touch' do
+    context 'input has no updated timestamp' do
+      let(:data) { Hash(name: 'John') }
+
+      it 'adds updated_at timestamp to hash' do
+        expect(described_class.touch(data)[:name]).to eq('John')
+
+        expect(described_class.touch(data)[:created_at]).to be_nil
+        expect(described_class.touch(data)[:updated_at]).to be_a(Time)
+      end
+    end
+
+    context 'input has updated_at timestamp' do
+      let(:data) { Hash(name: 'John', updated_at: :timestamp) }
+
+      it 'preserves original values' do
+        expect(described_class.touch(data)[:name]).to eq('John')
+        expect(described_class.touch(data)[:updated_at]).to eq(:timestamp)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was no way to override timestamps when using the `:add_timestamps` and `:touch` [transformations](http://rom-rb.org/4.0/learn/core/changesets/#changeset-mapping) with changesets.

I discussed it with @flash-gordon and decided to open a PR to add the possibility. I added tests and tried to follow the conventions, but let me know if anything is missing.

Edit: opened a [pull request](https://github.com/rom-rb/rom-rb.org/pull/255) to rom-rb.org as well.