### PR TITLE
Fix warning about shadowed arg1

### DIFF
--- a/core/lib/rom/commands/class_interface.rb
+++ b/core/lib/rom/commands/class_interface.rb
@@ -151,7 +151,7 @@ module ROM
       #       relation :users
       #       register_as :create
       #
-      #       before my_hook: { arg1: 1, arg1: 2 }
+      #       before my_hook: { arg1: 1, arg2: 2 }
       #
       #       def my_hook(tuple, arg1:, arg2:)
       #         puts "hook called with args: #{arg1} and #{arg2}"


### PR DESCRIPTION
I got this warning when installing `rom-core-5.1.2`:

```
Installing darkfish documentation for rom-core-5.1.2
(eval):9: warning: key :arg1 is duplicated and overwritten on line 9
(eval):9: warning: key :arg1 is duplicated and overwritten on line 9
```

I believe it is related to this line.