### PR TITLE
Add support for repository plugins

### DIFF
--- a/repository/lib/rom/repository.rb
+++ b/repository/lib/rom/repository.rb
@@ -9,6 +9,8 @@ require 'rom/container'
 require 'rom/repository/class_interface'
 require 'rom/repository/session'
 
+ROM::Plugins.register(:repository, adapter: false)
+
 module ROM
   # Abstract repository class to inherit from
   #

--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -116,6 +116,11 @@ module ROM
         end
       end
 
+      # @api public
+      def use(plugin, options = EMPTY_HASH)
+        ROM.plugin_registry[:repository].fetch(plugin).apply_to(self, options)
+      end
+
       private
 
       # @api private

--- a/repository/spec/integration/plugin_spec.rb
+++ b/repository/spec/integration/plugin_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe 'repository plugin' do
+  include_context 'database'
+  include_context 'relations'
+  include_context 'seeds'
+  include_context 'repo'
+
+  let(:nullify_plugin) do
+    Module.new do
+      def self.apply(target, _options)
+        target.prepend(self)
+      end
+
+      def set_relation(*)
+        super.where { `1 = 0` }
+      end
+    end
+  end
+
+  before do
+    plugin = nullify_plugin
+
+    ROM.plugins do
+      register :nullify_datasets, plugin, type: :repository
+    end
+  end
+
+  let(:user_repo) do
+    Class.new(repo_class) { use :nullify_datasets }.new(rom)
+  end
+
+  it 'always returns empty result set' do
+    expect(user_repo.all_users.to_a).to eql([])
+  end
+end


### PR DESCRIPTION
Depends on #545 

Example usage:

```ruby
module NullifyPlugin
  def self.apply(target, _options)
    target.prepend(self)
  end

  def set_relation(*)
    super.where { `1 = 0` }
  end
end

ROM.plugins do
  register :nullify_datasets, NullifyPlugin, type: :repository
end

class UserRepo < ROM::Repository[:users]
  use :nullify_datasets
end
```