### PR TITLE
[core] fix forwarding to root in Relation::Combined

### DIFF
--- a/core/lib/rom/relation/combined.rb
+++ b/core/lib/rom/relation/combined.rb
@@ -14,15 +14,25 @@ module ROM
 
       # Create a new relation combined with others
       #
-      # @param [Relation] root
+      # @param [Relation] relation
       # @param [Array<Relation>] nodes
       #
       # @return [Combined]
       #
       # @api public
-      def self.new(root, nodes)
-        root_ns = root.options[:struct_namespace]
-        super(root, nodes.map { |node| node.struct_namespace(root_ns) })
+      def self.new(relation, nodes)
+        struct_ns = relation.options[:struct_namespace]
+        new_nodes = nodes.map { |node| node.struct_namespace(struct_ns) }
+
+        root =
+          if relation.is_a?(self)
+            new_nodes.concat(relation.nodes)
+            relation.root
+          else
+            relation
+          end
+
+        super(root, new_nodes)
       end
 
       # Combine this graph with more nodes
@@ -142,7 +152,7 @@ module ROM
 
       # @api private
       def decorate?(other)
-        super || other.is_a?(Wrap)
+        super || other.is_a?(self.class) || other.is_a?(Wrap)
       end
     end
   end

--- a/core/spec/unit/rom/relation/combined/method_missing_spec.rb
+++ b/core/spec/unit/rom/relation/combined/method_missing_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe ROM::Relation::Combined, '#method_missing' do
+  subject(:relation) do
+    ROM::Relation::Combined.new(users, [tasks])
+  end
+
+  let(:users) do
+    Class.new(ROM::Relation) do
+      def add_node(node)
+        ROM::Relation::Combined.new(self, [node])
+      end
+    end.new([])
+  end
+
+  let(:tasks) do
+    Class.new(ROM::Relation).new([], name: ROM::Relation::Name[:tasks])
+  end
+
+  let(:posts) do
+    Class.new(ROM::Relation).new([], name: ROM::Relation::Name[:posts])
+  end
+
+  describe 'forwards to the root' do
+    context 'when return value is another combined relation' do
+      it 'merges nodes' do
+        result = relation.add_node(posts)
+
+        expect(result).to be_instance_of(ROM::Relation::Combined)
+        expect(result.root).to be(users)
+        expect(result.nodes).to eql([tasks, posts])
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the response from a forwarded method call returns another combined
relation, we need to merged nodes and return a new combined relation.
Otherwise we were loosing previously combined nodes.

Fixes #525