### PR TITLE
Command plugin to accept input with aliased keys

### DIFF
--- a/core/lib/rom/core.rb
+++ b/core/lib/rom/core.rb
@@ -33,6 +33,7 @@ require 'rom/plugins/relation/registry_reader'
 require 'rom/plugins/relation/instrumentation'
 require 'rom/plugins/command/schema'
 require 'rom/plugins/command/timestamps'
+require 'rom/plugins/command/alias'
 require 'rom/plugins/schema/timestamps'
 
 module ROM
@@ -45,5 +46,6 @@ module ROM
     register :instrumentation, ROM::Plugins::Relation::Instrumentation, type: :relation
     register :schema, ROM::Plugins::Command::Schema, type: :command
     register :timestamps, ROM::Plugins::Command::Timestamps, type: :command
+    register :alias, ROM::Plugins::Command::Alias, type: :command
   end
 end

--- a/core/lib/rom/plugins/command/alias.rb
+++ b/core/lib/rom/plugins/command/alias.rb
@@ -1,0 +1,51 @@
+require 'set'
+
+module ROM
+  module Plugins
+    module Command
+      # A plugin for transparently translating schema defined aliases
+      # into canonical names expected by adapters.
+      #
+      # @example
+      #   class User < ROM::Relations[:sql]
+      #     schema(infer: true) do
+      #       attribute :first_name, Types::String.meta(alias: name)
+      #     end
+      #   end
+      #
+      #   class CreateUser < ROM::Commands::Create[:sql]
+      #     result :one
+      #     use :alias
+      #   end
+      #
+      #   result = rom.command(:user).create.call(name: 'Jane')
+      #   result[:first_name]  #=> 'Jane'
+      #
+      # @api public
+      module Alias
+        module T
+          extend Transproc::Registry
+
+          import :rename_keys, from: Transproc::HashTransformations
+        end
+
+        # @api private
+        def self.included(klass)
+          super
+          klass.before :map_aliases
+          klass.include(InstanceMethods)
+        end
+
+        module InstanceMethods
+          # @api private
+          def map_aliases(tuples, *)
+            mapping = relation.class.schema.alias_mapping.invert
+            map_input_tuples(tuples) do |t|
+              T[:rename_keys].(t, mapping)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/lib/rom/plugins/command/alias.rb
+++ b/core/lib/rom/plugins/command/alias.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ROM
   module Plugins
     module Command

--- a/core/lib/rom/plugins/command/alias.rb
+++ b/core/lib/rom/plugins/command/alias.rb
@@ -9,7 +9,7 @@ module ROM
       # @example
       #   class User < ROM::Relations[:sql]
       #     schema(infer: true) do
-      #       attribute :first_name, Types::String.meta(alias: name)
+      #       attribute :first_name, alias: name
       #     end
       #   end
       #

--- a/core/lib/rom/plugins/command/alias.rb
+++ b/core/lib/rom/plugins/command/alias.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module ROM
   module Plugins
     module Command

--- a/core/lib/rom/schema.rb
+++ b/core/lib/rom/schema.rb
@@ -450,6 +450,17 @@ module ROM
       [:schema, [name, attributes.map(&:to_ast)]]
     end
 
+    # Hash from canonical name to alias for aliased attributes
+    #
+    # @return [Hash<Symbol, Symbol>]
+    #
+    # @api public
+    def alias_mapping
+      each_with_object({}) do |attr, obj|
+        obj[attr.name] = attr.alias if attr.aliased?
+      end
+    end
+
     # @api private
     def set!(key, value)
       instance_variable_set("@#{ key }", value)

--- a/core/spec/unit/rom/plugins/command/alias_spec.rb
+++ b/core/spec/unit/rom/plugins/command/alias_spec.rb
@@ -1,0 +1,36 @@
+require 'rom/command'
+require 'rom/plugins/command/alias'
+
+RSpec.describe ROM::Plugins::Command::Alias do
+  include_context 'container'
+
+  let(:users) { container.commands.users }
+  let(:command) { users.create }
+
+  before do
+    configuration.relation :users do
+      schema(:users) do
+        attribute :first_name, Types::String.meta(alias: :name)
+      end
+    end
+
+    configuration.commands(:users) do
+      define :create, type: :create do
+        result :one
+        use :alias
+      end
+    end
+  end
+
+  it 'accepts input with aliased names' do
+    result = command.call(name: 'Joe')
+
+    expect(result[:first_name]).to eq('Joe')
+  end
+
+  it 'accepts input with canonical names' do
+    result = command.call(first_name: 'Joe')
+
+    expect(result[:first_name]).to eq('Joe')
+  end
+end

--- a/core/spec/unit/rom/plugins/command/alias_spec.rb
+++ b/core/spec/unit/rom/plugins/command/alias_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ROM::Plugins::Command::Alias do
   before do
     configuration.relation :users do
       schema(:users) do
-        attribute :first_name, Types::String.meta(alias: :name)
+        attribute :first_name, Types::String, alias: :name
       end
     end
 

--- a/core/spec/unit/rom/schema_spec.rb
+++ b/core/spec/unit/rom/schema_spec.rb
@@ -67,4 +67,13 @@ RSpec.describe ROM::Schema do
       expect(schema.project(:name).primary_key_name).to be(:id)
     end
   end
+
+  describe '#alias_mapping' do
+    it 'returns a hash from canonical name to alias including aliased attributes' do
+      attrs = { id: ROM::Types::Integer.meta(name: :id, alias: :pk), name: ROM::Types::String }
+      schema = ROM::Schema.define(:name, attributes: attrs.values)
+
+      expect(schema.alias_mapping).to eq(id: :pk)
+    end
+  end
 end

--- a/core/spec/unit/rom/schema_spec.rb
+++ b/core/spec/unit/rom/schema_spec.rb
@@ -70,8 +70,11 @@ RSpec.describe ROM::Schema do
 
   describe '#alias_mapping' do
     it 'returns a hash from canonical name to alias including aliased attributes' do
-      attrs = { id: ROM::Types::Integer.meta(name: :id, alias: :pk), name: ROM::Types::String }
-      schema = ROM::Schema.define(:name, attributes: attrs.values)
+      attrs = [
+        define_attr_info(:Integer, name: :id, alias: :pk),
+        define_attr_info(:String, name: :name)
+      ]
+      schema = ROM::Schema.define(:name, attributes: attrs)
 
       expect(schema.alias_mapping).to eq(id: :pk)
     end


### PR DESCRIPTION
This PR adds an `:alias` command plugin that allows to use the alias for aliased attributes as input keys:

```ruby
class User < ROM::Relations[:sql]
  schema(infer: true) do
    attribute :first_name, Types::String.meta(alias: name)
  end
end

class CreateUser < ROM::Commands::Create[:sql]
  result :one
  use :alias
end

result = rom.command(:user).create.call(name: 'Jane')
result[:first_name]  #=> 'Jane'
```

In my view, this can fix the current asymmetry between reading/writing data to/from the datastore. Now, when you configure an alias for an attribute, reading methods (like `#first` or `#to_a`), automatically perform the configured translation and return keys with the aliased names. However, when the user comes back to the engine with a command, that automation is lost and the "unwrapping" translation has to be handled manually. I see it as an abstraction leak, where the application level suddenly must be aware of canonical names (besides schema configuration, of course).

The good news are that it should be 100% backwards compatible, because commands using `:alias` plugin would still accept the canonical names as keys. So what do you think about activating this plugin by default? We could just check whether the schema has any alias at all and, if not, do not enter the tuple iteration for better performance.

In my limited knowledge of rom behaviour, I'm not sure if it is needed to test the plugin for different command scenarios. If so, please tell me.

Tests and documentation must be updated if #512 is merged.

Thanks.

## Resources

- [Original discussion](https://discourse.rom-rb.org/t/aliased-attributes-in-commands/295)