### PR TITLE
[changeset] support for command options and plugins

### DIFF
--- a/changeset/lib/rom/changeset.rb
+++ b/changeset/lib/rom/changeset.rb
@@ -7,176 +7,172 @@ require 'rom/constants'
 require 'rom/initializer'
 
 module ROM
-	# Abstract Changeset class
-	#
-	# If you inherit from this class you need to configure additional settings
-	#
-	# @example define a custom changeset using :upsert command
-	#   class NewTag < ROM::Changeset[:tags]
-	#     command_type :upsert
-	#   end
-	#
-	# @abstract
-	class Changeset
-		DEFAULT_COMMAND_OPTS = { mapper: false }.freeze
+  # Abstract Changeset class
+  #
+  # If you inherit from this class you need to configure additional settings
+  #
+  # @example define a custom changeset using :upsert command
+  #   class NewTag < ROM::Changeset[:tags]
+  #     command_type :upsert
+  #   end
+  #
+  # @abstract
+  class Changeset
+    extend Initializer
+    extend Dry::Core::Cache
+    extend Dry::Core::ClassAttributes
 
-		extend Initializer
-		extend Dry::Core::Cache
-		extend Dry::Core::ClassAttributes
+    # @!method self.command_type
+    #   Get or set changeset command type
+    #
+    #   @overload command_type
+    #     Return configured command_type
+    #     @return [Symbol]
+    #
+    #   @overload command_type(identifier)
+    #     Set relation identifier for this changeset
+    #     @param [Symbol] identifier The command type identifier
+    #     @return [Symbol]
+    defines :command_type
 
-		# @!method self.command_type
-		#   Get or set changeset command type
-		#
-		#   @overload command_type
-		#     Return configured command_type
-		#     @return [Symbol]
-		#
-		#   @overload command_type(identifier)
-		#     Set relation identifier for this changeset
-		#     @param [Symbol] identifier The command type identifier
-		#     @return [Symbol]
-		defines :command_type
+    # @!method self.command_options
+    #   Get or set command options
+    #
+    #   @overload command_options
+    #     Return configured command_options
+    #     @return [Hash,nil]
+    #
+    #   @overload command_options(**options)
+    #     Set command options
+    #     @param options [Hash] The command options
+    #     @return [Hash]
+    defines :command_options
 
-		# @!method self.command_options
-		#   Get or set command options
-		#
-		#   @overload command_options
-		#     Return configured command_options
-		#     @return [Hash,nil]
-		#
-		#   @overload command_options(**options)
-		#     Set command options
-		#     @param options [Hash] The command options
-		#     @return [Hash]
-		defines :command_options
+    # @!method self.command_plugins
+    #   Get or set command plugins options
+    #
+    #   @overload command_plugins
+    #     Return configured command_plugins
+    #     @return [Hash,nil]
+    #
+    #   @overload command_plugins(**options)
+    #     Set command plugin options
+    #     @param options [Hash] The command plugin options
+    #     @return [Hash]
+    defines :command_plugins
 
-		# @!method self.command_plugins
-		#   Get or set command plugins options
-		#
-		#   @overload command_plugins
-		#     Return configured command_plugins
-		#     @return [Hash,nil]
-		#
-		#   @overload command_plugins(**options)
-		#     Set command plugin options
-		#     @param options [Hash] The command plugin options
-		#     @return [Hash]
-		defines :command_plugins
+    # @!method self.relation
+    #   Get or set changeset relation identifier
+    #
+    #   @overload relation
+    #     Return configured relation identifier for this changeset
+    #     @return [Symbol]
+    #
+    #   @overload relation(identifier)
+    #     Set relation identifier for this changeset
+    #     @param [Symbol] identifier The relation identifier from the ROM container
+    #     @return [Symbol]
+    defines :relation
 
-		# @!method self.relation
-		#   Get or set changeset relation identifier
-		#
-		#   @overload relation
-		#     Return configured relation identifier for this changeset
-		#     @return [Symbol]
-		#
-		#   @overload relation(identifier)
-		#     Set relation identifier for this changeset
-		#     @param [Symbol] identifier The relation identifier from the ROM container
-		#     @return [Symbol]
-		defines :relation
+    # @!attribute [r] relation
+    #   @return [Relation] The changeset relation
+    param :relation
 
-		# @!attribute [r] relation
-		#   @return [Relation] The changeset relation
-		param :relation
+    # @!attribute [r] command_type
+    #   @return [Symbol] a custom command identifier
+    option :command_type, default: -> { self.class.command_type }
 
-		# @!attribute [r] command_type
-		#   @return [Symbol] a custom command identifier
-		option :command_type, default: -> { self.class.command_type }
+    # @!attribute [r] command_options
+    #   @return [Hash] Configured options for the command
+    option :command_options, default: -> { self.class.command_options }
 
-		# @!attribute [r] command_options
-		#   @return [Hash] Configured options for the command
-		option :command_options, default: -> { self.class.command_options }
+    # @!attribute [r] command_plugins
+    #   @return [Hash] Configured plugin options for the command
+    option :command_plugins, default: -> { self.class.command_plugins }
 
-		# @!attribute [r] command_plugins
-		#   @return [Hash] Configured plugin options for the command
-		option :command_plugins, default: -> { self.class.command_plugins }
+    # Set the default command options
+    command_options(mapper: false)
 
-		# Set the default command options
-		command_options(mapper: false)
+    # Set the default command plugin options
+    command_plugins(EMPTY_HASH)
 
-		# Set the default command plugin options
-		command_plugins(EMPTY_HASH)
-
-		# Create a changeset class preconfigured for a specific relation
-		#
-		# @example
-		#   class NewUserChangeset < ROM::Changeset::Create[:users]
-		#   end
-		#
-		#   users.changeset(NewUserChangeset).data(name: 'Jane')
-		#
-		# @api public
-		def self.[](relation_name)
-			fetch_or_store([relation_name, self]) {
-				Class.new(self) { relation(relation_name) }
-			}
-		end
-
-		# Enable a plugin for the changeset
-		#
-		# @api public
-		def self.use(plugin, options = EMPTY_HASH)
-			ROM.plugin_registry[:changeset].fetch(plugin).apply_to(self, options)
-		end
-
-		# Return a new changeset with provided relation
-		#
-		# New options can be provided too
-		#
-		# @param [Relation] relation
-		# @param [Hash] new_options
-		#
-		# @return [Changeset]
-		#
-		# @api public
-		def new(relation, new_options = EMPTY_HASH)
-			self.class.new(relation, new_options.empty? ? options : options.merge(new_options))
-		end
-
-		# Persist changeset
-		#
-		# @example
-		#   changeset = users.changeset(name: 'Jane')
-		#   changeset.commit
-		#   # => { id: 1, name: 'Jane' }
-		#
-		# @return [Hash, Array]
-		#
-		# @api public
-		def commit
-			command.call
-		end
-
-		# Return string representation of the changeset
-		#
-		# @return [String]
-		#
-		# @api public
-		def inspect
-			%(#<#{self.class} relation=#{relation.name.inspect}>)
-		end
-
-		# Return a command for this changeset
-		#
-		# @return [ROM::Command]
-		#
-		# @api private
-		def command
-			relation.command(command_type, command_options)
-		end
-
-		# Return configured command options
-		#
-		# @return [Hash]
-		#
-		# @api private
-		def command_options
-      DEFAULT_COMMAND_OPTS
-        .merge(self.class.command_options)
-        .merge(use: command_plugins.keys, plugins_options: command_plugins)
+    # Create a changeset class preconfigured for a specific relation
+    #
+    # @example
+    #   class NewUserChangeset < ROM::Changeset::Create[:users]
+    #   end
+    #
+    #   users.changeset(NewUserChangeset).data(name: 'Jane')
+    #
+    # @api public
+    def self.[](relation_name)
+      fetch_or_store([relation_name, self]) {
+        Class.new(self) { relation(relation_name) }
+      }
     end
-	end
+
+    # Enable a plugin for the changeset
+    #
+    # @api public
+    def self.use(plugin, options = EMPTY_HASH)
+      ROM.plugin_registry[:changeset].fetch(plugin).apply_to(self, options)
+    end
+
+    # Return a new changeset with provided relation
+    #
+    # New options can be provided too
+    #
+    # @param [Relation] relation
+    # @param [Hash] new_options
+    #
+    # @return [Changeset]
+    #
+    # @api public
+    def new(relation, new_options = EMPTY_HASH)
+      self.class.new(relation, new_options.empty? ? options : options.merge(new_options))
+    end
+
+    # Persist changeset
+    #
+    # @example
+    #   changeset = users.changeset(name: 'Jane')
+    #   changeset.commit
+    #   # => { id: 1, name: 'Jane' }
+    #
+    # @return [Hash, Array]
+    #
+    # @api public
+    def commit
+      command.call
+    end
+
+    # Return string representation of the changeset
+    #
+    # @return [String]
+    #
+    # @api public
+    def inspect
+      %(#<#{self.class} relation=#{relation.name.inspect}>)
+    end
+
+    # Return a command for this changeset
+    #
+    # @return [ROM::Command]
+    #
+    # @api private
+    def command
+      relation.command(command_type, command_compiler_options)
+    end
+
+    # Return configured command compiler options
+    #
+    # @return [Hash]
+    #
+    # @api private
+    def command_compiler_options
+      command_options.merge(use: command_plugins.keys, plugins_options: command_plugins)
+    end
+  end
 end
 
 require 'rom/changeset/stateful'

--- a/changeset/lib/rom/changeset.rb
+++ b/changeset/lib/rom/changeset.rb
@@ -7,154 +7,176 @@ require 'rom/constants'
 require 'rom/initializer'
 
 module ROM
-  # Abstract Changeset class
-  #
-  # If you inherit from this class you need to configure additional settings
-  #
-  # @example define a custom changeset using :upsert command
-  #   class NewTag < ROM::Changeset[:tags]
-  #     command_type :upsert
-  #   end
-  #
-  # @abstract
-  class Changeset
-    DEFAULT_COMMAND_OPTS = { mapper: false }.freeze
+	# Abstract Changeset class
+	#
+	# If you inherit from this class you need to configure additional settings
+	#
+	# @example define a custom changeset using :upsert command
+	#   class NewTag < ROM::Changeset[:tags]
+	#     command_type :upsert
+	#   end
+	#
+	# @abstract
+	class Changeset
+		DEFAULT_COMMAND_OPTS = { mapper: false }.freeze
 
-    extend Initializer
-    extend Dry::Core::Cache
-    extend Dry::Core::ClassAttributes
+		extend Initializer
+		extend Dry::Core::Cache
+		extend Dry::Core::ClassAttributes
 
-    # @!method self.command_type
-    #   Get or set changeset command type
-    #
-    #   @overload command_type
-    #     Return configured command_type
-    #     @return [Symbol]
-    #
-    #   @overload command_type(identifier)
-    #     Set relation identifier for this changeset
-    #     @param [Symbol] identifier The command type identifier
-    #     @return [Symbol]
-    defines :command_type
+		# @!method self.command_type
+		#   Get or set changeset command type
+		#
+		#   @overload command_type
+		#     Return configured command_type
+		#     @return [Symbol]
+		#
+		#   @overload command_type(identifier)
+		#     Set relation identifier for this changeset
+		#     @param [Symbol] identifier The command type identifier
+		#     @return [Symbol]
+		defines :command_type
 
-    # @!method self.command_options
-    #   Get or set command options
-    #
-    #   @overload command_options
-    #     Return configured command_options
-    #     @return [Hash,nil]
-    #
-    #   @overload command_options(**options)
-    #     Set command options
-    #     @param options [Hash] The command options
-    #     @return [Hash]
-    defines :command_options
+		# @!method self.command_options
+		#   Get or set command options
+		#
+		#   @overload command_options
+		#     Return configured command_options
+		#     @return [Hash,nil]
+		#
+		#   @overload command_options(**options)
+		#     Set command options
+		#     @param options [Hash] The command options
+		#     @return [Hash]
+		defines :command_options
 
-    # @!method self.relation
-    #   Get or set changeset relation identifier
-    #
-    #   @overload relation
-    #     Return configured relation identifier for this changeset
-    #     @return [Symbol]
-    #
-    #   @overload relation(identifier)
-    #     Set relation identifier for this changeset
-    #     @param [Symbol] identifier The relation identifier from the ROM container
-    #     @return [Symbol]
-    defines :relation
+		# @!method self.command_plugins
+		#   Get or set command plugins options
+		#
+		#   @overload command_plugins
+		#     Return configured command_plugins
+		#     @return [Hash,nil]
+		#
+		#   @overload command_plugins(**options)
+		#     Set command plugin options
+		#     @param options [Hash] The command plugin options
+		#     @return [Hash]
+		defines :command_plugins
 
-    # @!attribute [r] relation
-    #   @return [Relation] The changeset relation
-    param :relation
+		# @!method self.relation
+		#   Get or set changeset relation identifier
+		#
+		#   @overload relation
+		#     Return configured relation identifier for this changeset
+		#     @return [Symbol]
+		#
+		#   @overload relation(identifier)
+		#     Set relation identifier for this changeset
+		#     @param [Symbol] identifier The relation identifier from the ROM container
+		#     @return [Symbol]
+		defines :relation
 
-    # @!attribute [r] command_type
-    #   @return [Symbol] a custom command identifier
-    option :command_type, default: -> { self.class.command_type }
+		# @!attribute [r] relation
+		#   @return [Relation] The changeset relation
+		param :relation
 
-    # @!attribute [r] command_options
-    #   @return [Hash] Configured options for the command
-    option :command_options, default: -> { self.class.command_options }
+		# @!attribute [r] command_type
+		#   @return [Symbol] a custom command identifier
+		option :command_type, default: -> { self.class.command_type }
 
-    # Set the default command options
-    command_options(mapper: false)
+		# @!attribute [r] command_options
+		#   @return [Hash] Configured options for the command
+		option :command_options, default: -> { self.class.command_options }
 
-    # Create a changeset class preconfigured for a specific relation
-    #
-    # @example
-    #   class NewUserChangeset < ROM::Changeset::Create[:users]
-    #   end
-    #
-    #   users.changeset(NewUserChangeset).data(name: 'Jane')
-    #
-    # @api public
-    def self.[](relation_name)
-      fetch_or_store([relation_name, self]) {
-        Class.new(self) { relation(relation_name) }
-      }
+		# @!attribute [r] command_plugins
+		#   @return [Hash] Configured plugin options for the command
+		option :command_plugins, default: -> { self.class.command_plugins }
+
+		# Set the default command options
+		command_options(mapper: false)
+
+		# Set the default command plugin options
+		command_plugins(EMPTY_HASH)
+
+		# Create a changeset class preconfigured for a specific relation
+		#
+		# @example
+		#   class NewUserChangeset < ROM::Changeset::Create[:users]
+		#   end
+		#
+		#   users.changeset(NewUserChangeset).data(name: 'Jane')
+		#
+		# @api public
+		def self.[](relation_name)
+			fetch_or_store([relation_name, self]) {
+				Class.new(self) { relation(relation_name) }
+			}
+		end
+
+		# Enable a plugin for the changeset
+		#
+		# @api public
+		def self.use(plugin, options = EMPTY_HASH)
+			ROM.plugin_registry[:changeset].fetch(plugin).apply_to(self, options)
+		end
+
+		# Return a new changeset with provided relation
+		#
+		# New options can be provided too
+		#
+		# @param [Relation] relation
+		# @param [Hash] new_options
+		#
+		# @return [Changeset]
+		#
+		# @api public
+		def new(relation, new_options = EMPTY_HASH)
+			self.class.new(relation, new_options.empty? ? options : options.merge(new_options))
+		end
+
+		# Persist changeset
+		#
+		# @example
+		#   changeset = users.changeset(name: 'Jane')
+		#   changeset.commit
+		#   # => { id: 1, name: 'Jane' }
+		#
+		# @return [Hash, Array]
+		#
+		# @api public
+		def commit
+			command.call
+		end
+
+		# Return string representation of the changeset
+		#
+		# @return [String]
+		#
+		# @api public
+		def inspect
+			%(#<#{self.class} relation=#{relation.name.inspect}>)
+		end
+
+		# Return a command for this changeset
+		#
+		# @return [ROM::Command]
+		#
+		# @api private
+		def command
+			relation.command(command_type, command_options)
+		end
+
+		# Return configured command options
+		#
+		# @return [Hash]
+		#
+		# @api private
+		def command_options
+      DEFAULT_COMMAND_OPTS
+        .merge(self.class.command_options)
+        .merge(use: command_plugins.keys, plugins_options: command_plugins)
     end
-
-    # Enable a plugin for the changeset
-    #
-    # @api public
-    def self.use(plugin, options = EMPTY_HASH)
-      ROM.plugin_registry[:changeset].fetch(plugin).apply_to(self, options)
-    end
-
-    # Return a new changeset with provided relation
-    #
-    # New options can be provided too
-    #
-    # @param [Relation] relation
-    # @param [Hash] new_options
-    #
-    # @return [Changeset]
-    #
-    # @api public
-    def new(relation, new_options = EMPTY_HASH)
-      self.class.new(relation, new_options.empty? ? options : options.merge(new_options))
-    end
-
-    # Persist changeset
-    #
-    # @example
-    #   changeset = users.changeset(name: 'Jane')
-    #   changeset.commit
-    #   # => { id: 1, name: 'Jane' }
-    #
-    # @return [Hash, Array]
-    #
-    # @api public
-    def commit
-      command.call
-    end
-
-    # Return string representation of the changeset
-    #
-    # @return [String]
-    #
-    # @api public
-    def inspect
-      %(#<#{self.class} relation=#{relation.name.inspect}>)
-    end
-
-    # Return a command for this changeset
-    #
-    # @return [ROM::Command]
-    #
-    # @api private
-    def command
-      relation.command(command_type, command_options)
-    end
-
-    # Return configured command options
-    #
-    # @return [Hash]
-    #
-    # @api private
-    def command_options
-      DEFAULT_COMMAND_OPTS.merge(self.class.command_options)
-    end
-  end
+	end
 end
 
 require 'rom/changeset/stateful'

--- a/changeset/lib/rom/changeset.rb
+++ b/changeset/lib/rom/changeset.rb
@@ -37,6 +37,19 @@ module ROM
     #     @return [Symbol]
     defines :command_type
 
+    # @!method self.command_options
+    #   Get or set command options
+    #
+    #   @overload command_options
+    #     Return configured command_options
+    #     @return [Hash,nil]
+    #
+    #   @overload command_options(**options)
+    #     Set command options
+    #     @param options [Hash] The command options
+    #     @return [Hash]
+    defines :command_options
+
     # @!method self.relation
     #   Get or set changeset relation identifier
     #
@@ -57,6 +70,13 @@ module ROM
     # @!attribute [r] command_type
     #   @return [Symbol] a custom command identifier
     option :command_type, default: -> { self.class.command_type }
+
+    # @!attribute [r] command_options
+    #   @return [Hash] Configured options for the command
+    option :command_options, default: -> { self.class.command_options }
+
+    # Set the default command options
+    command_options(mapper: false)
 
     # Create a changeset class preconfigured for a specific relation
     #
@@ -123,7 +143,16 @@ module ROM
     #
     # @api private
     def command
-      relation.command(command_type, DEFAULT_COMMAND_OPTS)
+      relation.command(command_type, command_options)
+    end
+
+    # Return configured command options
+    #
+    # @return [Hash]
+    #
+    # @api private
+    def command_options
+      DEFAULT_COMMAND_OPTS.merge(self.class.command_options)
     end
   end
 end

--- a/changeset/lib/rom/changeset/stateful.rb
+++ b/changeset/lib/rom/changeset/stateful.rb
@@ -236,7 +236,7 @@ module ROM
 
       # @api public
       def command
-        relation.command(command_type, DEFAULT_COMMAND_OPTS.merge(result: result))
+        relation.command(command_type, command_options.merge(result: result))
       end
 
       # Return string representation of the changeset

--- a/changeset/lib/rom/changeset/stateful.rb
+++ b/changeset/lib/rom/changeset/stateful.rb
@@ -234,11 +234,6 @@ module ROM
         __data__.is_a?(Array) ? :many : :one
       end
 
-      # @api public
-      def command
-        relation.command(command_type, command_options.merge(result: result))
-      end
-
       # Return string representation of the changeset
       #
       # @return [String]
@@ -246,6 +241,11 @@ module ROM
       # @api public
       def inspect
         %(#<#{self.class} relation=#{relation.name.inspect} data=#{__data__}>)
+      end
+
+      # @api private
+      def command_compiler_options
+        super.merge(result: result)
       end
 
       # Data transformation pipe

--- a/changeset/spec/integration/command_options_spec.rb
+++ b/changeset/spec/integration/command_options_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe 'changeset plugin' do
+  subject(:changeset) do
+    books.changeset(changeset_class).data(title: 'Hello World')
+  end
+
+  let(:changeset_class) do
+    Class.new(ROM::Changeset::Create) do
+      command_options input: -> tuple { tuple.merge(updated_at: Time.now) }
+    end
+  end
+
+  include_context 'database'
+  include_context 'relations'
+
+  it 'extends the command with the provided command options' do
+    book = changeset.commit
+
+    expect(book.updated_at).to be_within(0.25).of(Time.now)
+  end
+end

--- a/changeset/spec/integration/command_options_spec.rb
+++ b/changeset/spec/integration/command_options_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'changeset plugin' do
   let(:changeset_class) do
     Class.new(ROM::Changeset::Create) do
       command_options input: -> tuple { tuple.merge(updated_at: Time.now) }
+      command_plugins timestamps: { timestamps: [:created_at] }
     end
   end
 
@@ -17,6 +18,7 @@ RSpec.describe 'changeset plugin' do
   it 'extends the command with the provided command options' do
     book = changeset.commit
 
+    expect(book.created_at).to be_within(0.25).of(Time.now)
     expect(book.updated_at).to be_within(0.25).of(Time.now)
   end
 end

--- a/changeset/spec/shared/database.rb
+++ b/changeset/spec/shared/database.rb
@@ -5,6 +5,11 @@ RSpec.shared_context 'database setup' do
 
   let(:rom) { ROM.container(configuration) }
 
+  before :all do
+    Sequel.database_timezone = :utc
+    Sequel.application_timezone = :utc
+  end
+
   before do
     conn.loggers << LOGGER
   end


### PR DESCRIPTION
This adds support for configuring changeset commands using `command_options` and `command_plugins` class settings.

Here's what will be possible with this feature:

```ruby
module TimestampPlugin
  def self.apply(klass, options)
    klass.command_plugins :timestamps, timestamps: options
  end
end

ROM::Plugins.register(:timestamp, TimestampPlugin, type: :changeset)

class CreateChangeset < ROM::Changeset::Create
  use :timestamps, [:created_at]
end
```