### PR TITLE
Fix links to components in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ the full power of your database.
 
 Main rom gem provides following components:
 
-* [core](https://github.com/rom-rb/rom/blob/master/docsite/core/source/index.html.md) - Core and Adapter APIs
-* [changeset](https://github.com/rom-rb/rom/blob/master/docsite/changeset/source/index.html.md) - Changeset objects integrated with rom-core
-* [repository](https://github.com/rom-rb/rom/blob/master/docsite/repository/source/index.html.md) - Additional repository abstraction integrated with rom-core
+* [core](https://rom-rb.org/learn/core/5.2/) - Core and Adapter APIs
+* [changeset](https://rom-rb.org/learn/changeset/5.2/) - Changeset objects integrated with rom-core
+* [repository](https://rom-rb.org/learn/repository/5.2/) - Additional repository abstraction integrated with rom-core
 
 Learn more:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ the full power of your database.
 
 Main rom gem provides following components:
 
-* [core](https://github.com/rom-rb/rom/blob/master/core/README.md) - Core and Adapter APIs
-* [changeset](https://github.com/rom-rb/rom/blob/master/changeset/README.md) - Changeset objects integrated with rom-core
-* [repository](https://github.com/rom-rb/rom/blob/master/repository/README.md) - Additional repository abstraction integrated with rom-core
+* [core](https://github.com/rom-rb/rom/blob/master/docsite/core/source/index.html.md) - Core and Adapter APIs
+* [changeset](https://github.com/rom-rb/rom/blob/master/docsite/changeset/source/index.html.md) - Changeset objects integrated with rom-core
+* [repository](https://github.com/rom-rb/rom/blob/master/docsite/repository/source/index.html.md) - Additional repository abstraction integrated with rom-core
 
 Learn more:
 


### PR DESCRIPTION
Hey, it seems like you restructured the repo - when I clicked on the links, I received 404s.

I _assume_ the links should point to these pages, but please ensure I guessed you intention correctly.

Once you confirm that, I could also fix the links on these _index.html.md_ pages.