### PR TITLE
Revert "Provide adapter to schema DSL instance"

### DIFF
--- a/core/lib/rom/relation/class_interface.rb
+++ b/core/lib/rom/relation/class_interface.rb
@@ -105,7 +105,6 @@ module ROM
           @schema_proc = proc do |*args, &inner_block|
             schema_dsl.new(
               relation_name,
-              adapter: adapter,
               schema_class: schema_class,
               attr_class: schema_attr_class,
               inferrer: schema_inferrer.with(enabled: infer),

--- a/core/spec/unit/rom/relation/schema_spec.rb
+++ b/core/spec/unit/rom/relation/schema_spec.rb
@@ -251,32 +251,6 @@ RSpec.describe ROM::Relation, '.schema' do
       expect(schema[:admin]).to eql(ROM::Types::Bool.meta(name: :admin, source: ROM::Relation::Name[:test_users]))
     end
 
-    it 'passes adapter to schema_dsl' do
-      module Test::ExamplePlugin
-        def self.apply(schema, name: :example, type: ROM::Types::String)
-          attr = type.meta(name: name, source: schema.name)
-
-          schema.attributes.concat(schema.class.attributes([attr], schema.attr_class))
-        end
-      end
-
-      ROM.plugins do
-        adapter :memory do
-          register :example, Test::ExamplePlugin, type: :schema
-        end
-      end
-
-      class Test::Users < ROM::Relation[:memory]
-        schema do
-          use :example
-        end
-      end
-
-      schema = Test::Users.schema_proc.call
-
-      expect(schema[:example]).to eql(ROM::Types::String.meta(name: :example, source: ROM::Relation::Name[:test_users]))
-    end
-
     it 'raises an error on double definition' do
       expect {
         class Test::Users < ROM::Relation[:memory]


### PR DESCRIPTION
Reverts rom-rb/rom#480

This broke `rspec ./spec/integration/setup_spec.rb:44 # Setting up rom suite configuring plugins for schemas extends schema dsl` so it needs more work.