### PR TITLE
1st class schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ if ENV["USE_DRY_INITIALIZER_MASTER"].eql?("true")
   gem "dry-initializer", github: "dry-rb/dry-initializer", branch: "master"
 end
 
-gem "rom-sql", github: "rom-rb/rom-sql", branch: "master"
+gem "rom-sql", github: "rom-rb/rom-sql", branch: "update-to-rom6"
 
 gem "dry-core", github: "dry-rb/dry-core", branch: "master"
 gem "dry-monitor", github: "dry-rb/dry-monitor", branch: "master"

--- a/lib/rom/compat.rb
+++ b/lib/rom/compat.rb
@@ -21,14 +21,18 @@ module ROM
     class Relation < Core
       undef :id
 
+      def default_name
+        if constant.respond_to?(:default_name)
+          constant.default_name
+        else
+          ROM::Relation::Name[Inflector.underscore(constant.name)]
+        end
+      end
+
       def id
         return options[:id] if options[:id]
 
-        if constant.respond_to?(:relation_name)
-          constant.relation_name
-        else
-          Inflector.underscore(constant.name)
-        end.to_sym
+        default_name.relation
       end
     end
 

--- a/lib/rom/components.rb
+++ b/lib/rom/components.rb
@@ -36,6 +36,7 @@ module ROM
       attr_reader :handlers
 
       DUPLICATE_ERRORS = {
+        schemas: RelationAlreadyDefinedError,
         relations: RelationAlreadyDefinedError,
         commands: CommandAlreadyDefinedError,
         mappers: MapperAlreadyDefinedError

--- a/lib/rom/components/core.rb
+++ b/lib/rom/components/core.rb
@@ -142,7 +142,7 @@ module ROM
 
       # @api private
       def gateway_name
-        relation.gateway
+        options[:gateway] || relation.gateway
       end
     end
   end

--- a/lib/rom/components/relation.rb
+++ b/lib/rom/components/relation.rb
@@ -8,16 +8,24 @@ module ROM
     class Relation < Core
       id :relation
 
+      # @!attribute [r] name
+      #   @return [Symbol] Relation name
+      option :name, type: Types.Instance(ROM::Relation::Name), default: -> { default_name }
+
       # Registry id
       #
       # @return [Symbol]
       #
       # @api public
       def id
-        # TODO: this could go away already
-        options[:id] || constant.relation_name.to_sym
+        options[:id] || name.relation
       end
       alias_method :relation_id, :id
+
+      # @api private
+      def default_name
+        constant.default_name
+      end
 
       # Registry namespace
       #
@@ -32,21 +40,28 @@ module ROM
       #
       # @api public
       def build
-        # TODO: this should become a built-in feature, no neeed to use a plugin
-        constant.use(:registry_reader, relations: components.relations.map(&:id).uniq)
+        constant.use(:registry_reader, relations: components.relations.map(&:id))
 
         trigger("relations.class.ready", relation: constant, adapter: adapter)
 
-        # schema must be established prior applying plugins because they may
-        # depend on the schema
-        schema = finalize_schema
-
         apply_plugins
 
-        trigger("relations.dataset.allocated", dataset: dataset, relation: constant,
-                                               adapter: adapter)
+        payload = {
+          schema: schema,
+          adapter: adapter,
+          gateway: gateway,
+          relation: constant,
+          registry: relations
+        }
 
-        relation = constant.new(dataset, **relation_options(schema))
+        trigger("relations.schema.set", payload)
+
+        trigger(
+          "relations.dataset.allocated",
+          dataset: dataset, relation: constant, schema: schema, adapter: adapter
+        )
+
+        relation = constant.new(dataset, **relation_options)
 
         trigger("relations.object.registered", registry: relations, relation: relation)
 
@@ -56,24 +71,26 @@ module ROM
       private
 
       # @api private
-      memoize def dataset
-        gateway.dataset(constant.relation_name.dataset).instance_exec(constant, &constant.dataset)
+      memoize def schema
+        component = components.schemas(id: name.dataset).first
+        component.build
       end
 
       # @api private
-      def relation_options(schema)
+      memoize def dataset
+        gateway.dataset(name.dataset).instance_exec(schema, &constant.dataset)
+      end
+
+      # @api private
+      def relation_options
         {__registry__: relations,
+         name: name,
          schema: schema,
          inflector: inflector,
+         schemas: configuration.schemas,
          mappers: configuration.mappers.new(id, adapter: adapter),
          commands: configuration.commands.new(id, adapter: adapter),
          **plugin_options}
-      end
-
-      # @api private
-      def finalize_schema
-        # TODO: relation DSL auto-defines an empty schema so this is a workaround
-        components.schemas(relation: constant).last.build
       end
     end
   end

--- a/lib/rom/components/schema.rb
+++ b/lib/rom/components/schema.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rom/relation/name"
 require_relative "core"
 
 module ROM
@@ -8,55 +9,103 @@ module ROM
     class Schema < Core
       id :schema
 
-      # @!attribute [r] proc
-      #   @return [Class] A proc for evaluation via schema DSL
-      #   @api public
-      option :proc, type: Types.Interface(:call)
+      # @!attribute [r] id
+      #   @return [Symbol] Registry local id
+      option :id, type: Types::Strict::Symbol
 
-      # @!attribute [r] relation
-      #   @return [Class] A relation class
-      #   @api public
-      option :relation, type: Types.Instance(Class)
+      # @!attribute [r] view
+      #   @return [Symbol]
+      option :view, type: Types::Strict::Bool.default(false)
+
+      # @!attribute [r] name
+      #   @return [Symbol] Relation name
+      option :name, type: Types.Instance(ROM::Relation::Name)
+
+      # @!attribute [r] gateway_name
+      #   @return [Symbol] Gateway identifier
+      option :gateway_name, optional: true, type: Types::Strict::Symbol
+
+      # @!attribute [r] adapter
+      #   @return [Symbol] Adapter identifier
+      option :adapter, optional: true, type: Types::Strict::Symbol
+
+      # @!attribute [r] infer
+      #   @return [Boolean] A proc for evaluation via schema DSL
+      option :infer, optional: true, type: Types::Strict::Bool.default(false)
+
+      # @!attribute [r] block
+      #   @return [Class] A proc for evaluation via schema DSL
+      option :block, type: Types.Interface(:call)
+
+      # @!attribute [r] dsl_class
+      #   @return [Class] The DSL class
+      option :dsl_class, optional: true
+
+      # @!attribute [r] attr_class
+      #   @return [Class] Schema's DSL attribute class
+      option :attr_class, optional: true
+
+      # @!attribute [r] relation_class
+      #   @return [Class]
+      option :relation_class, type: Types.Instance(Class)
+
+      # @!attribute [r] inferrer
+      #   @return [Inferrer] Schema's inferrer
+      option :inferrer, optional: true, reader: false
 
       # @api public
       def namespace
         "schemas"
       end
 
+      # @api private
+      def canonical_schema
+        id = components.schemas(relation_class: relation_class).first.id
+        configuration.schemas[id]
+      end
+
       # @api public
       def build
-        plugins = self.plugins
+        if view?
+          canonical_schema.instance_eval(&block)
+        else
+          plugins = self.plugins
 
-        schema = proc.call do
-          # This is evaluated using Schema::DSL where app_plugin is defined
-          plugins.each { |plugin| app_plugin(plugin) }
+          schema = dsl.call(inflector: inflector) do
+            plugins.each { |plugin| app_plugin(plugin) }
+          end
+
+          schema.finalize_attributes!(gateway: gateway, relations: relations)
+          schema.finalize_associations!(relations: relations)
+          schema.finalize!
         end
-
-        payload = {
-          schema: schema,
-          adapter: adapter,
-          gateway: gateway,
-          relation: relation,
-          registry: relations
-        }
-
-        schema.finalize_attributes!(gateway: gateway, relations: relations)
-        schema.finalize_associations!(relations: relations)
-        schema.finalize!
-
-        trigger("relations.schema.allocated", payload)
-
-        # TODO: it would be great if we could remove setting schemas as a class ivar
-        relation.set_schema!(schema)
-
-        trigger("relations.schema.set", payload)
-
-        schema
       end
 
       # @api private
-      def call(**opts)
-        proc.call(**opts)
+      def gateway
+        gateways[gateway_name] if gateways.key?(gateway_name)
+      end
+
+      # @api private
+      def dsl(**opts)
+        dsl_class.new(name, **dsl_options, **opts, &block)
+      end
+
+      # @api private
+      def view?
+        view.equal?(true)
+      end
+
+      private
+
+      # @api private
+      def dsl_options
+        {schema_class: constant, attr_class: attr_class, inferrer: inferrer}
+      end
+
+      # @api private
+      def inferrer
+        options[:inferrer].with(enabled: infer)
       end
     end
   end

--- a/lib/rom/configuration_dsl.rb
+++ b/lib/rom/configuration_dsl.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rom/relation/name"
 require "rom/configuration_dsl/relation"
 require "rom/configuration_dsl/command_dsl"
 require "rom/configuration_dsl/mapper_dsl"
@@ -21,10 +22,20 @@ module ROM
     # @api public
     def relation(name, options = EMPTY_HASH, &block)
       klass_opts = {adapter: default_adapter}.merge(options)
+
       klass = Relation.build_class(name, klass_opts)
       klass.schema_opts(dataset: name, relation: name)
-      klass.class_eval(&block) if block
-      register_relation(klass, id: name)
+
+      if block
+        klass.class_eval(&block)
+      end
+
+      if klass.components.schemas.empty?
+        klass.schema(name) {}
+      end
+
+      register_relation(klass, name: klass.components.schemas.first.name)
+
       klass
     end
 

--- a/lib/rom/configuration_dsl/relation.rb
+++ b/lib/rom/configuration_dsl/relation.rb
@@ -22,7 +22,6 @@ module ROM
         Dry::Core::ClassBuilder.new(name: class_name,
                                     parent: ROM::Relation[adapter]).call do |klass|
           klass.gateway(options.fetch(:gateway, :default))
-          klass.schema(name) {}
         end
       end
     end

--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -21,6 +21,7 @@ module ROM
 
   EnvAlreadyFinalizedError = Class.new(StandardError)
   GatewayAlreadyDefinedError = Class.new(StandardError)
+  SchemaAlreadyDefinedError = Class.new(StandardError)
   RelationAlreadyDefinedError = Class.new(StandardError)
   CommandAlreadyDefinedError = Class.new(StandardError)
   MapperAlreadyDefinedError = Class.new(StandardError)
@@ -58,6 +59,8 @@ module ROM
   end
 
   GatewayMissingError = Class.new(ElementNotFoundError)
+
+  SchemaMissingError = Class.new(ElementNotFoundError)
 
   RelationMissingError = Class.new(ElementNotFoundError)
 

--- a/lib/rom/container.rb
+++ b/lib/rom/container.rb
@@ -112,9 +112,6 @@ module ROM
 
         container.register(:configuration, runtime_config)
         container.register(:gateways, runtime_config.gateways)
-        container.register(:relations, Runtime::Resolver.new(:relations, configuration: runtime_config))
-        container.register(:mappers, Runtime::Resolver.new(:mappers, configuration: runtime_config))
-        container.register(:commands, Runtime::Resolver.new(:commands, configuration: runtime_config))
       end
     end
 
@@ -133,7 +130,7 @@ module ROM
     #
     # @api public
     def mappers
-      self[:mappers]
+      self[:configuration].mappers
     end
 
     # Return relation registry
@@ -142,7 +139,7 @@ module ROM
     #
     # @api public
     def relations
-      self[:relations]
+      self[:configuration].relations
     end
 
     # Return command registry
@@ -151,7 +148,7 @@ module ROM
     #
     # @api public
     def commands
-      self[:commands]
+      self[:configuration].commands
     end
 
     # Disconnect all gateways

--- a/lib/rom/plugins/relation/registry_reader.rb
+++ b/lib/rom/plugins/relation/registry_reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rom/constants"
+require "rom/runtime/resolver"
 
 module ROM
   module Plugins
@@ -27,7 +28,7 @@ module ROM
           super
           return if klass.instance_methods.include?(:__registry__)
 
-          klass.option :__registry__, default: -> { EMPTY_REGISTRY }
+          klass.option :__registry__, default: -> { Runtime::Resolver.new(:relations) }
         end
 
         private

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -29,6 +29,12 @@ module ROM
         relations schema
       ].freeze
 
+      # @api private
+      def inherited(klass)
+        super
+        klass.instance_variable_set("@dataset", dataset) if dataset
+      end
+
       # Return adapter-specific relation subclass
       #
       # @example
@@ -56,7 +62,7 @@ module ROM
       #
       # @api public
       def dataset(&block)
-        if defined?(@dataset)
+        if defined?(@dataset) && !block
           @dataset
         else
           @dataset = block || DEFAULT_DATASET_PROC

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -23,19 +23,8 @@ module ROM
 
       include Components
 
-      subscribe("configuration.relations.object.registered") do |event|
-        relation = event[:relation]
-        registry = event[:registry]
-
-        schemas = relation.schemas.reduce({}) do |h, (a, e)|
-          h.update(a => e.is_a?(Proc) ? relation.class.instance_exec(registry, &e) : e)
-        end
-
-        relation.schemas.update(schemas)
-        relation
-      end
-
       DEFAULT_DATASET_PROC = -> * { self }.freeze
+
       INVALID_RELATIONS_NAMES = %i[
         relations schema
       ].freeze
@@ -94,12 +83,16 @@ module ROM
       #
       # @param [Symbol] dataset An optional dataset name
       # @param [Boolean] infer Whether to do an automatic schema inferring
+      # @param [Boolean, Symbol] view Whether this is a view schema
       #
       # @api public
-      def schema(dataset = nil, as: nil, infer: false, &block)
-        if defined?(@schema) && !block && !infer
-          @schema
-        elsif block || infer
+      def schema(dataset = nil, as: nil, infer: false, view: false, &block)
+        if view
+          components.add(
+            :schemas,
+            id: view, view: true, name: Name[view], relation_class: self, block: block
+          )
+        else
           raise MissingSchemaClassError, self unless schema_class
 
           ds_name = dataset || schema_opts.fetch(:dataset, default_name.dataset)
@@ -107,42 +100,24 @@ module ROM
 
           raise InvalidRelationName, relation if invalid_relation_name?(relation)
 
-          # TODO: such legacy very wow - this should be removed eventually
-          @relation_name = Name[relation, ds_name]
+          name = Name[relation, ds_name]
 
-          schema_proc = proc do |**kwargs, &inner_block|
-            schema_dsl.new(
-              relation_name,
-              schema_class: schema_class,
-              attr_class: schema_attr_class,
-              inferrer: schema_inferrer.with(enabled: infer),
-              &block
-            ).call(**kwargs, &inner_block)
-          end
-
-          # TODO: remove this eventually. Schemas are now evaluated using components
-          #       during finalization, storing schema_proc is no longer needed
-          @schema_proc = components.add(:schemas, id: relation, proc: schema_proc, relation: self)
+          components.add(
+            :schemas,
+            id: name.dataset,
+            name: name,
+            infer: infer,
+            view: view,
+            constant: schema_class,
+            relation_class: self,
+            dsl_class: schema_dsl,
+            attr_class: schema_attr_class,
+            inferrer: schema_inferrer,
+            adapter: adapter,
+            gateway_name: gateway,
+            block: block
+          )
         end
-      end
-      # @api private
-      attr_reader :schema_proc
-
-      # Assign a schema to a relation class
-      #
-      # @param [Schema] schema
-      #
-      # @return [Schema]
-      #
-      # @api private
-      def set_schema!(schema)
-        @schema = schema
-      end
-
-      # TODO: this could be deprecated / moved to rom/compat
-      # @return [Name] Qualified relation name
-      def relation_name
-        @relation_name || Name[Inflector.underscore(Inflector.demodulize(name)).to_sym]
       end
 
       # Define a relation view with a specific schema
@@ -199,19 +174,21 @@ module ROM
           raise ArgumentError, "schema attribute names must be provided as the second argument"
         end
 
-        name, new_schema_fn, relation_block =
+        name, schema_block, relation_block =
           if args.size == 1
-            ViewDSL.new(*args, schema, &block).call
+            ViewDSL.new(*args, &block).call
           else
             [*args, block]
           end
 
-        schemas[name] =
+        block =
           if args.size == 2
             -> _ { schema.project(*args[1]) }
           else
-            new_schema_fn
+            schema_block
           end
+
+        schema(view: name, &block)
 
         if relation_block.arity > 0
           auto_curry_guard do
@@ -265,6 +242,7 @@ module ROM
         Curried
       end
 
+      # TODO: move to rom/compat
       # @api private
       def view_methods
         ancestor_methods = ancestors.reject { |klass| klass == self }
@@ -273,9 +251,10 @@ module ROM
         instance_methods - ancestor_methods + auto_curried_methods.to_a
       end
 
-      # @api private
-      def schemas
-        @schemas ||= {}
+      # TODO: this could be deprecated / moved to rom/compat
+      # @return [Name] Qualified relation name
+      def relation_name
+        default_name
       end
 
       # Return default relation name used in schemas
@@ -284,17 +263,21 @@ module ROM
       #
       # @api private
       def default_name(inflector = Inflector)
-        Name[inflector.underscore(name).tr("/", "_").to_sym]
+        if (schema = components.schemas.first)
+          schema.name
+        else
+          Name[inflector.underscore(name).tr("/", "_").to_sym]
+        end
       end
 
       # @api private
-      def default_schema(klass = self, inflector: Inflector)
-        klass.schema ||
-          if (schema_comp = klass.components.schemas.detect { |c| c.relation == klass })
-            klass.set_schema!(schema_comp.(inflector: inflector))
-          else
-            klass.schema_class.define(klass.default_name)
-          end
+      def default_schema
+        components.schemas.first.build
+      end
+
+      # @api private
+      def default_dataset_name(inflector = Inflector)
+        inflector.underscore(inflector.demodulize(name)).tr("/", "_").to_sym
       end
 
       # @api private
@@ -304,6 +287,7 @@ module ROM
 
       private
 
+      # @api private
       def invalid_relation_name?(relation)
         INVALID_RELATIONS_NAMES.include?(relation.to_sym)
       end

--- a/lib/rom/relation/view_dsl.rb
+++ b/lib/rom/relation/view_dsl.rb
@@ -21,13 +21,12 @@ module ROM
 
       # @!attribute [r] new_schema
       #   @return [Proc] The schema proc returned by the schema DSL
-      attr_reader :new_schema
+      attr_reader :schema_block
 
       # @api private
-      def initialize(name, schema, &block)
+      def initialize(name, &block)
         @name = name
-        @schema = schema
-        @new_schema = nil
+        @schema_block = nil
         @relation_block = nil
         instance_eval(&block)
       end
@@ -40,7 +39,7 @@ module ROM
       #
       # @api public
       def schema(&block)
-        @new_schema = -> relations { @schema.with(relations: relations).instance_exec(&block) }
+        @schema_block = block
       end
 
       # Define a relation block for a relation view
@@ -60,7 +59,7 @@ module ROM
       #
       # @api private
       def call
-        [name, new_schema, relation_block]
+        [name, schema_block, relation_block]
       end
     end
   end

--- a/spec/integration/relations/default_dataset_spec.rb
+++ b/spec/integration/relations/default_dataset_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ROM::Relation, ".dataset" do
 
   it "injects configured dataset when block was provided" do
     configuration.relation(:users) do
-      dataset do |_klass|
+      dataset do
         insert(id: 2, name: "Joe")
         insert(id: 1, name: "Jane")
 
@@ -18,7 +18,7 @@ RSpec.describe ROM::Relation, ".dataset" do
     expect(container.relations[:users].to_a).to eql([{id: 1, name: "Jane"}])
   end
 
-  it "yields relation class for setting custom dataset proc" do
+  it "yields schema for setting custom dataset proc" do
     configuration.relation(:users) do
       schema(:users) do
         attribute :id, ROM::Memory::Types::Integer.meta(primary_key: true)

--- a/spec/integration/relations/default_dataset_spec.rb
+++ b/spec/integration/relations/default_dataset_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe ROM::Relation, ".dataset" do
         attribute :name, ROM::Memory::Types::String
       end
 
-      dataset do |rel_klass|
+      dataset do |schema|
         insert(id: 2, name: "Joe")
         insert(id: 1, name: "Jane")
 
-        order(*rel_klass.schema.primary_key.map(&:name))
+        order(*schema.primary_key.map(&:name))
       end
     end
 

--- a/spec/unit/rom/relation/attribute_reader_spec.rb
+++ b/spec/unit/rom/relation/attribute_reader_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ROM::Relation, "#[]" do
 
     relation = Test::Users.new([])
 
-    expect(relation[:id]).to be(Test::Users.schema[:id])
-    expect(relation[:name]).to be(Test::Users.schema[:name])
+    expect(relation[:id]).to be(relation.schema[:id])
+    expect(relation[:name]).to be(relation.schema[:name])
   end
 end

--- a/spec/unit/rom/relation/class_interface/relation_name_spec.rb
+++ b/spec/unit/rom/relation/class_interface/relation_name_spec.rb
@@ -2,7 +2,7 @@
 
 require "rom/relation"
 
-RSpec.describe ROM::Relation, ".relation_name" do
+RSpec.describe ROM::Relation, ".default_name" do
   context "when schema is defined" do
     subject(:relation_class) do
       Class.new(ROM::Relation) do
@@ -24,7 +24,7 @@ RSpec.describe ROM::Relation, ".relation_name" do
         end
       end
 
-      expect(Test::Users.relation_name.to_sym).to eql(:users)
+      expect(Test::Users.default_name.to_sym).to eql(:test_users)
     end
   end
 end

--- a/spec/unit/rom/relation/map_to_spec.rb
+++ b/spec/unit/rom/relation/map_to_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ROM::Relation, "#map_to" do
     ROM::Relation.new(
       dataset,
       name: ROM::Relation::Name[:users],
-      schema: ROM::Relation.default_schema,
       mappers: mappers
     )
   end


### PR DESCRIPTION
Schemas are now part of the runtime, lazy-loaded and configured just
like all other components, and **they are decoupled from relations now**.

This drastically simplified handling
everything that may need access to schemas and further simplifications
are still possible.

This has a temporary breaking change because Relation.dataset receives
a schema now, instead of a relation class. I will restore original
behavior in rom/compat later on in a PR that will improve handling of
the default dataset (this is part of 6.0.0 feature scope).

Apart from lazy-loading, there's another big benefit of this refactor -
relation classes no longer hold their schemas as class variables. This
means that the same relation class can be re-used in the same process in
different configurations. It also means that standard inheritance will
be finally possible.