### PR TITLE
Support passing container to Repository as either param or option

### DIFF
--- a/repository/lib/rom/repository.rb
+++ b/repository/lib/rom/repository.rb
@@ -86,7 +86,7 @@ module ROM
 
     # @!attribute [r] container
     #   @return [ROM::Container] The container used to set up a repo
-    param :container, allow: ROM::Container
+    option :container, allow: ROM::Container
 
     # @!attribute [r] struct_namespace
     #   @return [Module,Class] The namespace for auto-generated structs
@@ -100,13 +100,10 @@ module ROM
     #   @return [RelationRegistry] The relation proxy registry used by a repo
     attr_reader :relations
 
-    # Initializes a new repo by establishing configured relation proxies from
-    # the passed container
-    #
-    # @param container [ROM::Container] The rom container with relations and optional commands
+    # Initializes a new repository object
     #
     # @api private
-    def initialize(container, options = EMPTY_HASH)
+    def initialize(*)
       super
       @relations = {}
     end

--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -28,22 +28,36 @@ module ROM
         end
       end
 
-      # Initialize a new repository object
+      # Initialize a new repository object, establishing configured relation proxies from
+      # the passed container
       #
-      # @param [ROM::Container] container Finalized rom container
+      # @overload new(container, **options)
+      #   Initialize with container as leading parameter
       #
-      # @param [Hash] options Repository options
-      # @option options [Module] :struct_namespace Custom struct namespace
-      # @option options [Boolean] :auto_struct Enable/Disable auto-struct mapping
+      #   @param [ROM::Container] container Finalized rom container
+      #
+      #   @param [Hash] options Repository options
+      #   @option options [Module] :struct_namespace Custom struct namespace
+      #   @option options [Boolean] :auto_struct Enable/Disable auto-struct mapping
+      #
+      # @overload new(**options)
+      #   Inititalize with container as option
+      #
+      #   @param [Hash] options Repository options
+      #   @option options [ROM::Container] :container Finalized rom container
+      #   @option options [Module] :struct_namespace Custom struct namespace
+      #   @option options [Boolean] :auto_struct Enable/Disable auto-struct mapping
       #
       # @api public
-      def new(container, options = EMPTY_HASH)
+      def new(container = nil, **options)
+        container ||= options.fetch(:container)
+
         unless relation_reader
           relation_reader(RelationReader.new(self, container.relations.elements.keys))
           include(relation_reader)
         end
 
-        super
+        super(options.merge(container: container))
       end
 
       # Inherits configured relations and commands

--- a/repository/lib/rom/repository/root.rb
+++ b/repository/lib/rom/repository/root.rb
@@ -56,7 +56,7 @@ module ROM
       end
 
       # @see Repository#initialize
-      def initialize(container, options = EMPTY_HASH)
+      def initialize(*)
         super
         @root = set_relation(self.class.root)
       end

--- a/repository/spec/integration/dependency_injection_spec.rb
+++ b/repository/spec/integration/dependency_injection_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe 'Repository with additional dependencies injected' do
+  let(:configuration) {
+    ROM::Configuration.new(default: [:sql, DB_URI], memory: [:memory])
+  }
+
+  let(:rom) { ROM.container(configuration) }
+
+  describe 'keyword constructor params' do
+    describe 'direct injection in single subclass' do
+      let(:repo_class) {
+        Class.new(ROM::Repository) do
+          attr_reader :my_dep
+
+          def initialize(my_dep:, **args)
+            @my_dep = my_dep
+            super(**args)
+          end
+        end
+      }
+
+      it 'supports additional dependencies' do
+        my_dep = Object.new
+        repo = repo_class.new(container: rom, my_dep: my_dep)
+
+        expect(repo.container).to eql rom
+        expect(repo.my_dep).to eql my_dep
+      end
+    end
+
+    describe 'injections across deeper class hierarchy' do
+      before do
+        Test.const_set(:ROM, rom)
+      end
+
+      let(:base_repo_class) {
+        Class.new(ROM::Repository) do
+          def self.new(**args)
+            super(container: Test::ROM, **args)
+          end
+        end
+      }
+
+      let(:repo_class) {
+        Class.new(base_repo_class) do
+          attr_reader :my_dep
+
+          def initialize(my_dep:, **args)
+            @my_dep = my_dep
+            super(**args)
+          end
+        end
+      }
+
+      it 'supports additional dependencies provided from various classes in the hierarchy' do
+        my_dep = Object.new
+        repo = repo_class.new(my_dep: my_dep)
+
+        expect(repo.container).to eql rom
+        expect(repo.my_dep).to eql my_dep
+      end
+    end
+  end
+
+  describe 'positional constructor param for container' do
+    describe 'direct injection in single subclass' do
+      let(:repo_class) {
+        Class.new(ROM::Repository) do
+          attr_reader :my_dep
+
+          def initialize(*args, my_dep:, **kwargs)
+            @my_dep = my_dep
+            super(*args, **kwargs)
+          end
+        end
+      }
+
+      it 'supports additional dependencies' do
+        my_dep = Object.new
+        repo = repo_class.new(rom, my_dep: my_dep)
+
+        expect(repo.container).to eql rom
+        expect(repo.my_dep).to eql my_dep
+      end
+    end
+  end
+end


### PR DESCRIPTION
Being able to pass `container` as an option means Repository can work with an all-options constructor signature, which makes it easier to inject additional app-specific dependencies to subclasses using tools like dry-auto_inject (with its standard kwargs strategy).

This change is backwards compatible because the standard param continues to be respected.

So now you can initialize a repo in both these ways:

```ruby
UserRepo.new(rom)
UserRepo.new(container: rom)
```

And here's an example of how it'd with with dry-auto_inject:

```ruby
module MyApp
  class Repo < ROM::Repository
    include Import[container: "persistence.rom"]
  end

  class UserRepo < Repo
    include Import["another_dep"]
    
    # container is injected via superclass
    # can also work with `another_dep` inside instance methods here
  end
end
```

@solnic @flash-gordon How's this look to you?