### PR TITLE
Add links to the RubyGems.org gem pages

### DIFF
--- a/changeset/rom-changeset.gemspec
+++ b/changeset/rom-changeset.gemspec
@@ -11,6 +11,12 @@ Gem::Specification.new do |gem|
   gem.version       = ROM::Changeset::VERSION.dup
   gem.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "lib/**/*"]
   gem.license       = 'MIT'
+  gem.metadata      = {
+    'source_code_uri'   => 'https://github.com/rom-rb/rom/tree/master/changeset',
+    'documentation_uri' => 'https://api.rom-rb.org/rom/',
+    'mailing_list_uri'  => 'https://discourse.rom-rb.org/',
+    'bug_tracker_uri'   => 'https://github.com/rom-rb/rom/issues',
+  }
 
   gem.add_runtime_dependency 'dry-core', '~> 0.3', '>= 0.3.1'
   gem.add_runtime_dependency 'rom-core', '~> 5.0'

--- a/core/rom-core.gemspec
+++ b/core/rom-core.gemspec
@@ -11,6 +11,12 @@ Gem::Specification.new do |gem|
   gem.version       = ROM::Core::VERSION.dup
   gem.files         = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'lib/**/*']
   gem.license       = 'MIT'
+  gem.metadata      = {
+    'source_code_uri'   => 'https://github.com/rom-rb/rom/tree/master/core',
+    'documentation_uri' => 'https://api.rom-rb.org/rom/',
+    'mailing_list_uri'  => 'https://discourse.rom-rb.org/',
+    'bug_tracker_uri'   => 'https://github.com/rom-rb/rom/issues',
+  }
 
   gem.required_ruby_version = ">= 2.4.0"
 

--- a/repository/rom-repository.gemspec
+++ b/repository/rom-repository.gemspec
@@ -11,6 +11,12 @@ Gem::Specification.new do |gem|
   gem.version       = ROM::Repository::VERSION.dup
   gem.files         = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'lib/**/*']
   gem.license       = 'MIT'
+  gem.metadata      = {
+    'source_code_uri'   => 'https://github.com/rom-rb/rom/tree/master/repository',
+    'documentation_uri' => 'https://api.rom-rb.org/rom/',
+    'mailing_list_uri'  => 'https://discourse.rom-rb.org/',
+    'bug_tracker_uri'   => 'https://github.com/rom-rb/rom/issues',
+  }
 
   gem.add_runtime_dependency 'dry-initializer', '~> 3.0', '>= 3.0.1'
   gem.add_runtime_dependency 'dry-core', '~> 0.4'

--- a/rom.gemspec
+++ b/rom.gemspec
@@ -10,6 +10,12 @@ Gem::Specification.new do |gem|
   gem.version     = ROM::VERSION.dup
   gem.files       = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'lib/**/*']
   gem.license     = 'MIT'
+  gem.metadata    = {
+    'source_code_uri'   => 'https://github.com/rom-rb/rom',
+    'documentation_uri' => 'https://api.rom-rb.org/rom/',
+    'mailing_list_uri'  => 'https://discourse.rom-rb.org/',
+    'bug_tracker_uri'   => 'https://github.com/rom-rb/rom/issues',
+  }
 
   gem.add_runtime_dependency 'rom-core', '~> 5.0', '>= 5.0.2'
   gem.add_runtime_dependency 'rom-repository', '~> 5.0'


### PR DESCRIPTION
RubyGems.org website doesn't support editing gem links manually anymore,
but these links can be added to gemspec metadata, and RubyGems.org will
automatically pick them up.