### PR TITLE
Schema and dataset setup improvements

### DIFF
--- a/lib/rom/components/dataset.rb
+++ b/lib/rom/components/dataset.rb
@@ -21,7 +21,7 @@ module ROM
 
       # @api private
       def blocks
-        [*datasets.map(&:block), block].compact
+        [*dataset_components.map(&:block), block].compact
       end
 
       # @api adapter
@@ -32,18 +32,19 @@ module ROM
       private
 
       # @api private
-      def datasets
+      memoize def schema
+        if config.id == config.relation_id
+          resolver.schemas[id] if resolver.schemas.key?(id)
+        elsif config.relation_id
+          resolver["schemas.#{config.relation_id}.#{id}"]
+        elsif resolver.schemas.key?(id)
+          resolver.schemas[id]
+        end
+      end
+
+      # @api private
+      memoize def dataset_components
         provider.components.datasets(abstract: true, adapter: adapter)
-      end
-
-      # @api private
-      def schema
-        resolver.schemas[schema_key] if schema_key
-      end
-
-      # @api private
-      def schema_key
-        resolver.components.get(:schemas, dataset: id)&.key
       end
     end
   end

--- a/lib/rom/components/dataset.rb
+++ b/lib/rom/components/dataset.rb
@@ -29,18 +29,27 @@ module ROM
         config.adapter
       end
 
+      # @api adapter
+      def relation_id
+        config.relation_id
+      end
+
       private
 
       # @api private
+      # rubocop:disable Metrics/AbcSize
       memoize def schema
-        if config.id == config.relation_id
+        if id == relation_id
           resolver.schemas[id] if resolver.schemas.key?(id)
-        elsif config.relation_id
-          resolver["schemas.#{config.relation_id}.#{id}"]
+        elsif relation_id
+          resolver.fetch("schemas.#{relation_id}.#{id}") {
+            resolver.fetch("schemas.#{relation_id}")
+          }
         elsif resolver.schemas.key?(id)
           resolver.schemas[id]
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       # @api private
       memoize def dataset_components

--- a/lib/rom/components/dsl/dataset.rb
+++ b/lib/rom/components/dsl/dataset.rb
@@ -8,6 +8,25 @@ module ROM
       # @private
       class Dataset < Core
         key :datasets
+
+        def configure
+          if relation?
+            config.join!({namespace: relation_id}, :right) if config.id != relation_id
+
+            config.relation_id = relation_id
+          end
+          super
+        end
+
+        private
+
+        def relation_id
+          provider.config.component.id
+        end
+
+        def relation?
+          provider.config.component.type == :relation
+        end
       end
     end
   end

--- a/lib/rom/components/dsl/relation.rb
+++ b/lib/rom/components/dsl/relation.rb
@@ -20,6 +20,7 @@ module ROM
         memoize def constant
           build_class do |dsl|
             config.component.adapter = dsl.adapter if dsl.adapter
+
             class_exec(&dsl.block) if dsl.block
 
             if (schema_dataset = components.schemas.first&.config&.dataset)

--- a/lib/rom/components/dsl/schema.rb
+++ b/lib/rom/components/dsl/schema.rb
@@ -64,6 +64,7 @@ module ROM
         end
 
         # @api private
+        # rubocop:disable Metrics/AbcSize
         def configure
           config.update(attributes: attributes.values)
 
@@ -84,6 +85,7 @@ module ROM
 
           super
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/rom/components/gateway.rb
+++ b/lib/rom/components/gateway.rb
@@ -17,6 +17,11 @@ module ROM
         gateway
       end
 
+      # @api private
+      def adapter
+        config.adapter
+      end
+
       private
 
       # @api private
@@ -26,11 +31,6 @@ module ROM
         else
           ROM::Gateway.setup(adapter, *config.args)
         end
-      end
-
-      # @api private
-      def adapter
-        config.adapter
       end
 
       # @api private

--- a/lib/rom/components/registry.rb
+++ b/lib/rom/components/registry.rb
@@ -51,7 +51,7 @@ module ROM
 
       # @api private
       def call(key, &fallback)
-        comp = detect { |_, component| component.key == key }&.last
+        comp = detect { |_, component| component.key == key && !component.abstract? }&.last
 
         if comp
           comp.build

--- a/lib/rom/components/schema.rb
+++ b/lib/rom/components/schema.rb
@@ -46,6 +46,11 @@ module ROM
       end
 
       # @api private
+      def relation
+        config.relation
+      end
+
+      # @api private
       def view?
         config.view.equal?(true)
       end

--- a/lib/rom/components/schema.rb
+++ b/lib/rom/components/schema.rb
@@ -10,7 +10,7 @@ module ROM
     class Schema < Core
       # @api private
       option :name, type: Types.Instance(ROM::Relation::Name), default: -> {
-        ROM::Relation::Name[config.id, config.dataset]
+        ROM::Relation::Name[config.relation, config.dataset]
       }
 
       # @api public

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -107,6 +107,14 @@ module ROM
     #   @api public
     option :inflector, default: -> { config.component.inflector }
 
+    # @!attribute [r] schemas
+    #   @return [Runtime::resolver] Relation schemas
+    option :schemas, default: -> { resolver.schemas.scoped(config.component.id, config: config) }
+
+    # @!attribute [r] schema
+    #   @return [Runtime::resolver] The canonical schema
+    option :schema, default: -> { schemas.infer(config.component.id) }
+
     # @!attribute [r] datasets
     #   @return [resolver] Relation associations
     option :datasets, default: -> { resolver.datasets(config: config) }
@@ -114,17 +122,7 @@ module ROM
     # @!attribute [r] dataset
     #   @return [Object] dataset used by the relation provided by relation's gateway
     #   @api public
-    option :dataset, default: -> { datasets.infer(config.component.dataset) }
-
-    # @!attribute [r] schemas
-    #   @return [Runtime::resolver] Relation schemas
-    option :schemas, default: -> { resolver.schemas.scoped(config.component.id, config: config) }
-
-    # @!attribute [r] schema
-    #   @return [Runtime::resolver] The canonical schema
-    option :schema, default: -> {
-      schemas.first || schemas.infer(config.component.id)
-    }
+    option :dataset, default: -> { datasets.infer(config.component.id) }
 
     # @!attribute [r] associations
     #   @return [Runtime::resolver] Relation associations

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -122,7 +122,9 @@ module ROM
 
     # @!attribute [r] schema
     #   @return [Runtime::resolver] The canonical schema
-    option :schema, default: -> { schemas.infer(config.component.id) }
+    option :schema, default: -> {
+      schemas.first || schemas.infer(config.component.id)
+    }
 
     # @!attribute [r] associations
     #   @return [Runtime::resolver] Relation associations

--- a/lib/rom/resolver.rb
+++ b/lib/rom/resolver.rb
@@ -101,9 +101,20 @@ module ROM
     end
 
     # @api private
+    # rubocop:disable Metrics/AbcSize
     def infer_component(**options)
-      provider.public_send(handler.key, **config[handler.key].inherit(**config.component, **options))
+      inferred_config = config[handler.key].inherit(**config.component, **options)
+
+      if type == :datasets && config.component.type == :relation
+        comp = provider.components.datasets(id: config.component.dataset).first
+
+        comp ||
+          provider.public_send(handler.key, **inferred_config, relation_id: config.component.id)
+      else
+        provider.public_send(handler.key, **inferred_config)
+      end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # @api private
     def provider

--- a/lib/rom/resolver.rb
+++ b/lib/rom/resolver.rb
@@ -95,7 +95,7 @@ module ROM
 
     # @api public
     def infer(id, **options)
-      fetch(id || :anonymous) do
+      fetch(id) do
         infer_component(id: id, **options).build
       end
     end
@@ -106,7 +106,14 @@ module ROM
       inferred_config = config[handler.key].inherit(**config.component, **options)
 
       if type == :datasets && config.component.type == :relation
-        comp = provider.components.datasets(id: config.component.dataset).first
+        comp = provider.components.datasets(relation_id: config.component.id, abstract: false).first
+
+        comp || provider.public_send(
+          handler.key,
+          **inferred_config, id: config.component.dataset, relation_id: config.component.id
+        )
+      elsif type == :schemas && config.component.type == :relation
+        comp = components.schemas(relation: config.component.id, abstract: false).first
 
         comp ||
           provider.public_send(handler.key, **inferred_config, relation_id: config.component.id)

--- a/lib/rom/settings.rb
+++ b/lib/rom/settings.rb
@@ -3,6 +3,7 @@
 require_relative "support/inflector"
 require_relative "support/configurable"
 
+# rubocop:disable Metrics/ModuleLength
 module ROM
   extend Configurable
 
@@ -19,6 +20,7 @@ module ROM
   # Gateway defaults
   setting :gateway do
     setting :type, default: :gateway
+    setting :abstract
     setting :id, default: :default
     setting :namespace, default: "gateways"
     setting :adapter
@@ -42,6 +44,7 @@ module ROM
   setting :schema do
     setting :type, default: :schema
     setting :id
+    setting :abstract
     setting :namespace, default: "schemas", join: true
     setting :dataset
     setting :as # TODO: move to rom/compat
@@ -62,7 +65,7 @@ module ROM
   setting :relation do
     setting :type, default: :relation
     setting :abstract
-    setting :id
+    setting :id, default: :anonymous
     setting :infer_id_from_class, inherit: true
     setting :namespace, default: "relations"
     setting :dataset
@@ -75,6 +78,7 @@ module ROM
   # Relation view defaults
   setting :view do
     setting :type, default: :view
+    setting :abstract
     setting :id
     setting :namespace, default: "views", join: true
     setting :args, default: [].freeze
@@ -89,6 +93,7 @@ module ROM
     setting :adapter
     setting :as
     setting :name
+    setting :abstract
     setting :relation
     setting :source
     setting :target
@@ -97,12 +102,13 @@ module ROM
     setting :result
     setting :view
     setting :override
-    setting :combine_keys
+    setting :combine_keys, default: {}
   end
 
   # Command defaults
   setting :command do
     setting :type, default: :command
+    setting :abstract
     setting :id
     setting :namespace, default: "commands", join: true
     setting :relation
@@ -113,6 +119,7 @@ module ROM
   # Command defaults
   setting :mapper do
     setting :type, default: :mapper
+    setting :abstract
     setting :id
     setting :namespace, default: "mappers", join: true
     setting :relation
@@ -124,3 +131,4 @@ module ROM
     _settings
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/lib/rom/settings.rb
+++ b/lib/rom/settings.rb
@@ -32,6 +32,7 @@ module ROM
     setting :type, default: :dataset
     setting :abstract
     setting :id
+    setting :relation_id
     setting :namespace, default: "datasets"
     setting :adapter
     setting :gateway

--- a/spec/suite/compat/unit/rom/relation/schema_spec.rb
+++ b/spec/suite/compat/unit/rom/relation/schema_spec.rb
@@ -5,6 +5,8 @@ require "rom/relation"
 RSpec.describe ROM::Relation, "#schema" do
   subject(:relation) do
     Class.new(ROM::Relation) do
+      config.component.id = :users
+
       schema(:users) do
         attribute :id, Types::String
       end

--- a/spec/suite/rom/command_compiler_spec.rb
+++ b/spec/suite/rom/command_compiler_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "ROM::CommandCompiler" do
 
   let(:users) do
     klass = Class.new(ROM::Memory::Relation) {
+      config.component.id = :users
+
       def by_id(id)
         restrict(id: id)
       end
@@ -71,15 +73,11 @@ RSpec.describe "ROM::CommandCompiler" do
     end
 
     describe "setting input from relation" do
-      let(:users) do
-        super().tap do |klass|
-          klass.schema(:users) do
-            attribute :name, ROM::Types::String.constructor { |v| "relation[#{v}]" }
-          end
-        end
-      end
-
       it "uses input schema from relation and does it once" do
+        users.schema(:users) do
+          attribute :name, ROM::Types::String.constructor { |v| "relation[#{v}]" }
+        end
+
         expect(command.input[{id: 1, name: "John"}][:name]).to eql("relation[John]")
       end
     end

--- a/spec/suite/rom/components/provider_spec.rb
+++ b/spec/suite/rom/components/provider_spec.rb
@@ -5,62 +5,53 @@ require "rom/components/provider"
 RSpec.describe ROM::Components::Provider do
   describe ".inherited" do
     it "imports components from the parent" do
-      module Test
-        class Parent
-          extend ROM.Provider(:dataset, type: :component)
+      parent = Class.new do
+        extend ROM.Provider(:dataset, type: :component)
 
-          dataset(:ds) do
-            %i[hello world]
-          end
-        end
-
-        class Child < Parent
+        dataset(:ds) do
+          %i[hello world]
         end
       end
 
-      dataset = Test::Child.components.get(:datasets, id: :ds)
+      child = Class.new(parent)
+
+      dataset = child.components.get(:datasets, id: :ds)
 
       expect(dataset).to be_abstract
       expect(dataset.id).to be(:ds)
-
-      expect(Test::Child.resolver.datasets[:ds]).to eql(%i[hello world])
     end
 
     # FIXME: running this spec causes other specs to randomly fail
     xit "allows defining anonymous multiple abstract components" do
-      module Test
-        class Parent
-          extend ROM.Provider(:gateway, :dataset, type: :component)
+      parent = Class.new do
+        extend ROM.Provider(:gateway, :dataset, type: :component)
 
-          config.component.adapter = :memory
-          config.dataset.abstract = true
+        config.component.adapter = :memory
+        config.dataset.abstract = true
 
-          gateway(:default)
+        gateway(:default)
 
-          dataset do
-            insert(:world)
-          end
-
-          dataset do
-            insert(:hello)
-          end
+        dataset do
+          insert(:world)
         end
 
-        class Child < Parent
-          dataset(id: :ds, abstract: false) do
-            reverse
-          end
+        dataset do
+          insert(:hello)
         end
       end
 
-      expect(Test::Child.components.datasets.size).to be(3)
+      child = Class.new(parent) do
+        dataset(id: :ds, abstract: false) do
+          reverse
+        end
+      end
 
-      dataset = Test::Child.components.get(:datasets, id: :ds)
+      expect(child.components.datasets.size).to be(3)
+
+      dataset = child.components.get(:datasets, id: :ds)
 
       expect(dataset).to_not be_abstract
       expect(dataset.id).to be(:ds)
-
-      expect(Test::Child.resolver.datasets[:ds]).to eql(%i[hello world])
     end
   end
 end

--- a/spec/suite/rom/components/provider_spec.rb
+++ b/spec/suite/rom/components/provider_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ROM::Components::Provider do
         class Parent
           extend ROM.Provider(:dataset, type: :component)
 
-          dataset(id: :ds) do
+          dataset(:ds) do
             %i[hello world]
           end
         end

--- a/spec/suite/rom/relation/dataset_spec.rb
+++ b/spec/suite/rom/relation/dataset_spec.rb
@@ -13,4 +13,71 @@ RSpec.describe ROM::Relation, "#dataset" do
 
     expect(relation.dataset).to be_empty
   end
+
+  it "returns dataset that uses a custom schema" do
+    module Test
+      class Users < ROM::Relation[:memory]
+        schema do
+          attribute :id, Types::Integer
+          attribute :name, Types::Integer
+        end
+
+        dataset do |schema|
+          ds = ROM::Memory::Dataset.new([])
+
+          ds.insert(id: 1, name: "Jane", email: "jane@doe.org")
+          ds.insert(id: 2, name: "Joe", email: "joe@doe.org")
+
+          ds.project(*schema.map(&:name))
+        end
+      end
+    end
+
+    relation = Test::Users.new
+
+    expect(relation.dataset.to_a).to eql([{id: 1, name: "Jane"}, {id: 2, name: "Joe"}])
+  end
+
+  it "returns default dataset when there's no matching schema" do
+    module Test
+      class Users < ROM::Relation[:memory]
+        schema(:listing) do
+          attribute :id, Types::Integer
+          attribute :name, Types::Integer
+        end
+
+        dataset do
+          []
+        end
+      end
+    end
+
+    relation = Test::Users.new
+
+    expect(relation.dataset).to be_empty
+  end
+
+  it "returns dataset that uses a custom schema with custom identifiers" do
+    module Test
+      class Users < ROM::Relation[:memory]
+        schema(:listing) do
+          attribute :id, Types::Integer
+          attribute :name, Types::Integer
+        end
+
+        dataset(:listing) do |schema|
+          ds = ROM::Memory::Dataset.new([])
+
+          ds.insert(id: 1, name: "Jane", email: "jane@doe.org")
+          ds.insert(id: 2, name: "Joe", email: "joe@doe.org")
+
+          ds.project(*schema.map(&:name))
+        end
+      end
+    end
+
+    relation = Test::Users.new
+
+    expect(relation.dataset.to_a).to eql([{id: 1, name: "Jane"}, {id: 2, name: "Joe"}])
+  end
 end

--- a/spec/suite/rom/relation/schema_spec.rb
+++ b/spec/suite/rom/relation/schema_spec.rb
@@ -33,4 +33,56 @@ RSpec.describe ROM::Relation, "#schema" do
     expect(relation.schema.name.dataset).to be(:people)
     expect(relation.schema.name.relation).to be(:users)
   end
+
+  context "with a resolver" do
+    subject(:relation) do
+      resolver.relations[:users]
+    end
+
+    let(:resolver) do
+      runtime.resolver
+    end
+
+    let(:runtime) do
+      ROM::Runtime.new(:memory)
+    end
+
+    let(:schema) do
+      relation.schema
+    end
+
+    it "returns an inferred empty schema by default" do
+      runtime.relation(:users)
+
+      expect(schema).to be_empty
+      expect(schema.name.relation).to be(:users)
+      expect(schema.name.dataset).to be(:users)
+    end
+
+    it "returns explictly defined schema" do
+      runtime.relation(:users) do
+        schema do
+          attribute :id, ROM::Types::Integer
+          attribute :name, ROM::Types::Integer
+        end
+      end
+
+      expect(schema).to_not be_empty
+      expect(schema.name.relation).to be(:users)
+      expect(schema.name.dataset).to be(:users)
+    end
+
+    it "returns explictly defined schema with a custom dataset" do
+      runtime.relation(:users) do
+        schema(:people) do
+          attribute :id, ROM::Types::Integer
+          attribute :name, ROM::Types::Integer
+        end
+      end
+
+      expect(schema).to_not be_empty
+      expect(schema.name.relation).to be(:users)
+      expect(schema.name.dataset).to be(:people)
+    end
+  end
 end


### PR DESCRIPTION
This makes resolver store schemas and datasets under nested namespaces so that it's possible to connect a schema with a dataset using relation identifier. A dataset with an id that matches a schema id means that this schema should be passed to dataset block (when block is provided of course). It also ensures that abstract components are not being built through resolving, which was a bug previously.