### PR TITLE
[core] fix class name inference in struct compiler

### DIFF
--- a/core/lib/rom/struct_compiler.rb
+++ b/core/lib/rom/struct_compiler.rb
@@ -104,7 +104,7 @@ module ROM
 
     # @api private
     def class_name(name)
-      Inflector.classify(Inflector.singularize(name))
+      Inflector.classify(name)
     end
   end
 end

--- a/core/spec/unit/rom/struct_compiler_spec.rb
+++ b/core/spec/unit/rom/struct_compiler_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe ROM::StructCompiler, '#call' do
   end
 
   context 'ROM::Struct' do
+    it 'generates valid class name in the default namespace' do
+      ast = [
+        :statuses,
+        [
+          [:attribute, attr_ast(:id, :Integer)],
+          [:attribute, attr_ast(:name, :String)]
+        ]
+      ]
+
+      struct = struct_compiler[*ast, ROM::Struct]
+
+      expect(struct.name).to eql('ROM::Struct::Status')
+    end
+
     it 'generates a struct for a given relation name and columns' do
       struct = struct_compiler[*input, ROM::Struct]
 


### PR DESCRIPTION
Fixing a bug that I found recently.

The actual culprit though is dry-rb/dry-inflector#27 - despite that, it still makes sense to just use `classify` as it does `singularize` under the hood.