### PR TITLE
Add support for relation.infer_id_from_class setting

### DIFF
--- a/lib/rom/runtime.rb
+++ b/lib/rom/runtime.rb
@@ -136,7 +136,15 @@ module ROM
     # @api private
     def register_constant(type, constant)
       if config.key?(constant.config.component.type)
-        constant.config.component.join!(config[constant.config.component.type])
+        parent_config = config[constant.config.component.type]
+        const_config = constant.config.component
+
+        const_config.inherit!(parent_config).join!(parent_config)
+
+        # TODO: make this work with all components
+        if const_config.key?(:infer_id_from_class) && const_config.infer_id_from_class
+          const_config.id = const_config.inflector.component_id(constant.name)&.to_sym
+        end
       end
 
       components.add(type, constant: constant, config: constant.config.component)

--- a/lib/rom/settings.rb
+++ b/lib/rom/settings.rb
@@ -62,6 +62,7 @@ module ROM
     setting :type, default: :relation
     setting :abstract
     setting :id
+    setting :infer_id_from_class, inherit: true
     setting :namespace, default: "relations"
     setting :dataset
     setting :adapter

--- a/spec/suite/rom/runtime/register_relation_spec.rb
+++ b/spec/suite/rom/runtime/register_relation_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rom/runtime"
+
+RSpec.describe ROM::Runtime, "#register_relation" do
+  subject(:runtime) do
+    ROM::Runtime.new
+  end
+
+  let(:resolver) do
+    runtime.resolver
+  end
+
+  it "registers a relation class using provided component's id" do
+    stub_const("Users", Class.new(ROM::Relation) { config.component.id = :users })
+
+    runtime.register_relation(Users)
+
+    expect(resolver["relations.users"]).to be_instance_of(Users)
+  end
+
+  it "registers a relation class with component's id inferred from the class name" do
+    runtime.config.relation.infer_id_from_class = true
+
+    stub_const("Users", Class.new(ROM::Relation))
+
+    runtime.register_relation(Users)
+
+    expect(resolver["relations.users"]).to be_instance_of(Users)
+  end
+end


### PR DESCRIPTION
This makes inferring relation ids from constant names explicitly configurable, which will make things much simpler to handle. This behavior was previously implicit and caused *a lot of pain* in the code.

You can configure it "globally" within your runtime or on a per-relation class basis.

```ruby
> runtime = ROM::Runtime.new { |runtime| runtime.config.relation.infer_id_from_class = true }
=> #<ROM::Runtime:0x00007f6d4790bc10..>
irb(main):005:0> class Users < ROM::Relation; end
=> nil
irb(main):006:0> runtime.register_relation(Users)
=> [#<ROM::Components::Relation:0x00007f6d479b2740...]
> runtime.resolver["relations.users"]
=> #<Users name=ROM::Relation::Name(users) dataset=[]>
```

This can be done relatively easily for other component types too.