### PR TITLE
[core] improve transformer

### DIFF
--- a/core/lib/rom/transformer.rb
+++ b/core/lib/rom/transformer.rb
@@ -15,6 +15,31 @@ module ROM
 
     defines :relation, :register_as
 
+    # Configure relation for the transformer
+    #
+    # @example with a custom name
+    #   class UsersMapper < ROM::Transformer
+    #     relation :users, as: :json_serializer
+    #
+    #     map do
+    #       rename_keys user_id: :id
+    #       deep_stringify_keys
+    #     end
+    #   end
+    #
+    #   users.map_with(:json_serializer)
+    #
+    # @param name [Symbol]
+    # @param options [Hash]
+    # @option options :as [Symbol] Mapper identifier
+    #
+    # @api public
+    def self.relation(name = Undefined, options = EMPTY_HASH)
+      return @relation if name.equal?(Undefined) && defined?(@relation)
+      register_as(options.fetch(:as, name))
+      super(name)
+    end
+
     # Define transformation pipeline
     #
     # @example

--- a/core/lib/rom/transformer.rb
+++ b/core/lib/rom/transformer.rb
@@ -15,6 +15,25 @@ module ROM
 
     defines :relation, :register_as
 
+    # Define transformation pipeline
+    #
+    # @example
+    #   class UsersMapper < ROM::Transformer
+    #     map do
+    #       rename_keys user_id: :id
+    #       deep_stringify_keys
+    #     end
+    #   end
+    #
+    # @return [self]
+    #
+    # @api public
+    def self.map(&block)
+      define! do
+        map_array(&block)
+      end
+    end
+
     # This is needed to make transformers compatible with rom setup
     #
     # @api private

--- a/core/spec/integration/transformer_spec.rb
+++ b/core/spec/integration/transformer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ROM::Transformer do
       relation :users
       register_as :default
 
-      map_array do
+      map do
         rename_keys user_id: :id
       end
     end

--- a/core/spec/integration/transformer_spec.rb
+++ b/core/spec/integration/transformer_spec.rb
@@ -2,11 +2,7 @@ require 'rom'
 require 'rom/transformer'
 
 RSpec.describe ROM::Transformer do
-  subject(:mapper) do
-    rom.mappers[:users][:default]
-  end
-
-  let(:relation) do
+  subject(:relation) do
     rom.relations[:users]
   end
 
@@ -14,11 +10,12 @@ RSpec.describe ROM::Transformer do
     ROM.container(:memory) do |config|
       config.relation(:users)
 
-      config.register_mapper(mapper_class)
+      config.register_mapper(default_mapper)
+      config.register_mapper(json_mapper)
     end
   end
 
-  let(:mapper_class) do
+  let(:default_mapper) do
     Class.new(ROM::Transformer) do
       relation :users, as: :default
 
@@ -28,9 +25,20 @@ RSpec.describe ROM::Transformer do
     end
   end
 
+  let(:json_mapper) do
+    Class.new(default_mapper) do
+      relation :users, as: :json
+
+      map do
+        deep_stringify_keys
+      end
+    end
+  end
+
   it 'works with rom container' do
     relation.insert(user_id: 1, name: 'Jane')
 
-    expect(relation.map_with(:default).to_a).to include(id: 1, name: 'Jane')
+    expect(relation.map_with(:default).to_a).to eql([id: 1, name: 'Jane'])
+    expect(relation.map_with(:json).to_a).to eql(['id' => 1, 'name' => 'Jane'])
   end
 end

--- a/core/spec/integration/transformer_spec.rb
+++ b/core/spec/integration/transformer_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe ROM::Transformer do
 
   let(:mapper_class) do
     Class.new(ROM::Transformer) do
-      relation :users
-      register_as :default
+      relation :users, as: :default
 
       map do
         rename_keys user_id: :id


### PR DESCRIPTION
This adds a `Transformer.map` shortcut which uses the new `define!` DSL from transproc 1.1.0 - when a transformer is defined using `map`, you will be able to use instance methods too. Furthermore `relation` now accepts `:as` option that will set `register_as`.