### PR TITLE
Allow to configure custom inflector

### DIFF
--- a/lib/rom/associations/definitions/abstract.rb
+++ b/lib/rom/associations/definitions/abstract.rb
@@ -7,6 +7,7 @@ require "rom/types"
 require "rom/initializer"
 require "rom/relation/name"
 require "rom/associations/through_identifier"
+require "rom/support/inflector"
 
 module ROM
   module Associations
@@ -94,7 +95,12 @@ module ROM
           through = options[:through]
 
           if through
-            options[:through] = ThroughIdentifier[through, target.relation, options[:assoc]]
+            options[:through] = ThroughIdentifier[
+              through,
+              target.relation,
+              options[:assoc],
+              inflector: options.fetch(:inflector, Inflector)
+            ]
           end
 
           options[:name] = target.relation

--- a/lib/rom/associations/through_identifier.rb
+++ b/lib/rom/associations/through_identifier.rb
@@ -16,13 +16,13 @@ module ROM
       attr_reader :assoc_name
 
       # @api private
-      def self.[](source, target, assoc_name = nil)
-        new(source, target, assoc_name || default_assoc_name(target))
+      def self.[](source, target, assoc_name = nil, inflector: Inflector)
+        new(source, target, assoc_name || default_assoc_name(target, inflector: inflector))
       end
 
       # @api private
-      def self.default_assoc_name(relation)
-        Inflector.singularize(relation).to_sym
+      def self.default_assoc_name(relation, inflector:)
+        inflector.singularize(relation).to_sym
       end
 
       # @api private

--- a/lib/rom/command_proxy.rb
+++ b/lib/rom/command_proxy.rb
@@ -8,10 +8,12 @@ module ROM
   #
   # @api private
   class CommandProxy
-    attr_reader :command, :root
+    attr_reader :command
+
+    attr_reader :root
 
     # @api private
-    def initialize(command, root = Inflector.singularize(command.name.relation).to_sym)
+    def initialize(command, root)
       @command = command
       @root = root
     end
@@ -23,7 +25,7 @@ module ROM
 
     # @api private
     def >>(other)
-      self.class.new(command >> other)
+      self.class.new(command >> other, root)
     end
 
     # @api private

--- a/lib/rom/commands/class_interface.rb
+++ b/lib/rom/commands/class_interface.rb
@@ -85,9 +85,9 @@ module ROM
       # @return [Class, Object]
       #
       # @api public
-      def create_class(name, type, &block)
+      def create_class(name, type, inflector: Inflector, &block)
         klass = Dry::Core::ClassBuilder
-          .new(name: "#{Inflector.classify(type)}[:#{name}]", parent: type)
+          .new(name: "#{inflector.classify(type)}[:#{name}]", parent: type)
           .call
 
         if block

--- a/lib/rom/configuration.rb
+++ b/lib/rom/configuration.rb
@@ -6,6 +6,7 @@ require "rom/environment"
 require "rom/setup"
 require "rom/configuration_dsl"
 require "rom/support/notifications"
+require "rom/support/inflector"
 
 module ROM
   class Configuration
@@ -38,7 +39,7 @@ module ROM
 
     def_delegators :@setup, :register_relation, :register_command, :register_mapper, :register_plugin,
                    :command_classes, :mapper_classes,
-                   :auto_registration
+                   :auto_registration, :inflector, :inflector=
 
     def_delegators :@environment, :gateways, :gateways_map, :configure, :config
 

--- a/lib/rom/configuration_dsl/command.rb
+++ b/lib/rom/configuration_dsl/command.rb
@@ -16,10 +16,11 @@ module ROM
       # @api private
       def self.build_class(name, relation, options = EMPTY_HASH, &block)
         type = options.fetch(:type) { name }
-        command_type = Inflector.classify(type)
+        inflector = options.fetch(:inflector) { Inflector }
+        command_type = inflector.classify(type)
         adapter = options.fetch(:adapter)
         parent = ROM::Command.adapter_namespace(adapter).const_get(command_type)
-        class_name = generate_class_name(adapter, command_type, relation)
+        class_name = generate_class_name(adapter, command_type, relation, inflector)
 
         Dry::Core::ClassBuilder.new(name: class_name, parent: parent).call do |klass|
           klass.register_as(name)
@@ -31,11 +32,11 @@ module ROM
       # Create a command subclass name based on adapter, type and relation
       #
       # @api private
-      def self.generate_class_name(adapter, command_type, relation)
+      def self.generate_class_name(adapter, command_type, relation, inflector)
         pieces = ["ROM"]
-        pieces << Inflector.classify(adapter)
+        pieces << inflector.classify(adapter)
         pieces << "Commands"
-        pieces << "#{command_type}[#{Inflector.classify(relation)}s]"
+        pieces << "#{command_type}[#{inflector.classify(relation)}s]"
         pieces.join("::")
       end
     end

--- a/lib/rom/configuration_dsl/relation.rb
+++ b/lib/rom/configuration_dsl/relation.rb
@@ -15,7 +15,8 @@ module ROM
       #
       # @api private
       def self.build_class(name, options = EMPTY_HASH)
-        class_name = "ROM::Relation[#{Inflector.camelize(name)}]"
+        inflector = options.fetch(:inflector) { Inflector }
+        class_name = "ROM::Relation[#{inflector.camelize(name)}]"
         adapter = options.fetch(:adapter)
 
         Dry::Core::ClassBuilder.new(name: class_name, parent: ROM::Relation[adapter]).call do |klass|

--- a/lib/rom/create_container.rb
+++ b/lib/rom/create_container.rb
@@ -34,7 +34,8 @@ module ROM
         mappers: setup.mapper_classes,
         plugins: setup.plugins,
         notifications: setup.notifications,
-        config: environment.config.dup.freeze
+        config: environment.config.dup.freeze,
+        inflector: setup.inflector
       )
 
       finalize.run!

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -6,6 +6,7 @@ require "rom/struct"
 require "rom/constants"
 require "rom/initializer"
 require "rom/support/memoizable"
+require "rom/support/inflector"
 
 require "rom/relation/class_interface"
 
@@ -136,17 +137,26 @@ module ROM
     #   @api public
     param :dataset
 
+    # @!attribute [r] inflector
+    #   @return [Dry::Inflector] String inflector
+    #   @api private
+    option :inflector, reader: true, default: -> { Inflector }
+
     # @!attribute [r] schema
     #   @return [Schema] relation schema, defaults to class-level canonical
     #                    schema (if it was defined) and sets an empty one as
     #                    the fallback
     #   @api public
-    option :schema, default: -> { self.class.schema || self.class.default_schema }
+    option :schema, default: -> {
+      self.class.schema || self.class.default_schema(inflector: inflector)
+    }
 
     # @!attribute [r] name
     #   @return [Object] The relation name
     #   @api public
-    option :name, default: -> { self.class.schema ? self.class.schema.name : self.class.default_name }
+    option :name, default: -> {
+      self.class.schema ? self.class.schema.name : self.class.default_name(inflector)
+    }
 
     # @!attribute [r] input_schema
     #   @return [Object#[]] tuple processing function, uses schema or defaults to Hash[]
@@ -596,7 +606,7 @@ module ROM
       if attr
         attr.name
       else
-        :"#{Inflector.singularize(name.dataset)}_id"
+        :"#{inflector.singularize(name.dataset)}_id"
       end
     end
 

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -104,14 +104,14 @@ module ROM
 
           @relation_name = Name[relation, ds_name]
 
-          @schema_proc = proc do |*args, &inner_block|
+          @schema_proc = proc do |**kwargs, &inner_block|
             schema_dsl.new(
               relation_name,
               schema_class: schema_class,
               attr_class: schema_attr_class,
               inferrer: schema_inferrer.with(enabled: infer),
               &block
-            ).call(*args, &inner_block)
+            ).call(**kwargs, &inner_block)
           end
         end
       end
@@ -294,15 +294,15 @@ module ROM
       # @return [Name]
       #
       # @api private
-      def default_name
-        Name[Inflector.underscore(name).tr("/", "_").to_sym]
+      def default_name(inflector = Inflector)
+        Name[inflector.underscore(name).tr("/", "_").to_sym]
       end
 
       # @api private
-      def default_schema(klass = self)
+      def default_schema(klass = self, inflector: Inflector)
         klass.schema ||
           if klass.schema_proc
-            klass.set_schema!(klass.schema_proc.call)
+            klass.set_schema!(klass.schema_proc.(inflector: inflector))
           else
             klass.schema_class.define(klass.default_name)
           end

--- a/lib/rom/schema/associations_dsl.rb
+++ b/lib/rom/schema/associations_dsl.rb
@@ -11,18 +11,29 @@ module ROM
     # This DSL is exposed in `associations do .. end` blocks in schema defintions.
     #
     # @api public
-    class AssociationsDSL < BasicObject
+    class AssociationsDSL < ::BasicObject
+      class << self
+        define_method(:const_missing, ::Object.method(:const_get))
+      end
+
+      include Associations::Definitions
+
       # @!attribute [r] source
       #   @return [Relation::Name] The source relation
       attr_reader :source
+
+      # @!attribute [r] inflector
+      #   @return [Dry::Inflector] String inflector
+      attr_reader :inflector
 
       # @!attribute [r] registry
       #   @return [RelationRegistry] Relations registry from a rom container
       attr_reader :registry
 
       # @api private
-      def initialize(source, &block)
+      def initialize(source, inflector = Inflector, &block)
         @source = source
+        @inflector = inflector
         @registry = {}
         instance_exec(&block)
       end
@@ -61,9 +72,9 @@ module ROM
       # @api public
       def one_to_many(target, **options)
         if options[:through]
-          many_to_many(target, **options)
+          many_to_many(target, **options, inflector: inflector)
         else
-          add(::ROM::Associations::Definitions::OneToMany.new(source, target, **options))
+          add(build(OneToMany, target, options))
         end
       end
       alias_method :has_many, :one_to_many
@@ -88,7 +99,7 @@ module ROM
         if options[:through]
           one_to_one_through(target, **options)
         else
-          add(::ROM::Associations::Definitions::OneToOne.new(source, target, **options))
+          add(build(OneToOne, target, options))
         end
       end
 
@@ -101,7 +112,7 @@ module ROM
       #
       # @api public
       def one_to_one_through(target, **options)
-        add(::ROM::Associations::Definitions::OneToOneThrough.new(source, target, **options))
+        add(build(OneToOneThrough, target, options))
       end
 
       # Establish a many-to-many association
@@ -118,7 +129,7 @@ module ROM
       #
       # @api public
       def many_to_many(target, **options)
-        add(::ROM::Associations::Definitions::ManyToMany.new(source, target, **options))
+        add(build(ManyToMany, target, options))
       end
 
       # Establish a many-to-one association
@@ -135,7 +146,7 @@ module ROM
       #
       # @api public
       def many_to_one(target, **options)
-        add(::ROM::Associations::Definitions::ManyToOne.new(source, target, **options))
+        add(build(ManyToOne, target, options))
       end
 
       # Shortcut for many_to_one which sets alias automatically
@@ -183,6 +194,10 @@ module ROM
 
       private
 
+      def build(definition, target, options)
+        definition.new(source, target, **options, inflector: inflector)
+      end
+
       # @api private
       def add(association)
         key = association.as || association.name
@@ -199,7 +214,7 @@ module ROM
 
       # @api private
       def dataset_name(name)
-        Inflector.pluralize(name).to_sym
+        inflector.pluralize(name).to_sym
       end
     end
   end

--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -29,12 +29,16 @@ module ROM
     attr_reader :notifications
 
     # @api private
+    attr_accessor :inflector
+
+    # @api private
     def initialize(notifications)
       @relation_classes = []
       @command_classes = []
       @mapper_classes = []
       @plugins = []
       @notifications = notifications
+      @inflector = Inflector
     end
 
     # Enable auto-registration for a given setup object
@@ -47,7 +51,7 @@ module ROM
     #
     # @api public
     def auto_registration(directory, **options)
-      auto_registration = AutoRegistration.new(directory, **options)
+      auto_registration = AutoRegistration.new(directory, inflector: inflector, **options)
       auto_registration.relations.map { |r| register_relation(r) }
       auto_registration.commands.map { |r| register_command(r) }
       auto_registration.mappers.map { |r| register_mapper(r) }
@@ -58,21 +62,21 @@ module ROM
     #
     # @api private
     def register_relation(*klasses)
-      klasses.reduce(@relation_classes, :<<)
+      @relation_classes.concat(klasses)
     end
 
     # Mapper sub-classes are being registered with this method during setup
     #
     # @api private
     def register_mapper(*klasses)
-      klasses.reduce(@mapper_classes, :<<)
+      @mapper_classes.concat(klasses)
     end
 
     # Command sub-classes are being registered with this method during setup
     #
     # @api private
     def register_command(*klasses)
-      klasses.reduce(@command_classes, :<<)
+      @command_classes.concat(klasses)
     end
 
     # @api private

--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -21,6 +21,8 @@ module ROM
 
     PathnameType = Types.Constructor(Pathname, &Kernel.method(:Pathname))
 
+    InflectorType = Types.Strict(Dry::Inflector)
+
     DEFAULT_MAPPING = {
       relations: :relations,
       mappers: :mappers,
@@ -50,6 +52,11 @@ module ROM
         }
       ]
     }
+
+    # @!attribute [r] inflector
+    #   @return [Dry::Inflector] String inflector
+    #   @api private
+    option :inflector, type: InflectorType, default: -> { Inflector }
 
     # Load relation files
     #
@@ -84,19 +91,25 @@ module ROM
           case namespace
           when String
             AutoRegistrationStrategies::CustomNamespace.new(
-              namespace: namespace, file: file, directory: directory
+              namespace: namespace,
+              file: file,
+              directory: directory,
+              inflector: inflector
             ).call
           when TrueClass
             AutoRegistrationStrategies::WithNamespace.new(
-              file: file, directory: directory
+              file: file, directory: directory, inflector: inflector
             ).call
           when FalseClass
             AutoRegistrationStrategies::NoNamespace.new(
-              file: file, directory: directory, entity: component_dirs.fetch(entity)
+              file: file,
+              directory: directory,
+              entity: component_dirs.fetch(entity),
+              inflector: inflector
             ).call
           end
 
-        Inflector.constantize(klass_name)
+        inflector.constantize(klass_name)
       end
     end
   end

--- a/lib/rom/setup/auto_registration_strategies/base.rb
+++ b/lib/rom/setup/auto_registration_strategies/base.rb
@@ -2,6 +2,7 @@
 
 require "rom/types"
 require "rom/initializer"
+require "rom/support/inflector"
 
 module ROM
   module AutoRegistrationStrategies
@@ -18,6 +19,11 @@ module ROM
       # @!attribute [r] file
       #   @return [String] Name of a component file
       option :file, type: Types::Strict::String
+
+      # @!attribute [r] inflector
+      #   @return [Dry::Inflector] String inflector
+      #   @api private
+      option :inflector, reader: true, default: -> { Inflector }
     end
   end
 end

--- a/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/custom_namespace.rb
@@ -25,7 +25,7 @@ module ROM
       #
       # @api private
       def call
-        parts = path_arr.map { |part| Inflector.camelize(part) }
+        parts = path_arr.map { |part| inflector.camelize(part) }
         potential = parts.map.with_index do |_, i|
           parts[(i - parts.size)..parts.size]
         end
@@ -66,7 +66,7 @@ module ROM
 
       # @api private
       def ns_const
-        @namespace_constant ||= Inflector.constantize(namespace)
+        @namespace_constant ||= inflector.constantize(namespace)
       end
 
       # @api private

--- a/lib/rom/setup/auto_registration_strategies/no_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/no_namespace.rb
@@ -24,7 +24,7 @@ module ROM
       #
       # @api private
       def call
-        Inflector.camelize(
+        inflector.camelize(
           file.sub(%r{^#{directory}/#{entity}/}, "").sub(EXTENSION_REGEX, "")
         )
       end

--- a/lib/rom/setup/auto_registration_strategies/with_namespace.rb
+++ b/lib/rom/setup/auto_registration_strategies/with_namespace.rb
@@ -20,7 +20,7 @@ module ROM
       #
       # @api private
       def call
-        Inflector.camelize(
+        inflector.camelize(
           file.sub(%r{^#{directory.dirname}/}, "").sub(EXTENSION_REGEX, "")
         )
       end

--- a/lib/rom/setup/finalize.rb
+++ b/lib/rom/setup/finalize.rb
@@ -22,13 +22,14 @@ module ROM
   #
   # @private
   class Finalize
-    attr_reader :gateways, :repo_adapter,
+    attr_reader :gateways, :repo_adapter, :inflector,
                 :relation_classes, :mapper_classes, :mapper_objects,
                 :command_classes, :plugins, :config, :notifications
 
     # @api private
     def initialize(options)
       @gateways = options.fetch(:gateways)
+      @inflector = options.fetch(:inflector)
 
       @relation_classes = options.fetch(:relation_classes)
       @command_classes = options.fetch(:command_classes)
@@ -84,7 +85,8 @@ module ROM
         relation_classes,
         mappers: mappers,
         plugins: global_plugins,
-        notifications: notifications
+        notifications: notifications,
+        inflector: inflector
       ).run!
     end
 
@@ -99,7 +101,13 @@ module ROM
     #
     # @api private
     def load_commands(relations)
-      FinalizeCommands.new(relations, gateways, command_classes, notifications).run!
+      FinalizeCommands.new(
+        relations,
+        gateways,
+        command_classes,
+        notifications: notifications,
+        inflector: inflector
+      ).run!
     end
   end
 end

--- a/lib/rom/setup/finalize/finalize_commands.rb
+++ b/lib/rom/setup/finalize/finalize_commands.rb
@@ -9,6 +9,8 @@ module ROM
     class FinalizeCommands
       attr_reader :notifications
 
+      attr_reader :inflector
+
       # Build command registry hash for provided relations
       #
       # @param [RelationRegistry] relations registry
@@ -16,11 +18,12 @@ module ROM
       # @param [Array] command_classes a list of command subclasses
       #
       # @api private
-      def initialize(relations, gateways, command_classes, notifications)
+      def initialize(relations, gateways, command_classes, **options)
         @relations = relations
         @gateways = gateways
         @command_classes = command_classes
-        @notifications = notifications
+        @inflector = options.fetch(:inflector, Inflector)
+        @notifications = options.fetch(:notifications)
       end
 
       # @return [Hash]
@@ -42,7 +45,13 @@ module ROM
         end
 
         registry = Registry.new
-        compiler = CommandCompiler.new(@gateways, @relations, registry, notifications)
+        compiler = CommandCompiler.new(
+          @gateways,
+          @relations,
+          registry,
+          notifications,
+          inflector: inflector
+        )
 
         @relations.each do |(name, relation)|
           rel_commands = commands.select { |c| c.relation.name == relation.name }

--- a/lib/rom/setup/finalize/finalize_relations.rb
+++ b/lib/rom/setup/finalize/finalize_relations.rb
@@ -3,11 +3,14 @@
 require "rom/constants"
 require "rom/relation_registry"
 require "rom/mapper_registry"
+require "rom/support/inflector"
 
 module ROM
   class Finalize
     class FinalizeRelations
       attr_reader :notifications
+
+      attr_reader :inflector
 
       # Build relation registry of specified descendant classes
       #
@@ -17,12 +20,13 @@ module ROM
       # @param [Array] relation_classes a list of relation descendants
       #
       # @api private
-      def initialize(gateways, relation_classes, notifications:, mappers: nil, plugins: EMPTY_ARRAY)
+      def initialize(gateways, relation_classes, **options)
         @gateways = gateways
         @relation_classes = relation_classes
-        @mappers = mappers
-        @plugins = plugins
-        @notifications = notifications
+        @inflector = options.fetch(:inflector, Inflector)
+        @mappers = options.fetch(:mappers, nil)
+        @plugins = options.fetch(:plugins, EMPTY_ARRAY)
+        @notifications = options.fetch(:notifications)
       end
 
       # @return [Hash]
@@ -103,7 +107,13 @@ module ROM
           dataset: dataset, relation: klass, adapter: klass.adapter
         )
 
-        options = {__registry__: registry, mappers: mapper_registry(rel_key, klass), schema: schema, **plugin_options}
+        options = {
+          __registry__: registry,
+          mappers: mapper_registry(rel_key, klass),
+          schema: schema,
+          inflector: inflector,
+          **plugin_options
+        }
 
         klass.new(dataset, **options)
       end

--- a/lib/rom/struct_compiler.rb
+++ b/lib/rom/struct_compiler.rb
@@ -17,7 +17,10 @@ module ROM
     extend Initializer
 
     param :registry, default: -> { Dry::Types }
+
     option :cache, default: -> { Cache.new }
+
+    option :inflector, reader: true, default: -> { Inflector }
 
     # @api private
     def initialize(*)
@@ -105,7 +108,7 @@ module ROM
 
     # @api private
     def class_name(name)
-      Inflector.classify(name)
+      inflector.classify(name)
     end
   end
 end

--- a/spec/fixtures/xml_space/xml_commands/create_customer.rb
+++ b/spec/fixtures/xml_space/xml_commands/create_customer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module XMLSpace
+  module XMLCommands
+    class CreateCustomer
+    end
+  end
+end

--- a/spec/fixtures/xml_space/xml_mappers/customer_list.rb
+++ b/spec/fixtures/xml_space/xml_mappers/customer_list.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module XMLSpace
+  module XMLMappers
+    class CustomerList
+    end
+  end
+end

--- a/spec/fixtures/xml_space/xml_relations/customers.rb
+++ b/spec/fixtures/xml_space/xml_relations/customers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module XMLSpace
+  module XMLRelations
+    class Customers
+    end
+  end
+end

--- a/spec/unit/rom/configuration_spec.rb
+++ b/spec/unit/rom/configuration_spec.rb
@@ -80,4 +80,16 @@ RSpec.describe ROM::Configuration do
       expect(conf.relation_classes(:custom)).to eql([rel_custom])
     end
   end
+
+  describe "setting inflector" do
+    example "is supported" do
+      inflector = double(:inflector)
+
+      configuration = ROM::Configuration.new(:memory, "something") do |conf|
+        conf.inflector = inflector
+      end
+
+      expect(configuration.inflector).to be(inflector)
+    end
+  end
 end

--- a/spec/unit/rom/schema/associations_dsl_spec.rb
+++ b/spec/unit/rom/schema/associations_dsl_spec.rb
@@ -3,9 +3,12 @@
 require "rom/schema/associations_dsl"
 
 RSpec.describe ROM::Schema::AssociationsDSL do
+  let(:args) { [ROM::Relation::Name[:users]] }
+
   subject(:dsl) do
-    ROM::Schema::AssociationsDSL.new(ROM::Relation::Name[:users]) do
+    ROM::Schema::AssociationsDSL.new(*args) do
       has_many :posts
+      has_many :labels, through: :posts
     end
   end
 
@@ -15,6 +18,22 @@ RSpec.describe ROM::Schema::AssociationsDSL do
 
       expect(association_set.type).to eql("ROM::AssociationSet[:users]")
       expect(association_set.key?(:posts)).to be(true)
+    end
+
+    context "using custom inflector" do
+      let(:inflector) do
+        Dry::Inflector.new do |i|
+          i.singular("labels", "tag")
+        end
+      end
+
+      let(:args) { [*super(), inflector] }
+
+      it do
+        association_set = dsl.call
+        expect(association_set.type).to eql("ROM::AssociationSet[:users]")
+        expect(association_set[:labels].options[:through].assoc_name).to eql(:tag)
+      end
     end
   end
 end

--- a/spec/unit/rom/setup/auto_registration_spec.rb
+++ b/spec/unit/rom/setup/auto_registration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ROM::Setup, "#auto_registration" do
   let(:notifications) { instance_double(ROM::Notifications::EventBus) }
 
   after do
-    %i[Persistence Users CreateUser UserList My].each do |const|
+    %i[Persistence Users CreateUser UserList My XMLSpace].each do |const|
       Object.send(:remove_const, const) if Object.const_defined?(const)
     end
 
@@ -234,6 +234,44 @@ RSpec.describe ROM::Setup, "#auto_registration" do
         describe "#mappers" do
           it "loads files and returns constants" do
             expect(setup.mapper_classes).to eql([My::Namespace::UserList])
+          end
+        end
+      end
+
+      context "when custom inflector" do
+        let(:inflector) do
+          Dry::Inflector.new do |i|
+            i.acronym("XML")
+          end
+        end
+
+        before do
+          setup.inflector = inflector
+          setup.auto_registration(
+            SPEC_ROOT.join("fixtures/xml_space"),
+            component_dirs: {
+              relations: :xml_relations,
+              mappers: :xml_mappers,
+              commands: :xml_commands
+            }
+          )
+        end
+
+        describe "#relations" do
+          it "loads files and returns constants" do
+            expect(setup.relation_classes).to eql([XMLSpace::XMLRelations::Customers])
+          end
+        end
+
+        describe "#commands" do
+          it "loads files and returns constants" do
+            expect(setup.command_classes).to eql([XMLSpace::XMLCommands::CreateCustomer])
+          end
+        end
+
+        describe "#mappers" do
+          it "loads files and returns constants" do
+            expect(setup.mapper_classes).to eql([XMLSpace::XMLMappers::CustomerList])
           end
         end
       end


### PR DESCRIPTION
All components that rely on inflector use an injected inflector now rather than using a global `ROM::Inflector`. This makes it possible to configure a custom inflector like that:

```ruby
configuration = ROM::Configuration.new(:memory, "something") do |conf|
  conf.inflector = my_custom_inflector
end
```
