### PR TITLE
Improve plugin setup

### DIFF
--- a/lib/rom/components/core.rb
+++ b/lib/rom/components/core.rb
@@ -72,7 +72,7 @@ module ROM
         )
       end
 
-      # @api public
+      # @api private
       def apply_plugins
         plugins.each do |plugin|
           plugin.apply_to(constant)

--- a/lib/rom/plugin_registry.rb
+++ b/lib/rom/plugin_registry.rb
@@ -13,8 +13,12 @@ module ROM
     attr_reader :types
 
     # @api private
+    attr_reader :mods
+
+    # @api private
     def initialize
       @types = ::Concurrent::Map.new
+      @mods = []
     end
 
     # Register a plugin for future use
@@ -27,6 +31,7 @@ module ROM
     # @option options [Symbol] :adapter (:default) which adapter this plugin
     # applies to. Leave blank for all adapters
     def register(name, mod, options = EMPTY_HASH)
+      mods << mod
       type(options.fetch(:type)).register(name, mod, options)
     end
 

--- a/spec/shared/changeset/database.rb
+++ b/spec/shared/changeset/database.rb
@@ -15,7 +15,11 @@ end
 RSpec.shared_context "changeset / database setup" do
   include_context "changeset / db_uri"
 
-  let(:configuration) { ROM::Configuration.new(:sql, db_uri) }
+  let(:configuration) do
+    ROM::Configuration.new(:sql, db_uri) do |config|
+      config.plugin(:sql, relation: :auto_restrictions)
+    end
+  end
 
   let(:conn) { configuration.gateways[:default].connection }
 

--- a/spec/shared/repository/database.rb
+++ b/spec/shared/repository/database.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rom/sql"
 RSpec.shared_context "repository / db_uri" do
   let(:base_db_uri) do
     ENV.fetch("BASE_DB_URI", "postgres@localhost/rom")
@@ -14,7 +15,9 @@ RSpec.shared_context "repository / database setup" do
   include_context "repository / db_uri"
 
   let(:configuration) do
-    ROM::Configuration.new(:sql, db_uri)
+    ROM::Configuration.new(:sql, db_uri) do |config|
+      config.plugin(:sql, relation: :auto_restrictions)
+    end
   end
 
   let(:conn) do


### PR DESCRIPTION
Trigger listeners only for enabled plugin
    
Previously any plugin that would subscribe to notifications would be
always triggered, which made it impossible to isolate plugin configs