### PR TITLE
[core] use Relation::Name's key for rejecting duped combine nodes

### DIFF
--- a/core/lib/rom/relation/combined.rb
+++ b/core/lib/rom/relation/combined.rb
@@ -22,7 +22,7 @@ module ROM
       # @api public
       def self.new(relation, nodes)
         struct_ns = relation.options[:struct_namespace]
-        new_nodes = nodes.uniq.map { |node| node.struct_namespace(struct_ns) }
+        new_nodes = nodes.uniq(&:name).map { |node| node.struct_namespace(struct_ns) }
 
         root =
           if relation.is_a?(self)

--- a/core/spec/integration/mapper/combine_spec.rb
+++ b/core/spec/integration/mapper/combine_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Mapper definition DSL' do
       configuration.relation(:tasks) do
         auto_map false
 
+        schema(:tasks) { }
+
         def for_users(users)
           names = users.map { |user| user[:name] }
           restrict { |task| names.include?(task[:name]) }
@@ -21,6 +23,8 @@ RSpec.describe 'Mapper definition DSL' do
 
       configuration.relation(:users) do
         auto_map false
+
+        schema(:users) { }
 
         def addresses(_users)
           [{ city: 'NYC', user: 'Jane' }, { city: 'Boston', user: 'Joe' }]
@@ -110,9 +114,9 @@ RSpec.describe 'Mapper definition DSL' do
       Test::Address.send(:include, Dry::Equalizer(:city))
 
       result = users.combine_with(
-        tasks.for_users.combine_with(tasks.tags),
-        users.addresses,
-        users.books
+        tasks.as(:tasks).for_users.combine_with(tasks.tags.as(:tags)),
+        users.addresses.as(:addresses),
+        users.books.as(:books)
       ) >> users.mappers[:entity]
 
       expect(result).to match_array([joe, jane])

--- a/core/spec/unit/rom/relation/combine_with_spec.rb
+++ b/core/spec/unit/rom/relation/combine_with_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ROM::Relation, '#combine_with' do
     Class.new(ROM::Memory::Relation) do
       auto_map false
 
+      schema(:users) { }
+
       def by_name(name)
         restrict(name: name)
       end
@@ -17,6 +19,8 @@ RSpec.describe ROM::Relation, '#combine_with' do
   let(:tasks_relation) do
     Class.new(ROM::Memory::Relation) do
       auto_map false
+
+      schema(:tasks) { }
 
       def for_users(users)
         names = users.map { |user| user[:name] }
@@ -28,6 +32,8 @@ RSpec.describe ROM::Relation, '#combine_with' do
   let(:tags_relation) do
     Class.new(ROM::Memory::Relation) do
       auto_map false
+
+      schema(:tags) { }
 
       attr_accessor :tasks
       forward :map


### PR DESCRIPTION
Refs #548 

It turned out using `Relation#eql?` (which is based on `dataset` and `name`) *is actually broken*. First of all `Relation::Name` is equalized only on `relation` and `dataset` attributes, so if there's an alias involved, it will not work. ~~It was too risky to fix it now because it's possible there's some code that relies on this equality behavior. It is something to address in 6.0.0.~~ I fixed it anyway in #563 

There's also another risk - equalizing on `Relation#dataset` *may result in materialization of the dataset*. I remember it happened in some cases in the past, that's why it was much better to use `Relation::Name#key` to figure out which nodes are duplicated. In theory, you can have more than one node with the same key but different datasets, but you would have to do this manually.

@joelvh - I reckon this should fix your problems

@v-kolesnikov - there's *a big chance* this will fix your problems too