### PR TITLE
Struct compiler now checks if a class exists before creating a new one

### DIFF
--- a/mapper/lib/rom/struct_compiler.rb
+++ b/mapper/lib/rom/struct_compiler.rb
@@ -34,11 +34,13 @@ module ROM
         if attributes.empty?
           ROM::OpenStruct
         else
-          build_class(name, ROM::Struct, ns) do |klass|
-            attributes.each do |(attr_name, type)|
-              klass.attribute(attr_name, type)
-            end
+          klass = get_class(name, ns) || build_class(name, ROM::Struct, ns)
+
+          attributes.each do |(attr_name, type)|
+            klass.attribute(attr_name, type)
           end
+
+          klass
         end
       end
     end
@@ -93,6 +95,13 @@ module ROM
     def visit_enum(node)
       type_node, * = node
       visit(type_node)
+    end
+
+    # @api private
+    def get_class(name, ns)
+      ns.const_get(class_name(name))
+    rescue NameError
+      nil
     end
 
     # @api private

--- a/mapper/spec/unit/rom/struct_compiler_spec.rb
+++ b/mapper/spec/unit/rom/struct_compiler_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe ROM::StructCompiler, '#call' do
     [:users, [[:attribute, attr_ast(:id, :Int)], [:attribute, attr_ast(:name, :String)]]]
   end
 
+  before do
+    ROM::Struct.send(:remove_const, :User) if ROM::Struct.constants.include?(:User)
+  end
+
   context 'ROM::Struct' do
     it 'generates a struct for a given relation name and columns' do
       struct = struct_compiler[*input, ROM::Struct]


### PR DESCRIPTION
This is related to https://github.com/dry-rb/dry-core/pull/26. I am still seeing an issue in some projects, which you can still reproduce using the steps in dry-rb/dry-core#25.

---

A class may already exist and just not be available (yet) because it hasn't been autoloaded. The StructCompiler class should call const_get in an attempt to load this class. If it can load the class, then it should use this class and not go to Dry::Core::ClassBuilder to build an entirely new class.

---

In my little script to reproduce this issue:

```ruby
repo = ProjectRepository.new(ROM.env)
project = repo.projects.to_a.first
puts project.class.to_s == "Projects::Project"
puts project.respond_to?(:to_model)
```

This shows up "false" and "true". I believe this is because the `Projects::Project` constant is not being autoloaded in `Dry::Core::ClassBuilder` due to the line I pointed out in dry-rb/dry-core#25. I am on Ruby 2.5, and so that line isn't called.

Reviewing my decision there, I think making `StructCompiler` attempt to find the class is a better course of action, as `ClassBuilder` would then only be used in the cases where we had to actually build a class. This is the route I've gone down with this PR.

With this patch applied, my little script shows up "true" and "true", indicating that the behaviour is correct... at least according to that script.

---

I couldn't work out a non-ghetto way of clearing the constant in the tests. Sorry.