### PR TITLE
Fix `command(:create, result: :many)` for combines

### DIFF
--- a/lib/rom/relation/combined.rb
+++ b/lib/rom/relation/combined.rb
@@ -148,6 +148,7 @@ module ROM
                 "#{self.class}#command doesn't work with #{type.inspect} command type yet"
         end
       end
+      ruby2_keywords(:command) if respond_to?(:ruby2_keywords, true)
 
       private
 


### PR DESCRIPTION
- In ruby 3.x the `result: :many` will get forwarded incorrectly if there is a `combine`. That is, something like `relation.command(:create, result: :many)` will work but `relation.combine(:child_relation).command(:create, result: :many)` will raise `ArgumentError: wrong number of arguments (given 2, expected 1)`. This fixes is it (I have tested by doing the following on my codebase `ROM::Relation::Combined.__send__(:ruby2_keywords, :command)`).