### PR TITLE
Avoid multiple relation readers in repo classes

### DIFF
--- a/repository/lib/rom/repository/class_interface.rb
+++ b/repository/lib/rom/repository/class_interface.rb
@@ -59,7 +59,7 @@ module ROM
       def new(container = nil, root: Undefined, **options)
         container ||= options.fetch(:container)
 
-        unless self < relation_reader
+        if ancestors.none? { |ancestor| ancestor.is_a?(relation_reader) }
           include relation_reader.new(
             relations: container.relations.elements.keys,
             cache: container.cache,

--- a/repository/spec/unit/repository/class_interface_spec.rb
+++ b/repository/spec/unit/repository/class_interface_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rom/repository'
+
+RSpec.describe ROM::Repository, '.new' do
+  include_context 'database'
+
+  subject(:repo_class) do
+    Class.new(ROM::Repository[:users])
+  end
+
+  it 'includes a relation reader module on a single instance' do
+    reader_modules = repo_class.new(rom).class.ancestors.select { |mod|
+      mod.is_a?(ROM::Repository::RelationReader)
+    }
+
+    expect(reader_modules.length).to eq(1)
+  end
+
+  it 'does not include multiple relation reader modules with multiple instances' do
+    _first_instance = repo_class.new(rom)
+
+    reader_modules = repo_class.new(rom).class.ancestors.select { |mod|
+      mod.is_a?(ROM::Repository::RelationReader)
+    }
+
+    expect(reader_modules.length).to eq(1)
+  end
+end


### PR DESCRIPTION
The previous check was not detecting instances of the relation reader in the ancestor hierarchy - and instances matter, as it’s not the relation_reader class itself that’s being included. Apologies if the tests aren't quite on point - I'm not really familiar with ROM internals.

I believe this was causing a memory leak (at least, in my use of ROM via Hanami 2.2.1+), as each repository used in any given request was having a relation reader module included, and these inclusions would happen again - unnecessarily - on every single request that followed.

Using memory_profiler, making the same request 10 times (after an initial 10 requests to warm things up) **using rom-repository 5.3.0**:

```
retained objects by gem
-----------------------------------
        41  rack-2.2.20
         7  rack-test-2.2.0
         7  uri-1.1.1
         4  other
         2  hanami-view-2.2.1
         2  readings/lib
         1  dry-logger-1.2.0
         1  hanami-router-2.2.0
         1  lib
         1  rack-cors-2.0.2
         1  roda-3.97.0
```

The same test, but **using rom-repository 5.4.2**:

```
retained objects by gem
-----------------------------------
       420  rom-repository-5.4.2
        41  rack-2.2.20
         7  rack-test-2.2.0
         7  uri-1.1.1
         4  other
         2  hanami-view-2.3.0
         2  readings/lib
         1  dry-logger-1.2.0
         1  hanami-router-2.3.0
         1  lib
         1  rack-cors-2.0.2
         1  roda-3.97.0
```

And then, **using this patch**, the numbers return to normal:

```
retained objects by gem
-----------------------------------
        41  rack-2.2.20
         7  rack-test-2.2.0
         7  uri-1.1.1
         4  other
         2  hanami-view-2.3.0
         2  readings/lib
         1  dry-logger-1.2.0
         1  hanami-router-2.3.0
         1  lib
         1  rack-cors-2.0.2
         1  roda-3.97.0
```

I've run my (sizeable Hanami) app's test suite with this patch, and there aren't any failures.