### PR TITLE
Better Warning module detection in spec_helper.rb

### DIFF
--- a/changeset/spec/spec_helper.rb
+++ b/changeset/spec/spec_helper.rb
@@ -44,7 +44,7 @@ module Test
   end
 end
 
-warning_api_available = RUBY_VERSION >= '2.4.0'
+warning_api_available = defined?(Warning)
 
 module SileneceWarnings
   def warn(str)

--- a/repository/spec/spec_helper.rb
+++ b/repository/spec/spec_helper.rb
@@ -36,7 +36,7 @@ module Test
   end
 end
 
-warning_api_available = RUBY_VERSION >= '2.4.0'
+warning_api_available = defined?(Warning)
 
 module SileneceWarnings
   def warn(str)


### PR DESCRIPTION
This is based on the following issue in Truffleruby https://github.com/oracle/truffleruby/issues/1470 and suggested by @eregon.

It's better to check availability of `Warning` module if given Ruby interpret has it rather than checking only Ruby version.

The latest Truffleruby 1.0.0-rc9 claims to be compatible with Ruby 2.4. Unfortunately, it doesn't contain `Warning` module yet.