### PR TITLE
Fix ROM Struct examples

### DIFF
--- a/core/lib/rom/struct.rb
+++ b/core/lib/rom/struct.rb
@@ -17,9 +17,10 @@ module ROM
   # about attribute types returned from relations, thus can be introspected to build
   # additional functionality when desired.
   #
-  # There is a caveat you should know about when working with structs. Struct classes
-  # have names but at the same time they're anonymous, i.e. you can't get the User struct class
-  # with ROM::Struct::User. ROM will create as many struct classes for User as needed,
+  # *NOTE*: There is a caveat you should know about when working with ROM structs.
+  # Struct classes have names but at the same time they're anonymous,
+  # i.e. you can't get the User struct class with ROM::Struct::User.
+  # ROM will create as many struct classes for User as needed,
   # they all will have the same name and ROM::Struct::User will be the common parent class for
   # them. Combined with the ability to provide your own namespace for structs this enables to
   # pre-define the parent class.

--- a/core/lib/rom/struct.rb
+++ b/core/lib/rom/struct.rb
@@ -31,11 +31,14 @@ module ROM
   #       primary_key :id
   #       column :name, String
   #     end
+  #
+  #     conf.relation(:users) do
+  #       schema(infer: true)
+  #       auto_struct true
+  #     end
   #   end
   #
   #   class UserRepo < ROM::Repository[:users]
-  #     schema(infer: true)
-  #     auto_struct true
   #   end
   #
   #   user_repo = UserRepo.new(rom)

--- a/core/lib/rom/struct.rb
+++ b/core/lib/rom/struct.rb
@@ -50,10 +50,10 @@ module ROM
   #   # see struct's schema attributes
   #
   #   model.schema.key(:id)
-  #   # => #<Dry::Types[id: Nominal<Integer meta={primary_key: true, alias: nil, source: :users}>]>
+  #   # => #<Dry::Types[id: Nominal<Integer meta={primary_key: true, source: :users}>]>
   #
   #   model.schema[:name]
-  #   # => #<Dry::Types[name: Sum<Nominal<NilClass> | Nominal<String meta={alias: nil, source: :users}> meta={alias: nil, source: :users}>]>
+  #   # => #<Dry::Types[name: Sum<Nominal<NilClass> | Nominal<String meta={source: :users}> meta={source: :users}>]>
   #
   # @example passing a namespace with an existing parent class
   #   module Entities

--- a/core/lib/rom/struct.rb
+++ b/core/lib/rom/struct.rb
@@ -33,6 +33,8 @@ module ROM
   #   end
   #
   #   class UserRepo < ROM::Repository[:users]
+  #     schema(infer: true)
+  #     auto_struct true
   #   end
   #
   #   user_repo = UserRepo.new(rom)
@@ -43,11 +45,11 @@ module ROM
   #
   #   # see struct's schema attributes
   #
-  #   # model.schema.key(:id)
-  #   # => #<Dry::Types[id: Nominal<Integer meta={primary_key: true, source: :users}>]>
+  #   model.schema.key(:id)
+  #   # => #<Dry::Types[id: Nominal<Integer meta={primary_key: true, alias: nil, source: :users}>]>
   #
   #   model.schema[:name]
-  #   # => #<Dry::Types[name: Sum<Nominal<NilClass> | Nominal<String> meta={source: :users}>]>
+  #   # => #<Dry::Types[name: Sum<Nominal<NilClass> | Nominal<String meta={alias: nil, source: :users}> meta={alias: nil, source: :users}>]>
   #
   # @example passing a namespace with an existing parent class
   #   module Entities
@@ -63,6 +65,7 @@ module ROM
   #   end
   #
   #   user_repo = UserRepo.new(rom)
+  #   user_repo.users.insert(name: "Jane")
   #   user = user_repo.users.by_pk(1).one!
   #   user.name # => "Jane"
   #   user.upcased_name # => "JANE"


### PR DESCRIPTION
Fixes #685

Also adds a **NOTE** in front of the caveat for ROM structs which was also discussed in #610