### PR TITLE
Auto-loadable components

### DIFF
--- a/lib/rom/resolver.rb
+++ b/lib/rom/resolver.rb
@@ -156,6 +156,8 @@ module ROM
 
     option :inferrer, default: -> { Inferrer.new }
 
+    option :loader, optional: true
+
     option :notifications, optional: true
 
     option :type, optional: true
@@ -173,6 +175,8 @@ module ROM
         fetch("#{namespace}.#{key}", &block)
       when String
         return container[key] if container.key?(key)
+
+        loader&.auto_load_component_file(type, key)
 
         with_resolver(root) { build(key, &block) }.tap { |item|
           container.register(key, item)

--- a/lib/rom/runtime.rb
+++ b/lib/rom/runtime.rb
@@ -131,6 +131,7 @@ module ROM
     # @param [String, Pathname] directory The root path to components
     # @param [Hash] options
     # @option options [Boolean,String] :namespace Toggle root namespace
+    # @option options [Boolean] :auto_load Toggle auto-loading via Zeitwerk
     #
     # @return [Configuration]
     #

--- a/lib/rom/runtime.rb
+++ b/lib/rom/runtime.rb
@@ -63,6 +63,7 @@ module ROM
 
     setting :auto_register do
       setting :root_directory
+      setting :auto_load
       setting :namespace
       setting :component_dirs, default: {
         relations: :relations, mappers: :mappers, commands: :commands
@@ -96,7 +97,13 @@ module ROM
     # @return [Resolver] Runtime component resolver
     # @api private
     def resolver
-      @resolver ||= super(config: config, notifications: notifications)
+      @resolver ||=
+        begin
+          options = {config: config, notifications: notifications}
+          options[:loader] = loader if config.auto_register.auto_load
+
+          super(**options)
+        end
     end
 
     # This is called internally when you pass a block to ROM.container

--- a/spec/fixtures/auto_loading/app/commands/users/create.rb
+++ b/spec/fixtures/auto_loading/app/commands/users/create.rb
@@ -1,0 +1,9 @@
+module Commands
+  module Users
+    class Create < ROM::Memory::Commands::Create
+      config.component.id = :create
+      config.component.relation = :users
+      config.component.namespace = "commands.users"
+    end
+  end
+end

--- a/spec/fixtures/auto_loading/app/mappers/users/listing.rb
+++ b/spec/fixtures/auto_loading/app/mappers/users/listing.rb
@@ -1,0 +1,9 @@
+module Mappers
+  module Users
+    class Listing < ROM::Transformer
+      config.component.id = :listing
+      config.component.relation = :users
+      config.component.namespace = "mappers.users"
+    end
+  end
+end

--- a/spec/fixtures/auto_loading/app/relations/users.rb
+++ b/spec/fixtures/auto_loading/app/relations/users.rb
@@ -1,0 +1,4 @@
+module Relations
+  class Users < ROM::Relation[:memory]
+  end
+end

--- a/spec/fixtures/auto_loading/persistence/commands/tasks/create.rb
+++ b/spec/fixtures/auto_loading/persistence/commands/tasks/create.rb
@@ -1,0 +1,11 @@
+module Persistence
+  module Commands
+    module Tasks
+      class Create < ROM::Memory::Commands::Create
+        config.component.id = :create
+        config.component.relation = :tasks
+        config.component.namespace = "commands.tasks"
+      end
+    end
+  end
+end

--- a/spec/fixtures/auto_loading/persistence/mappers/tasks/listing.rb
+++ b/spec/fixtures/auto_loading/persistence/mappers/tasks/listing.rb
@@ -1,0 +1,11 @@
+module Persistence
+  module Mappers
+    module Tasks
+      class Listing < ROM::Transformer
+        config.component.id = :listing
+        config.component.relation = :tasks
+        config.component.namespace = "mappers.tasks"
+      end
+    end
+  end
+end

--- a/spec/fixtures/auto_loading/persistence/relations/tasks.rb
+++ b/spec/fixtures/auto_loading/persistence/relations/tasks.rb
@@ -1,0 +1,6 @@
+module Persistence
+  module Relations
+    class Tasks < ROM::Relation[:memory]
+    end
+  end
+end

--- a/spec/suite/rom/runtime/auto_loading_spec.rb
+++ b/spec/suite/rom/runtime/auto_loading_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rom/runtime"
+
+RSpec.describe ROM::Runtime, "auto loading" do
+  subject(:runtime) do
+    ROM::Runtime.new(:memory)
+  end
+
+  let(:resolver) do
+    runtime.resolver
+  end
+
+  around do |example|
+    example.run
+  ensure
+    zeitwerk_teardown
+  end
+
+  def zeitwerk_teardown
+    Zeitwerk::Registry.loaders.each(&:unload)
+    Zeitwerk::Registry.loaders.clear
+    Zeitwerk::Registry.loaders_managing_gems.clear
+    Zeitwerk::ExplicitNamespace.cpaths.clear
+    Zeitwerk::ExplicitNamespace.tracer.disable
+  end
+
+  context "auto-loading with a namespace" do
+    it "auto-loads relation definition file" do
+      runtime.auto_register(
+        SPEC_ROOT.join("fixtures/auto_loading/persistence"), auto_load: false
+      ).finalize
+
+      expect(resolver.relations[:tasks]).to be_a(Persistence::Relations::Tasks)
+      expect(resolver.mappers[:tasks][:listing]).to be_a(Persistence::Mappers::Tasks::Listing)
+      expect(resolver.commands[:tasks][:create]).to be_a(Persistence::Commands::Tasks::Create)
+    end
+  end
+
+  context "auto-loading without a namespace" do
+    it "auto-loads component definition files" do
+      runtime.auto_register(
+        SPEC_ROOT.join("fixtures/auto_loading/app"), namespace: false, auto_load: true
+      ).finalize
+
+      expect(resolver.relations[:users]).to be_a(Relations::Users)
+      expect(resolver.mappers[:users][:listing]).to be_a(Mappers::Users::Listing)
+      expect(resolver.commands[:users][:create]).to be_a(Commands::Users::Create)
+    end
+  end
+end


### PR DESCRIPTION
This adds support for auto-loading of component files using Zeitwerk. All you need to do is this:

```ruby
rom = ROM.runtime(:sql, "sqlite::memory") do |cfg|
  cfg.auto_register("path-to-component-dir", auto_load: true) # <= that's it
end
```

Once this is enabled, whenever you ask for a rom component, it will infer fully qualified constant name based on component's key and try to load a corresponding file using Zeitwerk auto-loading, ie:

- `rom.relations[:users]` => `Relations::Users` => `#{components_dir}/relations/users`
- `rom.mappers[:users][:listing]` => `Mappers::Users::Listing` => `#{components_dir}/mappers/users/listing`

If you have top-level namespace enabled, it will be prepended automatically, ie:

- `rom.relations[:users]` => `Persistence::Relations::Users` => `#{components_dir}/persistence/relations/users`
- `rom.mappers[:users][:listing]` => `Persistence::Mappers::Users::Listing` => `#{components_dir}/persistence/mappers/users/listing`