### PR TITLE
[core] fix Relation::Name equality

### DIFF
--- a/core/lib/rom/relation/name.rb
+++ b/core/lib/rom/relation/name.rb
@@ -16,7 +16,7 @@ module ROM
     #
     # @api private
     class Name
-      include Dry::Equalizer(:relation, :dataset)
+      include Dry::Equalizer(:relation, :dataset, :key)
 
       # Coerce an object to a Name instance
       #

--- a/core/spec/unit/rom/relation/name_spec.rb
+++ b/core/spec/unit/rom/relation/name_spec.rb
@@ -25,6 +25,43 @@ RSpec.describe ROM::Relation::Name do
     end
   end
 
+  describe '#eql?' do
+    it 'returns true when relation is the same' do
+      expect(ROM::Relation::Name.new(:users))
+        .to eql(ROM::Relation::Name.new(:users))
+    end
+
+    it 'returns false when relation is not the same' do
+      expect(ROM::Relation::Name.new(:users))
+        .to_not eql(ROM::Relation::Name.new(:tasks))
+    end
+
+    it 'returns true when relation and dataset are the same' do
+      expect(ROM::Relation::Name.new(:users, :people))
+        .to eql(ROM::Relation::Name.new(:users, :people))
+    end
+
+    it 'returns false when relation and dataset are not the same' do
+      expect(ROM::Relation::Name.new(:users, :people))
+        .to_not eql(ROM::Relation::Name.new(:users, :folks))
+    end
+
+    it 'returns true when relation, dataset and alias are the same' do
+      expect(ROM::Relation::Name.new(:posts, :posts, :published))
+        .to eql(ROM::Relation::Name.new(:posts, :posts, :published))
+    end
+
+    it 'returns false when relation, dataset and alias are not the same' do
+      expect(ROM::Relation::Name.new(:posts, :articles, :published))
+        .to_not eql(ROM::Relation::Name.new(:posts, :posts, :deleted))
+    end
+
+    it 'returns false when relation and dataset are the same but aliases are different' do
+      expect(ROM::Relation::Name.new(:posts, :posts, :published))
+        .to_not eql(ROM::Relation::Name.new(:posts, :posts, :deleted))
+    end
+  end
+
   describe '#inspect' do
     it 'provides relation name' do
       name = ROM::Relation::Name.new(:users)


### PR DESCRIPTION
Previously equalizing relation names would skip checking `key` attribute, which is used when a relation is aliased. This is common when using associations with custom names, in such cases a relation is aliased.

Refs #562 