### PR TITLE
Introduce dataset components

### DIFF
--- a/lib/rom/components/dataset.rb
+++ b/lib/rom/components/dataset.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "core"
+
+module ROM
+  module Components
+    # @api public
+    class Dataset < Core
+      id :dataset
+
+      option :constant, type: Types.Instance(Class)
+      alias_method :relation_class, :constant
+
+      option :block, optional: true, type: Types.Interface(:call)
+
+      # @api public
+      def namespace
+        "datasets"
+      end
+
+      # @api public
+      def id
+        options[:id]
+      end
+
+      # @api public
+      memoize def build
+        datasets.reduce(canonical_dataset) { |dataset, component|
+          if component.block
+            dataset.instance_exec(schema, &component.block)
+          else
+            dataset
+          end
+        }
+      end
+
+      private
+
+      # @api private
+      memoize def canonical_dataset
+        dataset = gateway.dataset(id)
+
+        if block
+          dataset.instance_exec(schema, &block)
+        else
+          dataset
+        end
+      end
+
+      # @api private
+      def schema
+        configuration.schemas[id]
+      end
+
+      # @api private
+      def datasets
+        local_components.datasets(provider: relation_class.superclass)
+      end
+    end
+  end
+end

--- a/lib/rom/components/relation.rb
+++ b/lib/rom/components/relation.rb
@@ -56,12 +56,7 @@ module ROM
 
         trigger("relations.schema.set", payload)
 
-        trigger(
-          "relations.dataset.allocated",
-          dataset: dataset, relation: constant, schema: schema, adapter: adapter
-        )
-
-        relation = constant.new(dataset, **relation_options)
+        relation = constant.new(**relation_options)
 
         trigger("relations.object.registered", registry: relations, relation: relation)
 
@@ -71,14 +66,8 @@ module ROM
       private
 
       # @api private
-      memoize def schema
-        component = components.schemas(id: name.dataset).first
-        component.build
-      end
-
-      # @api private
-      memoize def dataset
-        gateway.dataset(name.dataset).instance_exec(schema, &constant.dataset)
+      def schema
+        configuration.schemas[name.dataset]
       end
 
       # @api private
@@ -87,6 +76,7 @@ module ROM
          name: name,
          schema: schema,
          inflector: inflector,
+         datasets: configuration.datasets,
          schemas: configuration.schemas,
          associations: configuration.associations.new(id, items: schema.associations),
          mappers: configuration.mappers.new(id, adapter: adapter),

--- a/lib/rom/configuration.rb
+++ b/lib/rom/configuration.rb
@@ -5,6 +5,8 @@ require "forwardable"
 require "rom/support/inflector"
 require "rom/support/notifications"
 require "rom/support/configurable"
+
+require "rom/components"
 require "rom/setup"
 require "rom/configuration_dsl"
 
@@ -47,7 +49,11 @@ module ROM
       @notifications = Notifications.event_bus(:configuration)
 
       config.gateways = Config.new
-      @setup = Setup.new(config: config.gateways)
+
+      @setup = Setup.new(
+        components: Components::Registry.new(owner: self),
+        config: config.gateways
+      )
 
       configure(*args, &block)
     end

--- a/lib/rom/configuration_dsl.rb
+++ b/lib/rom/configuration_dsl.rb
@@ -24,7 +24,7 @@ module ROM
       defaults = {inflector: inflector, adapter: default_adapter(options[:gateway])}
 
       klass = Relation.build_class(name, defaults.merge(options))
-      klass.schema_opts(dataset: name, relation: name)
+      klass.schema_opts(dataset: name, relation: name, **options)
 
       if block
         klass.class_eval(&block)

--- a/lib/rom/constants.rb
+++ b/lib/rom/constants.rb
@@ -21,6 +21,7 @@ module ROM
 
   EnvAlreadyFinalizedError = Class.new(StandardError)
   GatewayAlreadyDefinedError = Class.new(StandardError)
+  DatasetAlreadyDefinedError = Class.new(StandardError)
   SchemaAlreadyDefinedError = Class.new(StandardError)
   RelationAlreadyDefinedError = Class.new(StandardError)
   AssociationAlreadyDefinedError = Class.new(StandardError)
@@ -60,6 +61,8 @@ module ROM
   end
 
   GatewayMissingError = Class.new(ElementNotFoundError)
+
+  DatasetMissingError = Class.new(ElementNotFoundError)
 
   SchemaMissingError = Class.new(ElementNotFoundError)
 

--- a/lib/rom/runtime/resolver.rb
+++ b/lib/rom/runtime/resolver.rb
@@ -20,6 +20,7 @@ module ROM
 
       MISSING_ELEMENT_ERRORS = {
         schemas: SchemaMissingError,
+        datasets: DatasetMissingError,
         relations: RelationMissingError,
         associations: RelationMissingError,
         commands: CommandNotFoundError,

--- a/lib/rom/setup.rb
+++ b/lib/rom/setup.rb
@@ -30,12 +30,7 @@ module ROM
     attr_reader :cache
 
     # @api private
-    def initialize(
-      components: Components::Registry.new,
-      auto_register: EMPTY_HASH,
-      cache: Cache.new,
-      config: Configurable::Config.new
-    )
+    def initialize(components:, config:, auto_register: EMPTY_HASH, cache: Cache.new)
       @plugins = []
       @cache = cache
       @config = config

--- a/spec/compat/unit/setup/auto_registration_spec.rb
+++ b/spec/compat/unit/setup/auto_registration_spec.rb
@@ -3,7 +3,12 @@
 require "rom/compat"
 
 RSpec.describe ROM::Setup, "#auto_registration" do
-  subject(:setup) { ROM::Setup.new }
+  subject(:setup) do
+    ROM::Setup.new(
+      components: ROM::Components::Registry.new(owner: self),
+      config: ROM::Configurable::Config.new
+    )
+  end
 
   let!(:loaded_features) { $LOADED_FEATURES.dup }
 

--- a/spec/integration/core/setup_spec.rb
+++ b/spec/integration/core/setup_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Configuring ROM" do
     it "configures rom schema to store relations" do
       users_schema = users_relation.schema
       tasks_schema = tasks_relation.schema
+
       expect(users_schema.relations[:users]).to eql(users_relation)
       expect(tasks_schema.relations[:tasks]).to eql(tasks_relation)
     end

--- a/spec/integration/gateways/extending_relations_spec.rb
+++ b/spec/integration/gateways/extending_relations_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe "Gateways / Extending Relations" do
     module ROM
       module Memory
         class Relation < ROM::Relation
-          schema(:users) {}
-
           def self.freaking_awesome?
             true
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,13 @@ SPEC_ROOT = root = Pathname(__FILE__).dirname
 
 require_relative "support/coverage" if ENV["COVERAGE"] == "true"
 
+# rubocop:disable Lint/SuppressedException
+begin
+  require "pry-byebug"
+rescue LoadError
+end
+# rubocop:enable Lint/SuppressedException
+
 require "warning"
 
 Warning.ignore(/zeitwerk/)
@@ -30,13 +37,6 @@ end
 Dir[root.join("shared/**/*.rb").to_s].sort.each do |f|
   require f
 end
-
-# rubocop:disable Lint/SuppressedException
-begin
-  require "pry-byebug"
-rescue LoadError
-end
-# rubocop:enable Lint/SuppressedException
 
 module SpecProfiler
   def report(*)

--- a/spec/unit/rom/relation/class_interface/view_spec.rb
+++ b/spec/unit/rom/relation/class_interface/view_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe ROM::Relation, ".view" do
 
   it "returns view method name" do
     klass = Class.new(ROM::Relation[:memory]) {
-      schema { attribute :id, ROM::Types::Integer }
+      schema(:users) { attribute :id, ROM::Types::Integer }
     }
 
-    name = klass.view(:by_id, klass.schema) { self }
+    name = klass.view(:by_id, []) { self }
 
     expect(name).to be(:by_id)
   end


### PR DESCRIPTION
This adds lazy-loadable dataset components which makes the entire setup
consistent as now all core components are handled in the same way.

More features can be built on top of this new foundation, like
multi-gateway relations, caching specific datasets and more.