### PR TITLE
[changeset] fix binding map functions in Changeset::Update

### DIFF
--- a/changeset/lib/rom/changeset/pipe.rb
+++ b/changeset/lib/rom/changeset/pipe.rb
@@ -41,7 +41,10 @@ module ROM
 
       def bind(context)
         if processor.is_a?(Proc)
-          new(self.class[-> *args { context.instance_exec(*args, &processor) }])
+          bound_processor = self[-> *args { context.instance_exec(*args, &processor) }]
+          bound_diff_processor = self[-> *args { context.instance_exec(*args, &diff_processor) }]
+
+          new(bound_processor, diff_processor: bound_diff_processor)
         else
           self
         end


### PR DESCRIPTION
`map` blocks defined in `ROM::Changeset::Update` subclasses should be evaluated in the context of that changeset's _instance_, however, since the changes in https://github.com/rom-rb/rom/commit/d742f608958a5a6391f53165736f325a64d0066b, they're evaluated in the context of the changeset _class_.

This breaks ROM's documented behaviour and has caused some issues in an application I help with, which depends on the previous (non-broken) behaviour.

Of the 2 tests added here, only the test using an `Update` subclass fails, indicating that this behaviour is somehow specific to changesets using that superclass only.