### PR TITLE
Sort files before loading at auto-registration

### DIFF
--- a/lib/rom/setup/auto_registration.rb
+++ b/lib/rom/setup/auto_registration.rb
@@ -85,7 +85,7 @@ module ROM
     #
     # @api private
     def load_entities(entity)
-      Dir[globs[entity]].map do |file|
+      Dir[globs[entity]].sort.map do |file|
         require file
         klass_name =
           case namespace


### PR DESCRIPTION
`Dir.glob` doesn't guarantee the order of listed files.
It is inconvenient and leads random fails on different platforms in different environments: development, CI, production etc.

It is recommended to sort required files listed by `Dir.glob`:
- [Rubocop](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/lint/non_deterministic_require_order.rb)
- [Ruby 3](https://github.com/ruby/ruby/pull/2846/files)