### PR TITLE
Require plugins in repository

### DIFF
--- a/repository/lib/rom/repository.rb
+++ b/repository/lib/rom/repository.rb
@@ -4,6 +4,7 @@ require 'dry/core/cache'
 require 'dry/core/class_attributes'
 
 require 'rom/initializer'
+require 'rom/plugins'
 require 'rom/struct'
 require 'rom/container'
 require 'rom/repository/class_interface'


### PR DESCRIPTION
If rom/repository is required directly, the `ROM::Plugins` namespace
might not exist yet.

Easily reproduced from the command line:

```
user@ef8029912cf4:/opt/rom/repository$ ruby -rbundler/setup -rrom/repository -e true
Traceback (most recent call last):
        1: from -e:in `require'
/opt/rom/repository/lib/rom/repository.rb:12:in `<top (required)>': uninitialized constant ROM::Plugins (NameError)
```
Closes #598