### PR TITLE
Upgrade dry types core

### DIFF
--- a/core/lib/rom/attribute.rb
+++ b/core/lib/rom/attribute.rb
@@ -24,8 +24,8 @@ module ROM
     param :type
 
     # @api private
-    def [](input)
-      type[input]
+    def [](*args)
+      type[*args]
     end
 
     # Return true if this attribute type is a primary key

--- a/core/lib/rom/attribute.rb
+++ b/core/lib/rom/attribute.rb
@@ -370,7 +370,7 @@ module ROM
     #
     # @api private
     def to_write_type
-      type
+      type.meta(omittable: true)
     end
 
     # Return nullable attribute

--- a/core/lib/rom/attribute.rb
+++ b/core/lib/rom/attribute.rb
@@ -33,7 +33,7 @@ module ROM
     # @example
     #   class Users < ROM::Relation[:memory]
     #     schema do
-    #       attribute :id, Types::Int
+    #       attribute :id, Types::Integer
     #       attribute :name, Types::String
     #
     #       primary_key :id
@@ -58,7 +58,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :id, Types::Int
+    #       attribute :id, Types::Integer
     #       attribute :user_id, Types.ForeignKey(:users)
     #     end
     #   end
@@ -81,7 +81,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :user_id, Types::Int.meta(alias: :id)
+    #       attribute :user_id, Types::Integer.meta(alias: :id)
     #       attribute :name, Types::String
     #     end
     #   end
@@ -104,7 +104,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :id, Types::Int
+    #       attribute :id, Types::Integer
     #       attribute :user_id, Types.ForeignKey(:users)
     #     end
     #   end
@@ -127,7 +127,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :id, Types::Int
+    #       attribute :id, Types::Integer
     #       attribute :user_id, Types.ForeignKey(:users)
     #     end
     #   end
@@ -153,7 +153,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :user_id, Types::Int.meta(alias: :id)
+    #       attribute :user_id, Types::Integer.meta(alias: :id)
     #       attribute :name, Types::String
     #     end
     #   end
@@ -178,7 +178,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :user_id, Types::Int.meta(alias: :id)
+    #       attribute :user_id, Types::Integer.meta(alias: :id)
     #       attribute :name, Types::String
     #     end
     #   end
@@ -201,7 +201,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :user_id, Types::Int.meta(alias: :id)
+    #       attribute :user_id, Types::Integer.meta(alias: :id)
     #       attribute :name, Types::String
     #     end
     #   end
@@ -224,7 +224,7 @@ module ROM
     # @example
     #   class Tasks < ROM::Relation[:memory]
     #     schema do
-    #       attribute :user_id, Types::Int
+    #       attribute :user_id, Types::Integer
     #       attribute :name, Types::String
     #     end
     #   end
@@ -255,7 +255,7 @@ module ROM
     # @example
     #   class Users < ROM::Relation[:memory]
     #     schema do
-    #       attribute :id, Types::Int
+    #       attribute :id, Types::Integer
     #       attribute :name, Types::String
     #     end
     #   end

--- a/core/lib/rom/relation/curried.rb
+++ b/core/lib/rom/relation/curried.rb
@@ -35,7 +35,7 @@ module ROM
 
       # @!attribute [r] arity
       #   @return [Integer] View's arity
-      option :arity, type: Types::Strict::Int
+      option :arity, type: Types::Strict::Integer
 
       # @!attribute [r] curry_args
       #   @return [Array] Arguments that will be passed to curried view

--- a/core/lib/rom/types.rb
+++ b/core/lib/rom/types.rb
@@ -26,7 +26,7 @@ module ROM
       # @return [Dry::Types::Definition]
       #
       # @api public
-      def ForeignKey(relation, type = Types::Int)
+      def ForeignKey(relation, type = Types::Integer)
         type.meta(foreign_key: true, target: relation)
       end
     end

--- a/core/rom-core.gemspec
+++ b/core/rom-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'dry-inflector', '~> 0.1'
   gem.add_runtime_dependency 'dry-container', '~> 0.6'
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  gem.add_runtime_dependency 'dry-types', '~> 0.12.1'
+  gem.add_runtime_dependency 'dry-types', '~> 0.13.0'
   gem.add_runtime_dependency 'dry-initializer', '~> 2.0'
   gem.add_runtime_dependency 'rom-mapper', '~> 1.2', '>= 1.2.1'
 

--- a/core/spec/integration/multi_env_spec.rb
+++ b/core/spec/integration/multi_env_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Setting up ROM with multiple environments' do
       module Test
         class Users < ROM::Relation[:memory]
           schema(:users) do
-            attribute :id, ROM::Types::Int
+            attribute :id, ROM::Types::Integer
             attribute :name, ROM::Types::String
 
             associations do
@@ -83,9 +83,9 @@ RSpec.describe 'Setting up ROM with multiple environments' do
 
         class Tasks  < ROM::Relation[:memory]
           schema(:tasks) do
-            attribute :id, ROM::Types::Int
+            attribute :id, ROM::Types::Integer
             attribute :title, ROM::Types::String
-            attribute :user_id, ROM::Types::Int
+            attribute :user_id, ROM::Types::Integer
 
             associations do
               belongs_to :user

--- a/core/spec/integration/relations/default_dataset_spec.rb
+++ b/core/spec/integration/relations/default_dataset_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ROM::Relation, '.dataset' do
   it 'yields relation class for setting custom dataset proc' do
     configuration.relation(:users) do
       schema(:users) do
-        attribute :id, ROM::Memory::Types::Int.meta(primary_key: true)
+        attribute :id, ROM::Memory::Types::Integer.meta(primary_key: true)
         attribute :name, ROM::Memory::Types::String
       end
 

--- a/core/spec/integration/setup_spec.rb
+++ b/core/spec/integration/setup_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'Configuring ROM' do
   it 'allows to use a relation with a schema in multiple containers' do
     class Test::UserRelation < ROM::Relation[:memory]
       schema(:users) do
-        attribute :id, Types::Int.meta(primary_key: true)
+        attribute :id, Types::Integer.meta(primary_key: true)
       end
     end
 

--- a/core/spec/unit/rom/attribute/method_missing_spec.rb
+++ b/core/spec/unit/rom/attribute/method_missing_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ROM::Attribute, '#method_missing' do
 
   context 'with a plain definition' do
     let(:type) do
-      ROM::Types::Int
+      ROM::Types::Integer
     end
 
     it 'forwards to its type' do
@@ -22,7 +22,7 @@ RSpec.describe ROM::Attribute, '#method_missing' do
 
   context 'with a type that can return new instances of its class' do
     let(:type) do
-      ROM::Types::Int.default(1)
+      ROM::Types::Integer.default(1)
     end
 
     it 'returns a new attribute if forwarded method returned a new type' do

--- a/core/spec/unit/rom/attribute/method_missing_spec.rb
+++ b/core/spec/unit/rom/attribute/method_missing_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ROM::Attribute, '#method_missing' do
     it 'returns a new attribute if forwarded method returned a new type' do
       new_attribute = attribute.default(2)
 
-      expect(new_attribute[nil]).to be(2)
+      expect(new_attribute[]).to be(2)
     end
   end
 end

--- a/core/spec/unit/rom/attribute/optional_spec.rb
+++ b/core/spec/unit/rom/attribute/optional_spec.rb
@@ -3,7 +3,7 @@ require 'rom/attribute'
 
 RSpec.describe ROM::Attribute, '#optional' do
   subject(:attribute) do
-    ROM::Attribute.new(ROM::Types::Int).meta(read: ROM::Types::Coercible::Int)
+    ROM::Attribute.new(ROM::Types::Integer).meta(read: ROM::Types::Coercible::Integer)
   end
 
   it 'transforms read type' do

--- a/core/spec/unit/rom/attribute/to_ast_spec.rb
+++ b/core/spec/unit/rom/attribute/to_ast_spec.rb
@@ -2,12 +2,12 @@ require 'rom/types'
 require 'rom/attribute'
 
 RSpec.describe ROM::Attribute, '#to_ast' do
-  subject(:attribute) { ROM::Attribute.new(ROM::Types::Int).meta(name: :id) }
+  subject(:attribute) { ROM::Attribute.new(ROM::Types::Integer).meta(name: :id) }
 
   types = [
-    ROM::Types::Int,
-    ROM::Types::Strict::Int,
-    ROM::Types::Strict::Int.optional
+    ROM::Types::Integer,
+    ROM::Types::Strict::Integer,
+    ROM::Types::Strict::Integer.optional
   ]
 
   to_attr = -> type { ROM::Attribute.new(type).meta(name: :id) }
@@ -20,7 +20,7 @@ RSpec.describe ROM::Attribute, '#to_ast' do
 
   example 'wrapped type' do
     expect(attribute.wrapped(:users).to_ast).
-      to eql([:attribute, [:id, ROM::Types::Int.to_ast,
+      to eql([:attribute, [:id, ROM::Types::Integer.to_ast,
                            wrapped: true, alias: :users_id]])
   end
 end

--- a/core/spec/unit/rom/container_spec.rb
+++ b/core/spec/unit/rom/container_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ROM::Container do
       schema(:tasks) do
         attribute :name, ROM::Types::String
         attribute :title, ROM::Types::String
-        attribute :priority, ROM::Types::Int
+        attribute :priority, ROM::Types::Integer
       end
     end
 

--- a/core/spec/unit/rom/mapper_compiler_spec.rb
+++ b/core/spec/unit/rom/mapper_compiler_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ROM::MapperCompiler, '#call' do
   end
 
   let(:ast) do
-    ROM::Relation.new([], schema: define_schema(:users, id: :Int, name: :String)).to_ast
+    ROM::Relation.new([], schema: define_schema(:users, id: :Integer, name: :String)).to_ast
   end
 
   let(:data) do

--- a/core/spec/unit/rom/memory/commands_spec.rb
+++ b/core/spec/unit/rom/memory/commands_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ROM::Memory::Commands do
   let(:relation) do
     Class.new(ROM::Relation[:memory]) do
       schema do
-        attribute :id, ROM::Memory::Types::Int
+        attribute :id, ROM::Memory::Types::Integer
         attribute :name, ROM::Memory::Types::String
       end
     end.new(ROM::Memory::Dataset.new([]))

--- a/core/spec/unit/rom/memory/relation_spec.rb
+++ b/core/spec/unit/rom/memory/relation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ROM::Memory::Relation do
       schema do
         attribute :name, ROM::Types::String
         attribute :email, ROM::Types::String
-        attribute :age, ROM::Types::Int
+        attribute :age, ROM::Types::Integer
       end
     end.new(dataset)
   end

--- a/core/spec/unit/rom/plugin_spec.rb
+++ b/core/spec/unit/rom/plugin_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "ROM::PluginRegistry" do
     rel_name = ROM::Relation::Name[:users]
 
     users = ROM::Schema::DSL.new(rel_name) {
-      attribute :id, ROM::Types::Int
+      attribute :id, ROM::Types::Integer
       attribute :name, ROM::Types::String
 
       use :datestamps
@@ -183,7 +183,7 @@ RSpec.describe "ROM::PluginRegistry" do
     users = ROM::Schema::DSL.new(rel_name) {
       use :schema_dsl_ext
 
-      attribute :id, ROM::Types::Int
+      attribute :id, ROM::Types::Integer
     }.call
 
     expect(users[:id].meta[:plugged_in]).to be true

--- a/core/spec/unit/rom/relation/attribute_reader_spec.rb
+++ b/core/spec/unit/rom/relation/attribute_reader_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Relation, '#[]' do
   it 'defines a canonical schema for a relation' do
     class Test::Users < ROM::Relation[:memory]
       schema do
-        attribute :id, Types::Int
+        attribute :id, Types::Integer
         attribute :name, Types::String
       end
     end

--- a/core/spec/unit/rom/relation/call_spec.rb
+++ b/core/spec/unit/rom/relation/call_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ROM::Relation, '#call' do
     let(:relation_class) do
       Class.new(ROM::Relation[:memory]) do
         schema do
-          attribute :id, ROM::Types::Int
+          attribute :id, ROM::Types::Integer
           attribute :name, ROM::Types::String
         end
       end
@@ -37,7 +37,7 @@ RSpec.describe ROM::Relation, '#call' do
     let(:relation_class) do
       Class.new(ROM::Relation[:memory]) do
         schema do
-          attribute :id, ROM::Types::String, read: ROM::Types::Coercible::Int
+          attribute :id, ROM::Types::String, read: ROM::Types::Coercible::Integer
           attribute :name, ROM::Types::String
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe ROM::Relation, '#call' do
     let(:relation_class) do
       Class.new(ROM::Relation[:memory]) do
         schema(:users) do
-          attribute :id, ROM::Types::Int
+          attribute :id, ROM::Types::Integer
           attribute :name, ROM::Types::String
         end
       end

--- a/core/spec/unit/rom/relation/class_interface/view_spec.rb
+++ b/core/spec/unit/rom/relation/class_interface/view_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ROM::Relation, '.view' do
 
   it 'returns view method name' do
     klass = Class.new(ROM::Relation[:memory]) {
-      schema { attribute :id, ROM::Types::Int }
+      schema { attribute :id, ROM::Types::Integer }
     }
 
     name = klass.view(:by_id, klass.schema) { self }
@@ -76,7 +76,7 @@ RSpec.describe ROM::Relation, '.view' do
       let(:relation_class) do
         Class.new(ROM::Memory::Relation) do
           schema(:users) do
-            attribute :id, ROM::Types::Int
+            attribute :id, ROM::Types::Integer
             attribute :name, ROM::Types::String
           end
 
@@ -128,7 +128,7 @@ RSpec.describe ROM::Relation, '.view' do
     include_context 'relation with views' do
       let(:relation_class) do
         attributes_inferrer = proc {
-          [[define_attribute(:users, :Int, name: :id), define_attribute(:users, :String, name: :name)],
+          [[define_attribute(:users, :Integer, name: :id), define_attribute(:users, :String, name: :name)],
            []]
         }
 

--- a/core/spec/unit/rom/relation/foreign_key_spec.rb
+++ b/core/spec/unit/rom/relation/foreign_key_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ROM::Relation, '#foreign_key' do
   subject(:relation) do
     Class.new(ROM::Relation) do
       schema(:users) do
-        attribute :id, ROM::Types::Int
-        attribute :group_id, ROM::Types::Int.meta(foreign_key: true, target: :groups)
+        attribute :id, ROM::Types::Integer
+        attribute :group_id, ROM::Types::Integer.meta(foreign_key: true, target: :groups)
       end
     end.new([])
   end

--- a/core/spec/unit/rom/relation/map_with_spec.rb
+++ b/core/spec/unit/rom/relation/map_with_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ROM::Relation, '#map_with' do
 
   context 'without the default mapper' do
     let(:schema) do
-      define_schema(:users, id: :Int, name: :String)
+      define_schema(:users, id: :Integer, name: :String)
     end
 
     let(:mappers) do
@@ -40,7 +40,7 @@ RSpec.describe ROM::Relation, '#map_with' do
 
   context 'with the default mapper' do
     let(:schema) do
-      define_schema(:users, id: :Int, name: :String).prefix(:user)
+      define_schema(:users, id: :Integer, name: :String).prefix(:user)
     end
 
     let(:mappers) do

--- a/core/spec/unit/rom/relation/new_spec.rb
+++ b/core/spec/unit/rom/relation/new_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Relation, '#new' do
   subject(:relation) do
     Class.new(ROM::Relation) do
       schema(:users) do
-        attribute :id, ROM::Types::String, read: ROM::Types::Coercible::Int
+        attribute :id, ROM::Types::String, read: ROM::Types::Coercible::Integer
         attribute :name, ROM::Types::String
       end
     end.new([], options)

--- a/core/spec/unit/rom/relation/output_schema_spec.rb
+++ b/core/spec/unit/rom/relation/output_schema_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Relation, '#output_schema' do
   subject(:relation) do
     Class.new(ROM::Relation[:memory]) do
       schema do
-        attribute :id, ROM::Types::String, read: ROM::Types::Int
+        attribute :id, ROM::Types::String, read: ROM::Types::Integer
         attribute :name, ROM::Types::String
       end
     end.new(ROM::Memory::Dataset.new([]))

--- a/core/spec/unit/rom/relation/schema_spec.rb
+++ b/core/spec/unit/rom/relation/schema_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ROM::Relation, '.schema' do
   it 'defines a canonical schema for a relation' do
     class Test::Users < ROM::Relation[:memory]
       schema do
-        attribute :id, Types::Int.meta(primary_key: true)
+        attribute :id, Types::Integer.meta(primary_key: true)
         attribute :name, Types::String
         attribute :admin, Types::Bool
       end
@@ -18,7 +18,7 @@ RSpec.describe ROM::Relation, '.schema' do
     schema = ROM::Memory::Schema.define(
       ROM::Relation::Name.new(:test_users),
       attributes: [
-        ROM::Memory::Types::Int.meta(primary_key: true, name: :id, source: relation_name),
+        ROM::Memory::Types::Integer.meta(primary_key: true, name: :id, source: relation_name),
         ROM::Memory::Types::String.meta(name: :name, source: relation_name),
         ROM::Memory::Types::Bool.meta(name: :admin, source: relation_name)
       ]
@@ -42,7 +42,7 @@ RSpec.describe ROM::Relation, '.schema' do
 
     class Test::Users < ROM::Relation[:memory]
       schema do
-        attribute :id, Types::Int
+        attribute :id, Types::Integer
         attribute :date, Types::Coercible::String, read: Test::Types::CoercibleDate
       end
     end
@@ -186,7 +186,7 @@ RSpec.describe ROM::Relation, '.schema' do
   it 'sets register_as and dataset' do
     class Test::Users < ROM::Relation[:memory]
       schema(:users) do
-        attribute :id, Types::Int
+        attribute :id, Types::Integer
         attribute :name, Types::String
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe ROM::Relation, '.schema' do
   it 'sets dataset and respects custom register_as' do
     class Test::Users < ROM::Relation[:memory]
       schema(:users, as: :test_users) do
-        attribute :id, Types::Int
+        attribute :id, Types::Integer
         attribute :name, Types::String
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe ROM::Relation, '.schema' do
     it 'returns defined schema' do
       class Test::Users < ROM::Relation[:memory]
         schema do
-          attribute :id, Types::Int.meta(primary_key: true)
+          attribute :id, Types::Integer.meta(primary_key: true)
           attribute :name, Types::String
           attribute :admin, Types::Bool
         end
@@ -255,9 +255,9 @@ RSpec.describe ROM::Relation, '.schema' do
       expect {
         class Test::Users < ROM::Relation[:memory]
           schema do
-            attribute :id, Types::Int.meta(primary_key: true)
+            attribute :id, Types::Integer.meta(primary_key: true)
             attribute :name, Types::String
-            attribute :id, Types::Int
+            attribute :id, Types::Integer
           end
         end
 
@@ -272,7 +272,7 @@ RSpec.describe ROM::Relation, '.schema' do
 
       Test::Users = Class.new(ROM::Relation[:memory]) do
         schema do
-          attribute :id, Types::Int.meta(primary_key: true)
+          attribute :id, Types::Integer.meta(primary_key: true)
           attribute :name, to_s_on_read.optional
         end
       end
@@ -293,7 +293,7 @@ RSpec.describe ROM::Relation, '.schema' do
     it 'is idempotent' do
       class Test::Users < ROM::Relation[:memory]
         schema do
-          attribute :id, Types::Int.meta(primary_key: true)
+          attribute :id, Types::Integer.meta(primary_key: true)
           attribute :name, Types::String
           attribute :admin, Types::Bool
         end
@@ -308,7 +308,7 @@ RSpec.describe ROM::Relation, '.schema' do
     it 'resets input and output schemas' do
       class Test::Users < ROM::Relation[:memory]
         schema do
-          attribute :id, Types::Int.meta(primary_key: true), read: Types::Int
+          attribute :id, Types::Integer.meta(primary_key: true), read: Types::Integer
           attribute :name, Types::String
         end
       end

--- a/core/spec/unit/rom/relation/struct_namespace_spec.rb
+++ b/core/spec/unit/rom/relation/struct_namespace_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ROM::Relation, '#struct_namespace' do
     subject(:relation) do
       Class.new(ROM::Relation) do
         schema(:users) do
-          attribute :id, ROM::Types::Int
+          attribute :id, ROM::Types::Integer
           attribute :name, ROM::Types::String
         end
       end.new(dataset, auto_struct: true)
@@ -66,7 +66,7 @@ RSpec.describe ROM::Relation, '#struct_namespace' do
         struct_namespace Test::Entities
 
         schema(:users) do
-          attribute :id, ROM::Types::Int
+          attribute :id, ROM::Types::Integer
           attribute :name, ROM::Types::String
         end
       end.new(dataset, auto_struct: true)
@@ -80,7 +80,7 @@ RSpec.describe ROM::Relation, '#struct_namespace' do
       let(:admins) do
         Class.new(relation.class) do
           schema(:users, as: :admins) do
-            attribute :id, ROM::Types::Int
+            attribute :id, ROM::Types::Integer
             attribute :name, ROM::Types::String
           end
         end.new(dataset, auto_struct: true)

--- a/core/spec/unit/rom/relation/to_ast_spec.rb
+++ b/core/spec/unit/rom/relation/to_ast_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Relation, '#to_ast' do
   let(:user_relation) do
     Class.new(ROM::Relation[:memory]) do
       schema(:users) do
-        attribute :id, ROM::Types::Int
+        attribute :id, ROM::Types::Integer
         attribute :name, ROM::Types::String
       end
 
@@ -17,8 +17,8 @@ RSpec.describe ROM::Relation, '#to_ast' do
   let(:task_relation) do
     Class.new(ROM::Relation[:memory]) do
       schema(:tasks) do
-        attribute :id, ROM::Types::Int
-        attribute :user_id, ROM::Types::Int.meta(foreign_key: true, target: :users)
+        attribute :id, ROM::Types::Integer
+        attribute :user_id, ROM::Types::Integer.meta(foreign_key: true, target: :users)
         attribute :title, ROM::Types::String
       end
 

--- a/core/spec/unit/rom/relation_spec.rb
+++ b/core/spec/unit/rom/relation_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe ROM::Relation do
   describe '#input_schema' do
     it 'returns a schema hash type' do
       relation = Class.new(ROM::Relation[:memory]) do
-        schema { attribute :id, ROM::Types::Coercible::Int }
+        schema { attribute :id, ROM::Types::Coercible::Integer }
       end.new([])
 
       expect(relation.input_schema[id: '1']).to eql(id: 1)

--- a/core/spec/unit/rom/schema/accessing_attributes_spec.rb
+++ b/core/spec/unit/rom/schema/accessing_attributes_spec.rb
@@ -3,7 +3,7 @@ require 'rom/schema'
 RSpec.describe ROM::Schema, '#[]' do
   context 'with a schema' do
     subject(:schema) do
-      define_schema(:users, id: :Int, name: :String, email: :String)
+      define_schema(:users, id: :Integer, name: :String, email: :String)
     end
 
     it 'returns an attribute identified by its canonical name' do
@@ -11,7 +11,7 @@ RSpec.describe ROM::Schema, '#[]' do
     end
 
     it 'returns an aliased attribute identified by its canonical name' do
-      expect(schema.rename(id: :user_id)[:id]).to eql(define_type(:id, :Int, source: :users, alias: :user_id))
+      expect(schema.rename(id: :user_id)[:id]).to eql(define_type(:id, :Integer, source: :users, alias: :user_id))
     end
 
     it 'raises KeyError when attribute is not found' do
@@ -25,15 +25,15 @@ RSpec.describe ROM::Schema, '#[]' do
     end
 
     let(:left) do
-      define_schema(:users, id: :Int, name: :String)
+      define_schema(:users, id: :Integer, name: :String)
     end
 
     let(:right) do
-      define_schema(:tasks, id: :Int, title: :String)
+      define_schema(:tasks, id: :Integer, title: :String)
     end
 
     it 'returns an attribute identified by its canonical name' do
-      expect(schema[:id]).to eql(define_type(:id, :Int, source: :users))
+      expect(schema[:id]).to eql(define_type(:id, :Integer, source: :users))
     end
 
     it 'returns an attribute identified by its canonical name when its unique' do
@@ -41,7 +41,7 @@ RSpec.describe ROM::Schema, '#[]' do
     end
 
     it 'returns an attribute identified by its canonical name and its source' do
-      expect(schema[:id, :tasks]).to eql(define_type(:id, :Int, source: :tasks))
+      expect(schema[:id, :tasks]).to eql(define_type(:id, :Integer, source: :tasks))
     end
 
     it 'raises KeyError when attribute is not found' do

--- a/core/spec/unit/rom/schema/append_spec.rb
+++ b/core/spec/unit/rom/schema/append_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ROM::Schema, '#append' do
   subject(:schema) { left.append(*right) }
 
   let(:left) do
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   end
 
   let(:right) do
-    define_schema(:tasks, user_id: :Int)
+    define_schema(:tasks, user_id: :Integer)
   end
 
   it 'returns a new schema with attributes from two schemas' do

--- a/core/spec/unit/rom/schema/canonical_spec.rb
+++ b/core/spec/unit/rom/schema/canonical_spec.rb
@@ -2,7 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#canonical' do
   subject(:schema) {
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   }
 
   it 'returns self by default' do

--- a/core/spec/unit/rom/schema/exclude_spec.rb
+++ b/core/spec/unit/rom/schema/exclude_spec.rb
@@ -2,7 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#exclude' do
   subject(:schema) do
-    define_schema(:users, id: :Int, name: :String, email: :String)
+    define_schema(:users, id: :Integer, name: :String, email: :String)
   end
 
   let(:excluded) do

--- a/core/spec/unit/rom/schema/finalize_spec.rb
+++ b/core/spec/unit/rom/schema/finalize_spec.rb
@@ -3,7 +3,7 @@ require 'rom/schema'
 RSpec.describe ROM::Schema, '#finalize!' do
   context 'without inferrer' do
     subject(:schema) do
-      define_schema(:users, id: :Int, name: :String)
+      define_schema(:users, id: :Integer, name: :String)
     end
 
     before { schema.finalize_attributes!.finalize! }
@@ -35,7 +35,7 @@ RSpec.describe ROM::Schema, '#finalize!' do
 
     context 'when all required attributes are present' do
       let(:attributes) do
-        [define_type(:id, :Int), define_type(:age, :Int)]
+        [define_type(:id, :Integer), define_type(:age, :Integer)]
       end
 
       it 'concats defined attributes with inferred attributes' do
@@ -45,8 +45,8 @@ RSpec.describe ROM::Schema, '#finalize!' do
 
     context 'when inferred attributes are overridden' do
       let(:attributes) do
-        [define_type(:id, :Int),
-         define_type(:age, :Int),
+        [define_type(:id, :Integer),
+         define_type(:age, :Integer),
          define_type(:name, :String).meta(custom: true)]
       end
 

--- a/core/spec/unit/rom/schema/merge_spec.rb
+++ b/core/spec/unit/rom/schema/merge_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ROM::Schema, '#merge' do
   subject(:schema) { left.merge(right) }
 
   let(:left) do
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   end
 
   let(:right) do
-    define_schema(:tasks, user_id: :Int)
+    define_schema(:tasks, user_id: :Integer)
   end
 
   it 'returns a new schema with attributes from two schemas' do

--- a/core/spec/unit/rom/schema/prefix_spec.rb
+++ b/core/spec/unit/rom/schema/prefix_spec.rb
@@ -2,7 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#prefix' do
   subject(:schema) do
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   end
 
   let(:prefixed) do

--- a/core/spec/unit/rom/schema/project_spec.rb
+++ b/core/spec/unit/rom/schema/project_spec.rb
@@ -2,7 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#project' do
   subject(:schema) do
-    define_schema(:users, id: :Int, name: :String, age: :Int)
+    define_schema(:users, id: :Integer, name: :String, age: :Integer)
   end
 
   it 'projects provided attribute names' do

--- a/core/spec/unit/rom/schema/rename_spec.rb
+++ b/core/spec/unit/rom/schema/rename_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Schema, '#rename' do
   subject(:schema) do
     define_schema(
       :users,
-      user_id: :Int, user_name: :String, user_email: :String
+      user_id: :Integer, user_name: :String, user_email: :String
     )
   end
 

--- a/core/spec/unit/rom/schema/type_spec.rb
+++ b/core/spec/unit/rom/schema/type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ROM::Attribute do
   describe '#inspect' do
     context 'with a primitive definition' do
       subject(:type) do
-        ROM::Attribute.new(ROM::Types::Int).meta(name: :id, primary_key: true)
+        ROM::Attribute.new(ROM::Types::Integer).meta(name: :id, primary_key: true)
       end
 
       specify do
@@ -35,7 +35,7 @@ RSpec.describe ROM::Attribute do
 
   describe '#method_missing' do
     subject(:type) do
-      ROM::Attribute.new(ROM::Types::Int).meta(name: :id, primary_key: true)
+      ROM::Attribute.new(ROM::Types::Integer).meta(name: :id, primary_key: true)
     end
 
     specify do

--- a/core/spec/unit/rom/schema/uniq_spec.rb
+++ b/core/spec/unit/rom/schema/uniq_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ROM::Schema, '#uniq' do
   subject(:schema) { left.merge(right) }
 
   let(:left) do
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   end
 
   let(:right) do
-    define_schema(:tasks, id: :Int, user_id: :Int)
+    define_schema(:tasks, id: :Integer, user_id: :Integer)
   end
 
   it 'returns a new schema with unique attributes from two schemas' do

--- a/core/spec/unit/rom/schema/wrap_spec.rb
+++ b/core/spec/unit/rom/schema/wrap_spec.rb
@@ -2,7 +2,7 @@ require 'rom/schema'
 
 RSpec.describe ROM::Schema, '#wrap' do
   subject(:schema) do
-    define_schema(:users, id: :Int, name: :String)
+    define_schema(:users, id: :Integer, name: :String)
   end
 
   let(:wrapped) do

--- a/core/spec/unit/rom/schema_spec.rb
+++ b/core/spec/unit/rom/schema_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ROM::Schema do
   describe '#to_h' do
     it 'returns hash with attributes' do
-      attrs = { id: ROM::Types::Int.meta(name: :id), name: ROM::Types::String.meta(name: :name) }
+      attrs = { id: ROM::Types::Integer.meta(name: :id), name: ROM::Types::String.meta(name: :name) }
       schema = ROM::Schema.define(:name, attributes: attrs.values)
 
       expect(schema.to_h).to eql(attrs)
@@ -10,7 +10,7 @@ RSpec.describe ROM::Schema do
 
   describe '#to_ast' do
     specify do
-      attrs = { id: ROM::Types::Int.meta(name: :id), name: ROM::Types::String.meta(name: :name) }
+      attrs = { id: ROM::Types::Integer.meta(name: :id), name: ROM::Types::String.meta(name: :name) }
       schema = ROM::Schema.define(:name, attributes: attrs.values)
 
       expect(schema.to_ast).
@@ -25,8 +25,8 @@ RSpec.describe ROM::Schema do
     subject(:schema) { ROM::Schema.define(:name, attributes: attrs.values).finalize_attributes! }
 
     let(:attrs) do
-      { user_id: ROM::Types::Int.meta(name: :user_id, primary_key: true),
-        group_id: ROM::Types::Int.meta(name: :group_id, primary_key: true),
+      { user_id: ROM::Types::Integer.meta(name: :user_id, primary_key: true),
+        group_id: ROM::Types::Integer.meta(name: :group_id, primary_key: true),
         name: ROM::Types::String.meta(name: :name) }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ROM::Schema do
     subject(:schema) { ROM::Schema.define(:name, attributes: attrs.values).finalize_attributes! }
 
     let(:attrs) do
-      { id: ROM::Types::Int.meta(name: :id, primary_key: true), name: ROM::Types::String.meta(name: :name) }
+      { id: ROM::Types::Integer.meta(name: :id, primary_key: true), name: ROM::Types::String.meta(name: :name) }
     end
 
     it 'returns the name of the primary key attribute' do

--- a/mapper/rom-mapper.gemspec
+++ b/mapper/rom-mapper.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   gem.add_runtime_dependency 'dry-core', '~> 0.3', '>= 0.3.1'
-  gem.add_runtime_dependency 'dry-types', '~> 0.12.1'
+  gem.add_runtime_dependency 'dry-types', '~> 0.13.0'
   gem.add_runtime_dependency 'dry-struct', '~> 0.4.0'
   gem.add_runtime_dependency 'transproc', '~> 1.0'
 

--- a/mapper/rom-mapper.gemspec
+++ b/mapper/rom-mapper.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   gem.add_runtime_dependency 'dry-core', '~> 0.3', '>= 0.3.1'
   gem.add_runtime_dependency 'dry-types', '~> 0.13.0'
-  gem.add_runtime_dependency 'dry-struct', '~> 0.4.0'
+  gem.add_runtime_dependency 'dry-struct', '~> 0.5.0'
   gem.add_runtime_dependency 'transproc', '~> 1.0'
 
   gem.add_development_dependency 'rake', '~> 11.3'

--- a/mapper/spec/unit/rom/struct_compiler_spec.rb
+++ b/mapper/spec/unit/rom/struct_compiler_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ROM::StructCompiler, '#call' do
   end
 
   let(:input) do
-    [:users, [[:attribute, attr_ast(:id, :Int)], [:attribute, attr_ast(:name, :String)]]]
+    [:users, [[:attribute, attr_ast(:id, :Integer)], [:attribute, attr_ast(:name, :String)]]]
   end
 
   context 'ROM::Struct' do
@@ -35,7 +35,7 @@ RSpec.describe ROM::StructCompiler, '#call' do
 
     context 'with reserved keywords as attribute names' do
       let(:input) do
-        [:users, [[:attribute, attr_ast(:id, :Int)],
+        [:users, [[:attribute, attr_ast(:id, :Integer)],
                     [:attribute, attr_ast(:name, :String)],
                     [:attribute, attr_ast(:alias, :String)],
                     [:attribute, attr_ast(:until, :Time)]]]
@@ -62,7 +62,7 @@ RSpec.describe ROM::StructCompiler, '#call' do
 
   context 'with constrained types' do
     let(:input) do
-      [:posts, [[:attribute, [:id, ROM::Types::Strict::Int.to_ast, alias: false, wrapped: false]],
+      [:posts, [[:attribute, [:id, ROM::Types::Strict::Integer.to_ast, alias: false, wrapped: false]],
                 [:attribute, [:status, ROM::Types::Strict::String.enum(%(Foo Bar)).to_ast, alias: false, wrapped: false]]]]
     end
 

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Setting up rom suite' do
   before do
     class Test::Users < ROM::Relation[:memory]
       schema(:users) do
-        attribute :id, Types::Int
+        attribute :id, Types::Integer
         attribute :name, Types::String
       end
     end


### PR DESCRIPTION
This updates the gem to the new `dry-types` types.

As mentioned in #494 this can't be released as `4.x`, but, however, maybe someone finds this interesting.