### PR TITLE
Improve plugin API

### DIFF
--- a/lib/rom/changeset.rb
+++ b/lib/rom/changeset.rb
@@ -115,7 +115,7 @@ module ROM
     #
     # @api public
     def self.use(plugin, **options)
-      ROM.plugins[:changeset].fetch(plugin).apply_to(self, **options)
+      ROM.plugins[:changeset].fetch(plugin).enable(self).apply(**options)
     end
 
     # Return a new changeset with provided relation

--- a/lib/rom/command.rb
+++ b/lib/rom/command.rb
@@ -4,6 +4,7 @@ require "rom/support/configurable"
 require "rom/types"
 require "rom/initializer"
 require "rom/pipeline"
+require "rom/plugins/class_methods"
 
 require "rom/commands/class_interface"
 require "rom/commands/composite"
@@ -26,6 +27,7 @@ module ROM
   # @api public
   class Command
     extend ROM::Provider(type: :command)
+    extend Plugins::ClassMethods
     extend Initializer
     extend ClassInterface
 

--- a/lib/rom/commands/class_interface.rb
+++ b/lib/rom/commands/class_interface.rb
@@ -109,24 +109,6 @@ module ROM
         end
       end
 
-      # Use a configured plugin in this relation
-      #
-      # @example
-      #   class CreateUser < ROM::Commands::Create[:memory]
-      #     use :pagintion
-      #
-      #     per_page 30
-      #   end
-      #
-      # @param [Symbol] plugin
-      # @param [Hash] options
-      # @option options [Symbol] :adapter (:default) first adapter to check for plugin
-      #
-      # @api public
-      def use(plugin, **options)
-        ROM.plugins[:command].fetch(plugin, adapter).apply_to(self, **options)
-      end
-
       # Return configured adapter identifier
       #
       # @return [Symbol]

--- a/lib/rom/compat/components/dsl/schema.rb
+++ b/lib/rom/compat/components/dsl/schema.rb
@@ -67,7 +67,7 @@ module ROM
               attributes: attributes,
               inferrer: inferrer,
               inflector: inflector,
-              plugins: plugins,
+              plugins: config.plugins,
               relation: name,
               definition: block
             )

--- a/lib/rom/compat/schema/dsl.rb
+++ b/lib/rom/compat/schema/dsl.rb
@@ -41,10 +41,6 @@ module ROM
       #   @return [Class] Attribute class that should be used
       option :attr_class, default: -> { Attribute }
 
-      # @!attribute [r] plugins
-      #   @return [Class] Plugins enabled by default through configuration
-      option :plugins, default: -> { EMPTY_ARRAY.dup }
-
       # @!attribute [r] attributes
       #   @return [Hash<Symbol, Hash>] A hash with attribute names as
       #   keys and attribute representations as values.
@@ -55,6 +51,10 @@ module ROM
       # @!attribute [r] definition
       #   @return [Class] An optional block that will be evaluated as part of this DSL
       option :definition, type: Types.Instance(Proc), default: -> { Proc.new {} }
+
+      # @!attribute [r] plugins
+      #   @return [Array<Plugin>]
+      option :plugins, default: -> { EMPTY_ARRAY }
 
       # @api private
       def self.new(**options, &block)
@@ -155,7 +155,7 @@ module ROM
 
       # @api public
       def plugin(name, **options)
-        plugin = plugins.detect { |plugin| plugin.name == name }
+        plugin = plugins.detect { |pl| pl.name == name }
         plugin.config.update(options) unless options.empty?
         plugin
       end
@@ -179,7 +179,7 @@ module ROM
 
             # Apply plugin defaults
             plugins.each do |plugin|
-              plugin.apply_to(self)
+              plugin.__send__(:apply_to, self)
             end
 
             attributes.freeze

--- a/lib/rom/components/dsl/schema.rb
+++ b/lib/rom/components/dsl/schema.rb
@@ -45,17 +45,11 @@ module ROM
 
         # @api private
         def call
-          # Enable available plugin's
-          plugins.each do |plugin|
-            plugin.enable(self) unless plugin.enabled?
-          end
-
           # Evaluate block only if it's not a schema defined by Relation.view DSL
           instance_eval(&block) if block && !config.view
 
-          # Apply plugin defaults
-          plugins.each do |plugin|
-            plugin.apply_to(self)
+          enabled_plugins.each_value do |plugin|
+            plugin.apply unless plugin.applied?
           end
 
           configure

--- a/lib/rom/mapper.rb
+++ b/lib/rom/mapper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rom/core"
+require "rom/plugins/class_methods"
 
 require_relative "mapper/dsl"
 require_relative "components/provider"
@@ -11,6 +12,7 @@ module ROM
   # @private
   class Mapper
     extend ROM::Provider(type: :mapper)
+    extend Plugins::ClassMethods
 
     include Dry::Equalizer(:transformers, :header)
     include DSL

--- a/lib/rom/mapper/dsl.rb
+++ b/lib/rom/mapper/dsl.rb
@@ -30,19 +30,6 @@ module ROM
           klass.instance_variable_set("@attribute_dsl", nil)
         end
 
-        # include a registered plugin in this mapper
-        #
-        # @param [Symbol] plugin
-        # @param [Hash] options
-        # @option options [Symbol] :adapter (:default) first adapter to check for plugin
-        #
-        # @api public
-        def use(plugin, options = {})
-          adapter = options.fetch(:adapter, :default)
-
-          ROM.plugins[:mapper].fetch(plugin, adapter).apply_to(self)
-        end
-
         # Return base_relation used for creating mapper registry
         #
         # This is used to "gather" mappers under same root name

--- a/lib/rom/plugin.rb
+++ b/lib/rom/plugin.rb
@@ -101,7 +101,7 @@ module ROM
 
     # @api private
     def apply_opts
-      config.to_h.except(*INTERNAL_OPTS)
+      (opts = config.to_h).slice(*(opts.keys - INTERNAL_OPTS))
     end
 
     # Apply this plugin to the target

--- a/lib/rom/plugins.rb
+++ b/lib/rom/plugins.rb
@@ -81,6 +81,7 @@ module ROM
           end
         end
       end
+      alias_method :[], :fetch
 
       # @api private
       def key?(name)

--- a/lib/rom/plugins/class_methods.rb
+++ b/lib/rom/plugins/class_methods.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ROM
+  module Plugins
+    # @api public
+    module ClassMethods
+      # Include a registered plugin in this relation class
+      #
+      # @param [Symbol] plugin
+      # @param [Hash] options
+      # @option options [Symbol] :adapter (:default) first adapter to check for plugin
+      #
+      # @api public
+      def use(name, **options)
+        plugin = plugins[name].configure(**options).enable(self).apply
+        component_config.plugins << plugin
+        self
+      end
+
+      # Return all available plugins for the component type
+      #
+      # @api public
+      def plugins
+        @plugins ||= ROM.plugins[component_config.type].adapter(component_config.adapter)
+      end
+
+      private
+
+      # Return component configuration
+      #
+      # @api private
+      def component_config
+        @component_config ||= config.key?(:component) ? config.component : config
+      end
+    end
+  end
+end

--- a/lib/rom/plugins/schema/timestamps.rb
+++ b/lib/rom/plugins/schema/timestamps.rb
@@ -50,7 +50,7 @@ module ROM
           #
           # @api public
           def timestamps(*names)
-            plugin(:timestamps).config.update(attributes: names)
+            plugin(:timestamps, attributes: names).apply
           end
         end
       end

--- a/lib/rom/relation.rb
+++ b/lib/rom/relation.rb
@@ -10,6 +10,7 @@ require "rom/constants"
 require "rom/initializer"
 require "rom/support/inflector"
 
+require "rom/plugins/class_methods"
 require "rom/relation/class_interface"
 
 require "rom/auto_curry"
@@ -41,6 +42,7 @@ module ROM
   # @api public
   class Relation
     extend ROM::Provider(:dataset, :schema, :view, :association, type: :relation)
+    extend Plugins::ClassMethods
     extend Initializer
     extend ClassInterface
 
@@ -54,7 +56,6 @@ module ROM
     setting :auto_struct, default: false
     setting :struct_namespace, default: ROM::Struct
     setting :wrap_class, default: Relation::Wrap
-    setting :plugins, default: EMPTY_ARRAY
 
     # @api private
     def self.inherited(klass)

--- a/lib/rom/relation/class_interface.rb
+++ b/lib/rom/relation/class_interface.rb
@@ -17,6 +17,7 @@ module ROM
     #
     # @api public
     module ClassInterface
+      include Plugins::ClassMethods
       extend Notifications::Listener
 
       # Return adapter-specific relation subclass
@@ -51,19 +52,6 @@ module ROM
             end
           RUBY
         end
-      end
-
-      # Include a registered plugin in this relation class
-      #
-      # @param [Symbol] plugin
-      # @param [Hash] options
-      # @option options [Symbol] :adapter (:default) first adapter to check for plugin
-      #
-      # @api public
-      def use(plugin, **options)
-        ROM.plugins[:relation]
-          .fetch(plugin, config.component.adapter)
-          .apply_to(self, **options)
       end
 
       # @api private

--- a/lib/rom/settings.rb
+++ b/lib/rom/settings.rb
@@ -114,6 +114,7 @@ module ROM
     setting :relation
     setting :adapter
     setting :gateway
+    setting :plugins, default: EMPTY_ARRAY, inherit: true
   end
 
   # Command defaults
@@ -124,6 +125,7 @@ module ROM
     setting :namespace, default: "mappers", join: true
     setting :relation
     setting :adapter
+    setting :plugins, default: EMPTY_ARRAY, inherit: true
   end
 
   # @api private

--- a/lib/rom/transformer.rb
+++ b/lib/rom/transformer.rb
@@ -2,6 +2,8 @@
 
 require "dry/transformer"
 
+require "rom/plugins/class_methods"
+
 require_relative "components/provider"
 require_relative "processor/transformer"
 
@@ -11,6 +13,7 @@ module ROM
   # @api public
   class Transformer < Dry::Transformer[Processor::Transformer::Functions]
     extend ROM::Provider(type: :mapper)
+    extend Plugins::ClassMethods
 
     # Define transformation pipeline
     #

--- a/spec/suite/rom/plugins/schema/timestamps_spec.rb
+++ b/spec/suite/rom/plugins/schema/timestamps_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Plugins / schema / :timestamps" do
   end
 
   it "accepts options" do
-    setup.plugin(:memory, schemas: :timestamps) do |p|
-      p.attributes = %i[created_on updated_on]
+    setup.plugin(:memory, schemas: :timestamps) do |config|
+      config.attributes = %i[created_on updated_on]
     end
 
     setup.relation(:users)

--- a/spec/suite/rom/plugins_spec.rb
+++ b/spec/suite/rom/plugins_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
-RSpec.describe "ROM::PluginRegistry" do
+RSpec.describe ROM::Plugins do
   include_context "container"
 
   before do

--- a/spec/suite/rom/relation/class_interface/use_spec.rb
+++ b/spec/suite/rom/relation/class_interface/use_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe ROM::Relation, ".use" do
+  subject(:relation) do
+    Class.new(ROM::Relation)
+  end
+
+  let(:plugin) do
+    relation.config.component.plugins.first
+  end
+
+  it "enables a plugin for the relation" do
+    relation.use(:instrumentation)
+
+    expect(plugin).to be_enabled
+    expect(plugin.config.target).to be(relation)
+  end
+
+  it "sets custom config" do
+    relation.use(:instrumentation, foo: "bar")
+
+    expect(plugin).to be_enabled
+    expect(plugin.config.foo).to eql("bar")
+    expect(plugin.config.target).to be(relation)
+  end
+end

--- a/spec/suite/rom/runtime_spec.rb
+++ b/spec/suite/rom/runtime_spec.rb
@@ -249,4 +249,14 @@ RSpec.describe ROM::Setup do
     expect(plugin).to_not be(ROM.plugins[plugin.key])
     expect(plugin.config.attributes).to eql(%w[foo bar])
   end
+
+  it "can define a local plugin after a component was registered" do
+    setup.relation(:users, adapter: :memory)
+
+    setup.plugin(:memory, relations: :instrumentation) do |config|
+      config.notifications = double(:notifications)
+    end
+
+    expect(registry.relations[:users]).to respond_to(:notifications)
+  end
 end


### PR DESCRIPTION
This unifies `use` interface and improves internal handling of plugins so that all scenarios are still supported while at the same time it adds support for extending either DSL or component's constant (in a generic way). Plugins are now *configured in the settings* for each component, so that **you can actually see which plugins have been enabled for a given component instance**, ie:

```ruby
> users
#<ROM::Relations::Users name=ROM::Relation::Name(users) dataset=#...>

> users.config.component.plugins.detect { |pl| pl.name == :pg_explain }
#<ROM::Plugin type=:relation name=:pg_explain mod=ROM::Plugins::Relation::SQL::Postgres::Explain adapter=:sql config=#<ROM::OpenStruct {:enabled=>true, :target=>ROM::Relations::Users, :applied=>true}> dsl=nil>
```

With this done, it should be possible to easily convert "default views" in rom-sql into a plugin and it should prevent auto_restrictions from being loaded more than once (which happened before and caused issues with method being defined multiple times, that's why we used to have a guard clause checking if a method isn't defined yet which was always just a hack to silence the warning).