### PR TITLE
Add docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ruby:latest
+
+# Install needed dependencies
+RUN apt-get update -qq && apt-get install -y libsqlite3-dev
+
+# Some files & directories variables
+ENV rom /opt/rom/
+ENV core core/
+ENV changeset changeset/
+ENV repository repository/
+ENV rom_version lib/rom/version.rb
+ENV core_version lib/rom/version.rb
+ENV changeset_version lib/rom/changeset/version.rb
+ENV repository_version lib/rom/repository/version.rb
+
+# Create non-root user
+RUN useradd -m user && \
+
+# Create rom directory
+mkdir $rom && \
+
+# Set user as owner of rom directory
+chown user:user $rom
+
+# Work as non-root in rom directory
+USER user
+WORKDIR $rom
+
+# Cache bundle install
+COPY --chown=user:user rom.gemspec Gemfile Gemfile.lock $rom
+COPY --chown=user:user ${core}rom-core.gemspec ${core}Gemfile ${rom}${core}
+COPY --chown=user:user ${changeset}rom-changeset.gemspec ${changeset}Gemfile ${rom}${changeset}
+COPY --chown=user:user ${repository}rom-repository.gemspec ${repository}Gemfile ${rom}${repository}
+COPY --chown=user:user ${rom_version} ${rom}${rom_version}
+COPY --chown=user:user ${core}${core_version} ${rom}${core}${core_version}
+COPY --chown=user:user ${changeset}${changeset_version} ${rom}${changeset}${changeset_version}
+COPY --chown=user:user ${repository}${repository_version} ${rom}${repository}${repository_version}
+RUN bundle install
+
+# Add the code
+COPY --chown=user:user . $rom

--- a/changeset/spec/spec_helper.rb
+++ b/changeset/spec/spec_helper.rb
@@ -56,10 +56,12 @@ module SileneceWarnings
   end
 end
 
+base_db_uri = ENV.fetch("BASE_DB_URI", "localhost/rom_repository")
+
 DB_URI = if defined? JRUBY_VERSION
-           'jdbc:postgresql://localhost/rom_repository'
+           "jdbc:postgresql://#{base_db_uri}"
          else
-           'postgres://localhost/rom_repository'
+           "postgres://#{base_db_uri}"
          end
 
 Warning.extend(SileneceWarnings) if warning_api_available

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  db:
+    image: postgres:latest
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_DB: rom_repository
+  app:
+    build: .
+    command: tail -f Gemfile
+    environment:
+      BASE_DB_URI: postgres@db/rom_repository
+    volumes:
+      - .:/opt/rom
+    links:
+      - db

--- a/repository/spec/spec_helper.rb
+++ b/repository/spec/spec_helper.rb
@@ -48,10 +48,12 @@ module SileneceWarnings
   end
 end
 
+base_db_uri = ENV.fetch("BASE_DB_URI", "localhost/rom_repository")
+
 DB_URI = if defined? JRUBY_VERSION
-           'jdbc:postgresql://localhost/rom_repository'
+           "jdbc:postgresql://#{base_db_uri}"
          else
-           'postgres://localhost/rom_repository'
+           "postgres://#{base_db_uri}"
          end
 
 Warning.extend(SileneceWarnings) if warning_api_available


### PR DESCRIPTION
I created this PR while preparing my environment to contribute in another PR.

This sets up a docker environment ready to start contributing to rom. I think that for a library like this one, which has system dependencies (sqlite dev tools), uses external services (postgres) and expects a given configuration (database url) it can be quite helpful. With it, you can just clone rom repo and do:

1. `docker-compose up -d`
2. `docker-compose exec app bundle exec rake spec`

I had to modify spec helper files in order to allow them to take database uri from the docker defined environment, but local development should behave as before.

If you find it useful and you want maybe I could add another commit modifying the README or CONTRIBUTING files?