### PR TITLE
Replace references to transproc by dry-transformer

### DIFF
--- a/docsite/changeset/source/mapping.html.md
+++ b/docsite/changeset/source/mapping.html.md
@@ -6,7 +6,7 @@ title: Mapping
 
 Changesets have an extendible data-pipe mechanism available via `Changeset.map` (for preconfigured mapping) and `Changeset#map` (for on-demand run-time mapping).
 
-Changeset mappings support all transformation functions from [transproc](https://github.com/solnic/transproc) project, and in addition to that we have:
+Changeset mappings support all transformation functions from [dry-transformer](https://dry-rb.org/gems/dry-transformer) project, and in addition to that we have:
 
 * `:add_timestamps`–sets `created_at` and `updated_at` timestamps (don't forget to add those fields to the table in case of using `rom-sql`)
 * `:touch`–sets `updated_at` timestamp

--- a/docsite/core/source/mappers.html.md
+++ b/docsite/core/source/mappers.html.md
@@ -60,7 +60,7 @@ With a custom mapper configured, you can use `Relation#map_with` interface to se
 users.map_with(:my_mapper).to_a
 ```
 
-`ROM::Transformer` is powered by [transproc](https://github.com/solnic/transproc#transformer).
+`ROM::Transformer` is powered by [dry-transformer](https://dry-rb.org/gems/dry-transformer).
 
 ## Learn more
 

--- a/lib/rom/changeset/pipe_registry.rb
+++ b/lib/rom/changeset/pipe_registry.rb
@@ -5,7 +5,7 @@ require "dry/transformer/registry"
 
 module ROM
   class Changeset
-    # Transproc Registry useful for pipe
+    # Dry::Transformer Registry useful for pipe
     #
     # @api private
     module PipeRegistry

--- a/lib/rom/processor/transformer.rb
+++ b/lib/rom/processor/transformer.rb
@@ -355,7 +355,7 @@ module ROM
 
       # Build row_proc
       #
-      # This transproc function is applied to each row in a dataset
+      # This dry-transformer function is applied to each row in a dataset
       #
       # @api private
       def initialize_row_proc


### PR DESCRIPTION
`transproc` was replaced by `dry-transformer`, but there were still some references to it left in the docs.