### PR TITLE
Bring back Repository#set_relation but deprecate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.4.1 2025-01-09
+
+### Fixed
+
+- [rom-repository] `set_relation` is deprecated and will be removed in 6.0.0 (issue #698 fixed via #699) (@flash-gordon)
+
 ## 5.4.0 2025-01-08
 
 ### Fixed

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -8,6 +8,7 @@ group :test do
   gem "simplecov", require: false, platforms: :ruby
   gem "simplecov-cobertura", require: false, platforms: :ruby
   gem "rexml", require: false
+  gem "tempfile"
 
   gem "warning"
 end

--- a/changeset/lib/rom/changeset/version.rb
+++ b/changeset/lib/rom/changeset/version.rb
@@ -2,6 +2,6 @@
 
 module ROM
   class Changeset
-    VERSION = '5.4.0'
+    VERSION = '5.4.1'
   end
 end

--- a/core/lib/rom/core/version.rb
+++ b/core/lib/rom/core/version.rb
@@ -2,6 +2,6 @@
 
 module ROM
   module Core
-    VERSION = '5.4.0'
+    VERSION = '5.4.1'
   end
 end

--- a/lib/rom/version.rb
+++ b/lib/rom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ROM
-  VERSION = '5.4.0'
+  VERSION = '5.4.1'
 end

--- a/repository/lib/rom/repository/relation_reader.rb
+++ b/repository/lib/rom/repository/relation_reader.rb
@@ -5,9 +5,11 @@ module ROM
     # @api private
     class RelationReader < ::Module
       module InstanceMethods
+        extend ::Dry::Core::Deprecations[:'rom-repository']
+
         private
 
-        # @api private
+        # @api public
         def prepare_relation(name, **)
           container
             .relations[name]
@@ -18,14 +20,20 @@ module ROM
         end
 
         # @api private
+        def set_relation(name) # rubocop:disable Naming/AccessorMethodName
+          prepare_relation(name)
+        end
+        deprecate :set_relation, :prepare_relation
+
+        # @api private
         def relation_reader(cache, ...)
           cache_key = relation_cache_key(...)
           cache.fetch_or_store(*cache_key) { prepare_relation(...) }
         end
 
         # @api private
-        def relation_cache_key(name, **)
-          [name, auto_struct, struct_namespace]
+        def relation_cache_key(name, **kwargs)
+          [name, auto_struct, struct_namespace, kwargs]
         end
       end
 

--- a/repository/lib/rom/repository/version.rb
+++ b/repository/lib/rom/repository/version.rb
@@ -2,6 +2,6 @@
 
 module ROM
   class Repository
-    VERSION = '5.4.0'
+    VERSION = '5.4.1'
   end
 end

--- a/repository/spec/integration/repository_spec.rb
+++ b/repository/spec/integration/repository_spec.rb
@@ -423,4 +423,41 @@ RSpec.describe 'ROM repository' do
 
     expect(post).to be(post_from_user)
   end
+
+  context 'using #prepare_relation' do
+    let(:repo_class) do
+      Class.new(ROM::Repository[:users]) do
+        def prepare_relation(name, custom: 'default')
+          super.select_append { `'#{custom}'`.as(:extra_column) }
+        end
+      end
+    end
+
+    it 'is uses modified relation' do
+      expect(repo.users.to_a.map(&:extra_column)).to eql(%w[default default])
+      expect(repo.users(custom: 'custom').to_a.map(&:extra_column)).to eql(%w[custom custom])
+    end
+  end
+
+  context 'using #set_relation' do
+    let(:log_file) do
+      Tempfile.new('dry_deprecations')
+    end
+
+    before do
+      Dry::Core::Deprecations.set_logger!(log_file)
+    end
+
+    let(:repo_class) do
+      Class.new(ROM::Repository[:users]) do
+        def custom_users
+          set_relation(:users).select_append { `'modified'`.as(:modified) }
+        end
+      end
+    end
+
+    it "constructs a relation but it's deprecated" do
+      expect(repo.custom_users.to_a.map(&:modified)).to eql(%w[modified modified])
+    end
+  end
 end

--- a/repository/spec/spec_helper.rb
+++ b/repository/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'tempfile'
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pathname'
+require 'tempfile'
 
 SPEC_ROOT = root = Pathname(__FILE__).dirname
 


### PR DESCRIPTION
It was part of the private API used by hanami/db. This marks prepare_relation as a replacement
