### PR TITLE
Pin unpinned-action references across 3 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       CODACY_PROJECT_TOKEN: "${{secrets.CODACY_PROJECT_TOKEN}}"
       APT_DEPS: libpq-dev libsqlite3-dev
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
     - name: Install package dependencies
       run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         ruby-version: "${{matrix.ruby}}"
     - name: Install latest bundler
@@ -61,7 +61,7 @@ jobs:
     - name: Run all tests
       run: bundle exec rake
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@master
+      uses: codacy/codacy-coverage-reporter-action@6904bd01e29ada115135b5eca20125758ccae53b
       if: github.ref == 'refs/heads/master' && env.COVERAGE == 'true' && env.COVERAGE_TOKEN != ''
       with:
         project-token: "${{secrets.CODACY_PROJECT_TOKEN}}"
@@ -86,11 +86,11 @@ jobs:
       GITHUB_LOGIN: rom-bot
       GITHUB_TOKEN: "${{secrets.GH_PAT}}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
     - name: Install package dependencies
       run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         ruby-version: 3.3
     - name: Install dependencies

--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -16,13 +16,13 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           fetch-depth: 0
       - run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: actions/setup-ruby@e932e7af67fc4a8fc77bd86b744acd4e42fe3543
         with:
           ruby-version: "2.6.x"
       - name: Set up git user

--- a/.github/workflows/sync_configs.yml
+++ b/.github/workflows/sync_configs.yml
@@ -17,9 +17,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout ${{github.repository}}
-        uses: actions/checkout@v1
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Checkout devtools
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           repository: rom-rb/devtools
           path: tmp/devtools
@@ -28,7 +28,7 @@ jobs:
           git config --local user.email "rom-bot@rom-rb.org"
           git config --local user.name "rom-bot"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: 2.6
       - name: Install dependencies


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/ci.yml`

- 🟠 MED `ruby/setup-ruby` (job `tests`)
- 🟠 MED `codacy/codacy-coverage-reporter-action` (job `tests`)
- 🟠 MED `ruby/setup-ruby` (job `release`)
- ⚪ LOW `actions/checkout` (job `tests`)
- ⚪ LOW `actions/checkout` (job `release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@
       CODACY_PROJECT_TOKEN: "${{secrets.CODACY_PROJECT_TOKEN}}"
       APT_DEPS: libpq-dev libsqlite3-dev
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
     - name: Install package dependencies
       run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         ruby-version: "${{matrix.ruby}}"
     - name: Install latest bundler
@@ -61,7 +61,7 @@
     - name: Run all tests
       run: bundle exec rake
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@master
+      uses: codacy/codacy-coverage-reporter-action@6904bd01e29ada115135b5eca20125758ccae53b
       if: github.ref == 'refs/heads/master' && env.COVERAGE == 'true' && env.COVERAGE_TOKEN != ''
       with:
         project-token: "${{secrets.CODACY_PROJECT_TOKEN}}"
@@ -86,11 +86,11 @@
       GITHUB_LOGIN: rom-bot
       GITHUB_TOKEN: "${{secrets.GH_PAT}}"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
     - name: Install package dependencies
       run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
       with:
         ruby-version: 3.3
     - name: Install dependencies
```

</details>

### `.github/workflows/docsite.yml`

- ⚪ LOW `actions/checkout` (job `update-docs`)
- ⚪ LOW `actions/setup-ruby` (job `update-docs`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -16,13 +16,13 @@
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           fetch-depth: 0
       - run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: actions/setup-ruby@e932e7af67fc4a8fc77bd86b744acd4e42fe3543
         with:
           ruby-version: "2.6.x"
       - name: Set up git user
```

</details>

### `.github/workflows/sync_configs.yml`

- 🟠 MED `ruby/setup-ruby` (job `main`)
- ⚪ LOW `actions/checkout` (job `main`)
- ⚪ LOW `actions/checkout` (job `main`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/sync_configs.yml
+++ b/.github/workflows/sync_configs.yml
@@ -17,9 +17,9 @@
       GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout ${{github.repository}}
-        uses: actions/checkout@v1
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Checkout devtools
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
         with:
           repository: rom-rb/devtools
           path: tmp/devtools
@@ -28,7 +28,7 @@
           git config --local user.email "rom-bot@rom-rb.org"
           git config --local user.name "rom-bot"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: 2.6
       - name: Install dependencies
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
