### PR TITLE
Fixed Object#with conflict with ActiveSupport 7.1

### DIFF
--- a/core/lib/rom/initializer.rb
+++ b/core/lib/rom/initializer.rb
@@ -7,6 +7,15 @@ module ROM
   module Initializer
     # @api private
     module DefineWithHook
+      # Prevent interference from Object#with from
+      # ActiveSuport 7.1 core extensions.
+      #
+      # @api private
+      def self.extended(klass)
+        klass.define_method(:with) {}
+        klass.undef_method(:with)
+      end
+
       # @api private
       def param(*)
         super.tap { __define_with__ }

--- a/core/lib/rom/pipeline.rb
+++ b/core/lib/rom/pipeline.rb
@@ -47,6 +47,15 @@ module ROM
     #
     # @api private
     module Proxy
+      # Prevent interference from Object#with from
+      # ActiveSuport 7.1 core extensions.
+      #
+      # @api private
+      def self.included(klass)
+        klass.define_method(:with) {}
+        klass.undef_method(:with)
+      end
+
       # @api private
       def respond_to_missing?(name, include_private = false)
         left.respond_to?(name) || super

--- a/core/spec/support/method_interference.rb
+++ b/core/spec/support/method_interference.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This mocks Object#with to simulate ActiveSupport 7.1
+# whose definition of #with caused interference
+class Object
+  def with(*args, **kwargs, &block)
+    Kernel.raise("Object#with conflict")
+  end
+end


### PR DESCRIPTION
ActiveSupport 7.1 defines `Object#with` that interferes with ROM. This PR fixes it.

We use `define_method/undef_method` sequence due to uncertain load order. The method needs to be defined for `undef_method` to mark a method as undefined. This solution ensures the fix works whether ActiveSupport is loaded before or after ROM.

Fixes #684