### PR TITLE
[core] better association set exceptions

### DIFF
--- a/core/lib/rom/constants.rb
+++ b/core/lib/rom/constants.rb
@@ -50,7 +50,7 @@ module ROM
 
     # @api private
     def set_message(key, registry)
-      "#{key.inspect} doesn't exist in #{registry.class.name} registry"
+      "#{key.inspect} doesn't exist in #{registry.type} registry"
     end
   end
 

--- a/core/lib/rom/schema/associations_dsl.rb
+++ b/core/lib/rom/schema/associations_dsl.rb
@@ -178,7 +178,7 @@ module ROM
       #
       # @api private
       def call
-        AssociationSet.new(registry)
+        AssociationSet[source.relation].new(registry)
       end
 
       private

--- a/core/spec/unit/rom/association_set_spec.rb
+++ b/core/spec/unit/rom/association_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ROM::AssociationSet do
     it 'builds a class with the provided identifier' do
       klass = ROM::AssociationSet[:users]
 
-      expect(klass.name).to eql("ROM::AssociationSet[:users]")
+      expect(klass.name).to eql('ROM::AssociationSet[:users]')
     end
 
     it 'caches the class' do

--- a/core/spec/unit/rom/association_set_spec.rb
+++ b/core/spec/unit/rom/association_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe ROM::AssociationSet do
   describe '#[]' do
     let(:users) { double(:users, aliased?: false) }

--- a/core/spec/unit/rom/association_set_spec.rb
+++ b/core/spec/unit/rom/association_set_spec.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe ROM::AssociationSet do
+  subject(:set) { ROM::AssociationSet[:projects].new(elements) }
+
+  describe '.[]' do
+    it 'builds a class with the provided identifier' do
+      klass = ROM::AssociationSet[:users]
+
+      expect(klass.name).to eql("ROM::AssociationSet[:users]")
+    end
+
+    it 'caches the class' do
+      expect(ROM::AssociationSet[:users]).to be(ROM::AssociationSet[:users])
+    end
+  end
+
   describe '#[]' do
+    let(:elements) { { users: users, post: posts } }
+
     let(:users) { double(:users, aliased?: false) }
     let(:posts) { double(:posts, aliased?: true, as: :post, name: :posts) }
-    let(:set) { ROM::AssociationSet.new(users: users, post: posts) }
 
     it 'fetches association' do
       expect(set[:users]).to be users
@@ -21,7 +36,7 @@ RSpec.describe ROM::AssociationSet do
     it 'throws exception on missing association' do
       expect { set[:labels] }.to raise_error(
         ROM::ElementNotFoundError,
-        ":labels doesn't exist in ROM::AssociationSet registry"
+        ":labels doesn't exist in ROM::AssociationSet[:projects] registry"
       )
     end
   end

--- a/core/spec/unit/rom/schema/associations_dsl_spec.rb
+++ b/core/spec/unit/rom/schema/associations_dsl_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rom/schema/associations_dsl'
+
+RSpec.describe ROM::Schema::AssociationsDSL do
+  subject(:dsl) do
+    ROM::Schema::AssociationsDSL.new(ROM::Relation::Name[:users]) do
+      has_many :posts
+    end
+  end
+
+  describe '#call' do
+    it 'returns a configured association set' do
+      association_set = dsl.call
+
+      expect(association_set.type).to eql('ROM::AssociationSet[:users]')
+      expect(association_set.key?(:posts)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Previously:

```
> users.associations[:foo]
ROM::ElementNotFoundError: :foo doesn't exist in ROM::AssociationSet registry
```

Now:

```
> users.associations[:foo]
ROM::ElementNotFoundError: :foo doesn't exist in ROM::AssociationSet[:users] registry
```