### PR TITLE
Fix permissions-missing in docsite.yml

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

### 🟠 `permissions-missing` · `update-docs`

Job `update-docs` performs a GitHub-governed write in step `Update release branches` (`git push --all "https://rom-bot:${{secrets.GH_PAT}}@github.com/$GITHUB_REPOSITORY.git"`), and the job also uses `actions/checkout` (GITHUB_TOKEN is in play). The job has no declared `permissio…

Reference: CWE-862 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -15,6 +15,8 @@
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
         with:
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
