### PR TITLE
Cleanup tests: remove unused statement

### DIFF
--- a/changeset/spec/integration/changeset_spec.rb
+++ b/changeset/spec/integration/changeset_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe 'Using changesets' do
   end
 
   describe 'Create' do
-    let(:create_changeset) do
-      Class.new(ROM::Changeset::Create)
-    end
-
     it 'sets empty data only for stateful changesets' do
       create = users.changeset(:create)
       expect(create).to be_empty


### PR DESCRIPTION
I was reading tests and payed attention to unused `let` statement. Git history hints that it should be removed.